### PR TITLE
Map: add motorway_construction layer

### DIFF
--- a/src/components/Map/styles/basicStyle.ts
+++ b/src/components/Map/styles/basicStyle.ts
@@ -7,6 +7,7 @@ import {
 } from './layers/buildings3dLayers';
 import { addHoverPaint } from '../behaviour/featureHover';
 import { BACKGROUND, GLYPHS, OSMAPP_SOURCES, OSMAPP_SPRITE } from '../consts';
+import { motorwayConstruction } from './layers/contruction';
 
 export const basicStyle = addHoverPaint({
   version: 8,
@@ -16,6 +17,7 @@ export const basicStyle = addHoverPaint({
   glyphs: GLYPHS,
   layers: [
     ...BACKGROUND,
+    motorwayConstruction,
     {
       id: 'landcover-glacier',
       type: 'fill',

--- a/src/components/Map/styles/layers/contruction.ts
+++ b/src/components/Map/styles/layers/contruction.ts
@@ -1,0 +1,38 @@
+export const motorwayConstruction = {
+  id: 'highway-motorway-construction',
+  type: 'line',
+  source: 'maptiler_planet',
+  'source-layer': 'transportation',
+  minzoom: 5,
+  filter: [
+    'all',
+    ['==', '$type', 'LineString'],
+    [
+      'all',
+      // ['!in', 'brunnel', 'bridge', 'tunnel'],
+      ['==', 'class', 'motorway_construction'],
+    ],
+  ],
+  layout: {
+    'line-cap': 'round',
+    'line-join': 'round',
+    visibility: 'visible',
+  },
+  paint: {
+    'line-color': '#fff',
+    'line-width': {
+      base: 1.2,
+      stops: [
+        [6.5, 0],
+        [7, 0.5],
+        [20, 18],
+      ],
+    },
+    'line-opacity': {
+      stops: [
+        [5, 0],
+        [14, 0.4],
+      ],
+    },
+  },
+};

--- a/src/components/Map/styles/outdoorStyle.ts
+++ b/src/components/Map/styles/outdoorStyle.ts
@@ -5,6 +5,7 @@ import {
 import { poiLayers } from './layers/poiLayers';
 import { addHoverPaint } from '../behaviour/featureHover';
 import { BACKGROUND, GLYPHS, OSMAPP_SOURCES, OSMAPP_SPRITE } from '../consts';
+import { motorwayConstruction } from './layers/contruction';
 
 // TODO add icons for outdoor to our sprite (guideposts, benches, etc)
 // https://api.maptiler.com/maps/outdoor/sprite.png?key=7dlhLl3hiXQ1gsth0kGu
@@ -18,6 +19,7 @@ export const outdoorStyle = addHoverPaint({
   glyphs: GLYPHS,
   layers: [
     ...BACKGROUND,
+    motorwayConstruction,
     {
       id: 'landcover_grass',
       type: 'fill',


### PR DESCRIPTION

https://osmapp-git-contruction-zbycz.vercel.app/#16.30/49.6688/18.3240


![Screenshot 2021-08-24 at 7 21 43](https://user-images.githubusercontent.com/385047/130560244-eed70e81-5949-4b07-b0e5-ea90a8ca84bf.png)



-----------------


For future reference, there is a data browser availible here: https://cloud.maptiler.com/tiles/v3-openmaptiles/

I have first verified, that the lines are in the data. It can be seen, that its the `#transportaion` source-layer, and can be selected by `class === motorway_contruction`.
![image](https://user-images.githubusercontent.com/385047/130557090-b8c5d92a-1ff5-474f-b4d3-6b0035b63225.png)
Then I opened their [Style Editor](https://cloud.maptiler.com/maps/style-editor/), cloned the Basic style, and made a copy of the `motorway` layer. Then I played little with the paint settings.


Fixes #29 