### PR TITLE
Adding translated place names using wikidata

### DIFF
--- a/src/components/FeaturePanel/FeatureHeading.tsx
+++ b/src/components/FeaturePanel/FeatureHeading.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { EditIconButton } from './helpers/EditIconButton';
+import { useFeatureContext } from '../utils/FeatureContext';
+import { fetchJson } from '../../services/fetch';
+import { intl } from '../../services/intl';
+import { appendSearchParams, findFirstMatchingKey } from '../helpers';
 
 const Wrapper = styled.div`
   font-size: 36px;
@@ -15,9 +19,54 @@ const Wrapper = styled.div`
   }
 `;
 
-export const FeatureHeading = ({ title, onEdit, deleted, editEnabled }) => (
-  <Wrapper deleted={deleted}>
-    {editEnabled && <EditIconButton onClick={() => onEdit('name')} />}
-    {title}
-  </Wrapper>
-);
+const IntlNameWrapper = styled.div`
+  font-size: 22px;
+  padding-top: 10px;
+`;
+
+export async function getWikiLabel(
+  url: string,
+  wikiid: string,
+  language: string,
+) {
+  const response = await fetchJson(url);
+  return response.entities?.[wikiid].labels[language]?.value;
+}
+
+export const FeatureHeading = ({ title, onEdit, deleted, editEnabled }) => {
+  const [intlName, setAltName] = useState(null);
+  const { feature } = useFeatureContext();
+  const wikiKeys = ['wikidata', 'brand:wikidata'];
+  const id = findFirstMatchingKey(feature.tags, wikiKeys);
+
+  useEffect(() => {
+    const apiUrl = appendSearchParams('https://www.wikidata.org/w/api.php', {
+      format: 'json',
+      origin: '*',
+      action: 'wbgetentities',
+      props: 'labels',
+      ids: id,
+    });
+
+    const fetchData = async (url: string, wikiid: string, language: string) => {
+      const wikiName = await getWikiLabel(url, wikiid, language);
+      setAltName(wikiName);
+    };
+
+    fetchData(apiUrl, id, intl.lang);
+  }, [id]);
+
+  return (
+    <Wrapper deleted={deleted}>
+      <div>
+        {editEnabled && <EditIconButton onClick={() => onEdit('name')} />}
+        {title}
+      </div>
+      {intlName && intlName !== title ? (
+        <IntlNameWrapper>{intlName}</IntlNameWrapper>
+      ) : (
+        <></>
+      )}
+    </Wrapper>
+  );
+};

--- a/src/components/helpers.tsx
+++ b/src/components/helpers.tsx
@@ -92,3 +92,24 @@ export const useMobileMode = () => useMediaQuery('(max-width: 700px)');
 
 // (>= mobile size) This changes just the app layout
 export const isDesktop = '(min-width: 500px)';
+
+export function appendSearchParams(url: string, params: Object) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    searchParams.append(key, value);
+  });
+
+  const urlWithParams = `${url}?${searchParams.toString()}`;
+
+  return urlWithParams;
+}
+
+export function findFirstMatchingKey(tags: Object, keys: Array<string>) {
+  for (let i = 0; i < keys.length; i += 1) {
+    if (keys[i] in tags) {
+      return tags[keys[i]];
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
I've written a little code to add an alternative, object sub-title for OSM objects that have a linked `wikidata` or `brand:wikidata` tag, which has an associated label in the user's language. This should also address #105 about translating place names. I am also toying with the idea of pulling into the description Wikipedia info for objects with a Wikipedia entry in the user's language, which is why I put some of the helper functions in the `helper.tsx` file, but that would be a separate PR somewhere down the line. Feel free to edit or clean up!