### PR TITLE
Fix handling of false coords; wikipedia tag with prefix

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -38,7 +38,7 @@ const useUpdateViewFromFeature = () => {
   const { setView } = useMapStateContext();
 
   React.useEffect(() => {
-    if (feature?.center && !getMapViewFromHash()) {
+    if (feature?.center.every(Boolean) && !getMapViewFromHash()) {
       const [lon, lat] = feature.center.map((deg) => deg.toFixed(4));
       setView(['17.00', lat, lon]);
     }

--- a/src/components/FeaturePanel/Coordinates.tsx
+++ b/src/components/FeaturePanel/Coordinates.tsx
@@ -131,7 +131,7 @@ const Coordinates = () => {
   const { feature } = useFeatureContext();
   const { center, roundedCenter = undefined } = feature;
   const coords = roundedCenter ?? center;
-  return coords ? <Coords coords={coords} /> : null;
+  return coords.every(Boolean) ? <Coords coords={coords} /> : null;
 };
 
 export default Coordinates;

--- a/src/components/FeaturePanel/Members.tsx
+++ b/src/components/FeaturePanel/Members.tsx
@@ -15,18 +15,16 @@ export const Members = () => {
         Relation members
       </Typography>
       <ul>
-        {members
-          .filter((item) => item.role)
-          .map((item) => {
-            const urlOsmId = getUrlOsmId({ type: item.type, id: item.ref });
-            return (
-              <li>
-                <Link href={`/${urlOsmId}`}>
-                  {`${item.role} – ${urlOsmId}`}
-                </Link>
-              </li>
-            );
-          })}
+        {members.map((item) => {
+          const urlOsmId = getUrlOsmId({ type: item.type, id: item.ref });
+          return (
+            <li>
+              <Link href={`/${urlOsmId}`}>
+                {item.role ? `${item.role} – ${urlOsmId}` : urlOsmId}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </Box>
   ) : null;

--- a/src/components/FeaturePanel/helpers/getUrlForTag.tsx
+++ b/src/components/FeaturePanel/helpers/getUrlForTag.tsx
@@ -1,7 +1,7 @@
 const urlRegExp = /^https?:\/\/.+/;
 
 export const getUrlForTag = (k, v) => {
-  if (k.match(/^:?wikipedia$/)) {
+  if (k.match(/:?wikipedia$/)) {
     if (v.match(/:/)) {
       const [lang, article] = v.split(':');
       return `https://${lang}.wikipedia.org/wiki/${article}`;

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -14,12 +14,12 @@ export const getFeatureImage = async (feature: Feature): Promise<Image> => {
 
   // for nonOsmObject we dont expect 2nd pass
   if (nonOsmObject) {
-    return center ? getMapillaryImage(center) : undefined;
+    return center.every(Boolean) ? getMapillaryImage(center) : undefined;
   }
 
   // first pass may be a skeleton --> start loading mapillary (center is similar)
   const osmid = getOsmappLink(feature);
-  if (skeleton && center) {
+  if (skeleton && center.every(Boolean)) {
     mapillaryPromise = getMapillaryImage(center);
     mapillaryForOsmId = osmid;
     return LOADING;
@@ -59,6 +59,7 @@ export const getFeatureImage = async (feature: Feature): Promise<Image> => {
 
   // fallback to mapillary
   return (
-    mapillaryPromise ?? (center ? await getMapillaryImage(center) : undefined)
+    mapillaryPromise ??
+    (center.every(Boolean) ? await getMapillaryImage(center) : undefined)
   );
 };


### PR DESCRIPTION
## Fix handling of false coords
[null, null] is treated as true in if-else statement
[undefined, undefined] is treated as true in if-else statement

This fixes https://github.com/zbycz/osmapp/issues/75

## Fix wikipedia tag with prefix
This fixes https://github.com/zbycz/osmapp/issues/82