### PR TITLE
FeatureImage: add Fody photodb

### DIFF
--- a/src/components/Panel/FeatureImage.js
+++ b/src/components/Panel/FeatureImage.js
@@ -81,7 +81,7 @@ const Attribution = styled.a`
   text-shadow: 0px 0px 1px rgba(0, 0, 0, 0.3);
   color: #fff;
   text-decoration: none;
-  opacity: 0.5;
+  opacity: ${({portrait}) => portrait ? 1 : 0.5};
 `;
 
 const FeatureImage = ({ feature, children }) => {
@@ -127,6 +127,7 @@ const FeatureImage = ({ feature, children }) => {
           title={`© ${source}${username ? `, ${username}` : ''}`}
           target="_blank"
           rel="noopener"
+          portrait={portrait}
         >
           {username ?? source}
         </Attribution>


### PR DESCRIPTION
Attempt to add general photo-db "Fody". It currently covers mostly CZ or EU, but author is open to worldwide usage.

See: https://openstreetmap.cz/git/tom.k/Fody/wiki/

## Current issue
Fody API returns correct CORS headers only for `Origin: openstreetmap.cz` 

Server side rendered page is fetched using node - but click on any other (i) icon and see error in console: https://osmapp-git-fody.zbycz.now.sh/node/394820093#14.24/50.0975/14.3104
 


## Screenshot (working scenario)

![image](https://user-images.githubusercontent.com/385047/81467564-b7743b00-91d9-11ea-9944-119c1aeb3d10.png)
