### PR TITLE
Fix Photon adress without street

### DIFF
--- a/src/components/SearchBox/renderOptionFactory.tsx
+++ b/src/components/SearchBox/renderOptionFactory.tsx
@@ -110,9 +110,10 @@ const getAdditionalText = (props) => {
 export const buildPhotonAddress = ({
   place,
   street,
+  city,
   housenumber: hnum,
   streetnumber: snum,
-}) => join(street ?? place, ' ', hnum ? hnum.replace(' ', '/') : snum);
+}) => join(street ?? place ?? city, ' ', hnum ? hnum.replace(' ', '/') : snum);
 
 export const renderOptionFactory = (inputValue) => (option) => {
   const { properties, geometry } = option;


### PR DESCRIPTION
Finally, I'm fixing seaching address witout street name, only city and house number.
See previous pull request for more info: https://github.com/zbycz/osmapp/pull/84