### PR TITLE
Make fhrs ids into links

### DIFF
--- a/src/components/FeaturePanel/helpers.tsx
+++ b/src/components/FeaturePanel/helpers.tsx
@@ -31,7 +31,7 @@ export const getUrlForTag = (k, v) => {
     const id = encodeURIComponent(v);
     return `https://pamatkovykatalog.cz/uskp/podle-relevance/1/seznam/?h=${id}&chranenoTed=1&hlObj=1&fulltext`;
   }
-  if (k === 'fhrd:id' ) {
+  if (k === 'fhrs:id' ) {
     return `https://ratings.food.gov.uk/business/en-GB/${v}`
   }
   if (k === 'website') {

--- a/src/components/FeaturePanel/helpers.tsx
+++ b/src/components/FeaturePanel/helpers.tsx
@@ -31,6 +31,9 @@ export const getUrlForTag = (k, v) => {
     const id = encodeURIComponent(v);
     return `https://pamatkovykatalog.cz/uskp/podle-relevance/1/seznam/?h=${id}&chranenoTed=1&hlObj=1&fulltext`;
   }
+  if (k === 'fhrd:id' ) {
+    return `https://ratings.food.gov.uk/business/en-GB/${v}`
+  }
   if (k === 'website') {
     return v.match(urlRegExp) ? v : `http://${v}`;
   }


### PR DESCRIPTION
The key [fhrs:id](https://wiki.openstreetmap.org/wiki/Key:fhrs:id) is used in the UK to give the id of an establishment in the food hygiene database.
Linking to this means that users can check the food hygiene rating of the establishment.
Future work would be to fetch the rating and show that in the card.