### PR TITLE
Public transport labels

### DIFF
--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -23,6 +23,7 @@ import { getLabel } from '../../helpers/featureLabel';
 import { ImageSection } from './ImageSection/ImageSection';
 import { IdSchemeFields } from './IdSchemeFields';
 import { TagsTable } from './TagsTable';
+import { PublicTransportWrapper } from './PublicTransport/PublicTransportWrapper';
 
 const featuredKeys = [
   'website',
@@ -54,6 +55,9 @@ const FeaturePanel = () => {
 
   return (
     <PanelWrapper>
+      <PublicTransportWrapper>
+        <h1>Here</h1>
+      </PublicTransportWrapper>
       <PanelScrollbars>
         <ImageSection />
         <PanelContent>

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -23,7 +23,6 @@ import { getLabel } from '../../helpers/featureLabel';
 import { ImageSection } from './ImageSection/ImageSection';
 import { IdSchemeFields } from './IdSchemeFields';
 import { TagsTable } from './TagsTable';
-import { PublicTransportWrapper } from './PublicTransport/PublicTransportWrapper';
 
 const featuredKeys = [
   'website',
@@ -55,9 +54,6 @@ const FeaturePanel = () => {
 
   return (
     <PanelWrapper>
-      <PublicTransportWrapper>
-        <h1>Here</h1>
-      </PublicTransportWrapper>
       <PanelScrollbars>
         <ImageSection />
         <PanelContent>

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -23,6 +23,7 @@ import { getLabel } from '../../helpers/featureLabel';
 import { ImageSection } from './ImageSection/ImageSection';
 import { IdSchemeFields } from './IdSchemeFields';
 import { TagsTable } from './TagsTable';
+import { PublicTransport } from './PublicTransport/PublicTransport';
 
 const featuredKeys = [
   'website',
@@ -103,6 +104,8 @@ const FeaturePanel = () => {
           )}
 
           {advanced && <Members />}
+
+          <PublicTransport tags={tags} />
 
           {editEnabled && (
             <>

--- a/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
+++ b/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
@@ -19,8 +19,11 @@ function whiteOrBlackText(hexBgColor) {
 }
 
 export const LineNumber: React.FC<LineNumberProps> = ({ name, color }) => {
+  const darkmode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
   let bgcolor: string;
-  if (!color) bgcolor = '#898989';
+  if (!color) bgcolor = darkmode ? '#898989' : '#dddddd';
+  // set the default color
   else bgcolor = color.toLowerCase();
 
   const divStyle: React.CSSProperties = {

--- a/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
+++ b/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useUserThemeContext } from '../../../helpers/theme';
 
 interface LineNumberProps {
   name: string;
@@ -19,7 +20,8 @@ function whiteOrBlackText(hexBgColor) {
 }
 
 export const LineNumber: React.FC<LineNumberProps> = ({ name, color }) => {
-  const darkmode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const { currentTheme } = useUserThemeContext();
+  const darkmode = currentTheme === 'dark';
 
   let bgcolor: string;
   if (!color) bgcolor = darkmode ? '#898989' : '#dddddd';

--- a/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
+++ b/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
@@ -19,13 +19,17 @@ function whiteOrBlackText(hexBgColor) {
 }
 
 export const LineNumber: React.FC<LineNumberProps> = ({ name, color }) => {
+  let bgcolor: string;
+  if (!color) bgcolor = '#898989';
+  else bgcolor = color.toLowerCase();
+
   const divStyle: React.CSSProperties = {
-    backgroundColor: color,
+    backgroundColor: bgcolor,
     paddingBlock: '0.2rem',
     paddingInline: '0.4rem',
     borderRadius: '0.125rem',
     display: 'inline',
-    color: whiteOrBlackText(color),
+    color: whiteOrBlackText(bgcolor),
   };
 
   return <div style={divStyle}>{name}</div>;

--- a/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
+++ b/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface LineNumberProps {
+  name: string;
+  color: string;
+}
+
+/**
+ * A function to determine whether the text color should be black or white
+ * @param hexBgColor The background color in hex format, e.g. #ff0000
+ * @returns 'black' or 'white' depending on the brightness of the background color
+ */
+function whiteOrBlackText(hexBgColor) {
+  const r = parseInt(hexBgColor.slice(1, 3), 16);
+  const g = parseInt(hexBgColor.slice(3, 5), 16);
+  const b = parseInt(hexBgColor.slice(5, 7), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 125 ? 'black' : 'white';
+}
+
+export const LineNumber: React.FC<LineNumberProps> = ({ name, color }) => {
+  const divStyle: React.CSSProperties = {
+    backgroundColor: color,
+    paddingBlock: '0.2rem',
+    paddingInline: '0.4rem',
+    borderRadius: '0.125rem',
+    display: 'inline',
+    color: whiteOrBlackText(color),
+  };
+
+  return <div style={divStyle}>{name}</div>;
+};

--- a/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { requestLines } from './requestRoutes';
+import { PublicTransportWrapper } from './PublicTransportWrapper';
+import { FeatureTags } from '../../../services/types';
+import { LineNumber } from './LineNumber';
+
+interface PublicTransportProps {
+  tags: FeatureTags;
+}
+
+export const PublicTransport: React.FC<PublicTransportProps> = ({ tags }) => {
+  const isPublicTransport =
+    Object.keys(tags).includes('public_transport') ||
+    tags.railway === 'station';
+
+  if (!isPublicTransport) {
+    return null;
+  }
+
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const loadData = async () => {
+      const lines = await requestLines(
+        router.query.all[0] as any,
+        Number(router.query.all[1]),
+      );
+      setData(lines);
+      setLoading(false);
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <div>
+      {loading ? (
+        <div>...</div>
+      ) : (
+        <PublicTransportWrapper>
+          {data.map((line) => (
+            <LineNumber name={line.ref} color={line.colour} />
+          ))}
+        </PublicTransportWrapper>
+      )}
+    </div>
+  );
+};

--- a/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { requestLines } from './requestRoutes';
+import { Typography } from '@material-ui/core';
+import { LineInformation, requestLines } from './requestRoutes';
 import { PublicTransportWrapper } from './PublicTransportWrapper';
 import { FeatureTags } from '../../../services/types';
 import { LineNumber } from './LineNumber';
@@ -8,6 +9,73 @@ import { LineNumber } from './LineNumber';
 interface PublicTransportProps {
   tags: FeatureTags;
 }
+
+const useLoadingState = () => {
+  const [routes, setRoutes] = useState<LineInformation[]>([]);
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(true);
+
+  const finishRoutes = (payload) => {
+    setLoading(false);
+    setRoutes(payload);
+  };
+
+  const startRoutes = () => {
+    setLoading(true);
+    setRoutes([]);
+    setError(undefined);
+  };
+
+  const failRoutes = () => {
+    setError('Could not load routes');
+    setLoading(false);
+  };
+
+  return { routes, error, loading, startRoutes, finishRoutes, failRoutes };
+};
+
+const PublicTransportInner = () => {
+  const router = useRouter();
+
+  const { routes, error, loading, startRoutes, finishRoutes, failRoutes } =
+    useLoadingState();
+
+  useEffect(() => {
+    const loadData = async () => {
+      startRoutes();
+      const lines = await requestLines(
+        router.query.all[0] as any,
+        Number(router.query.all[1]),
+      ).catch(failRoutes);
+      finishRoutes(lines);
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <div>
+      {loading ? (
+        <>
+          <span className="dotloader">.</span>
+          <span className="dotloader">.</span>
+          <span className="dotloader">.</span>
+        </>
+      ) : (
+        <PublicTransportWrapper>
+          {routes.map((line) => (
+            <LineNumber name={line.ref} color={line.colour} />
+          ))}
+        </PublicTransportWrapper>
+      )}
+      {error && (
+        <Typography color="secondary" paragraph>
+          Error: {error}
+        </Typography>
+      )}
+    </div>
+  );
+};
 
 export const PublicTransport: React.FC<PublicTransportProps> = ({ tags }) => {
   const isPublicTransport =
@@ -18,34 +86,5 @@ export const PublicTransport: React.FC<PublicTransportProps> = ({ tags }) => {
     return null;
   }
 
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const router = useRouter();
-
-  useEffect(() => {
-    const loadData = async () => {
-      const lines = await requestLines(
-        router.query.all[0] as any,
-        Number(router.query.all[1]),
-      );
-      setData(lines);
-      setLoading(false);
-    };
-
-    loadData();
-  }, []);
-
-  return (
-    <div>
-      {loading ? (
-        <div>...</div>
-      ) : (
-        <PublicTransportWrapper>
-          {data.map((line) => (
-            <LineNumber name={line.ref} color={line.colour} />
-          ))}
-        </PublicTransportWrapper>
-      )}
-    </div>
-  );
+  return PublicTransportInner();
 };

--- a/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
@@ -80,7 +80,9 @@ const PublicTransportInner = () => {
 export const PublicTransport: React.FC<PublicTransportProps> = ({ tags }) => {
   const isPublicTransport =
     Object.keys(tags).includes('public_transport') ||
-    tags.railway === 'station';
+    tags.railway === 'station' ||
+    tags.railway === 'halt' ||
+    tags.railway === 'subway_entrance';
 
   if (!isPublicTransport) {
     return null;

--- a/src/components/FeaturePanel/PublicTransport/PublicTransportWrapper.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransportWrapper.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const PublicTransportWrapper = ({ children }) => {
+  const divStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'start',
+    justifyContent: 'start',
+    gap: '0.5rem',
+    flexWrap: 'wrap',
+  };
+
+  return <div style={divStyle}>{children}</div>;
+};

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -13,8 +13,8 @@ export async function requestLines(
   // use the overpass api to request the lines in
   const overpassQuery = `[out:csv(ref, colour; false; ';')];
     ${featureType}(${id})->.center;
-    node(around.center:${radius})["railway"="stop"] -> .stops;
-    rel(bn.stops)[route=train];
+    node(around.center:${radius})["public_transport"="stop_position"] -> .stops;
+    rel(bn.stops)["route"~"bus|train|tram|subway|light_rail"];
     out;`;
 
   // send the request

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -1,6 +1,6 @@
 import { fetchText } from '../../../services/fetch';
 
-interface LineInformation {
+export interface LineInformation {
   ref: string;
   colour: string | undefined;
 }

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -6,7 +6,7 @@ interface LineInformation {
 }
 
 export async function requestLines(
-  featureType: 'node' | 'way' | 'rel',
+  featureType: 'node' | 'way' | 'relation',
   id: number,
   radius = 150,
 ) {
@@ -24,14 +24,20 @@ export async function requestLines(
     )}`,
   );
 
-  const resData = response.split('\n').map((line) => {
-    const ref = line.split(';')[0];
-    let colour = line.split(';')[1];
+  let resData = response.split('\n').map((line) => {
+    const ref = line.split(';').slice(0, -1).join(';');
+    let colour = line.split(';')[line.split(';').length - 1];
 
     // set colour to undefined if it is empty
     if (colour === '') colour = undefined;
     return { ref, colour } as LineInformation;
   });
 
+  resData = resData.filter((line) => line.ref !== '');
+  // remove duplicats
+  resData = resData.filter(
+    (line, index) => resData.findIndex((l) => l.ref === line.ref) === index,
+  );
+  resData.sort((a, b) => a.ref.localeCompare(b.ref));
   return resData;
 }

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -13,7 +13,10 @@ export async function requestLines(
   // use the overpass api to request the lines in
   const overpassQuery = `[out:csv(ref, colour; false; ';')];
     ${featureType}(${id})->.center;
-    node(around.center:${radius})["public_transport"="stop_position"] -> .stops;
+    (
+      node(around.center:${radius})["public_transport"="stop_position"];
+      node(around.center:${radius})["highway"="bus_stop"];
+    ) -> .stops;
     rel(bn.stops)["route"~"bus|train|tram|subway|light_rail"];
     out;`;
 

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -15,9 +15,10 @@ export async function requestLines(
     ${featureType}(${id})->.center;
     (
       node(around.center:${radius})["public_transport"="stop_position"];
-      node(around.center:${radius})["highway"="bus_stop"];
+      nw(around.center:${radius})["highway"="bus_stop"];
+      nwr(around.center:${radius})["amenity"="ferry_terminal"];
     ) -> .stops;
-    rel(bn.stops)["route"~"bus|train|tram|subway|light_rail"];
+    rel(bn.stops)["route"~"bus|train|tram|subway|light_rail|ferry|monorail"];
     out;`;
 
   // send the request

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -1,0 +1,37 @@
+import { fetchText } from '../../../services/fetch';
+
+interface LineInformation {
+  ref: string;
+  colour: string | undefined;
+}
+
+export async function requestLines(
+  featureType: 'node' | 'way' | 'rel',
+  id: number,
+  radius = 150,
+) {
+  // use the overpass api to request the lines in
+  const overpassQuery = `[out:csv(ref, colour; false; ';')];
+    ${featureType}(${id})->.center;
+    node(around.center:${radius})["railway"="stop"] -> .stops;
+    rel(bn.stops)[route=train];
+    out;`;
+
+  // send the request
+  const response: string = await fetchText(
+    `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(
+      overpassQuery,
+    )}`,
+  );
+
+  const resData = response.split('\n').map((line) => {
+    const ref = line.split(';')[0];
+    let colour = line.split(';')[1];
+
+    // set colour to undefined if it is empty
+    if (colour === '') colour = undefined;
+    return { ref, colour } as LineInformation;
+  });
+
+  return resData;
+}

--- a/src/services/__tests__/osmApi.test.ts
+++ b/src/services/__tests__/osmApi.test.ts
@@ -12,6 +12,7 @@ import {
 import { intl } from '../intl';
 import * as tagging from '../tagging/translations';
 import * as idTaggingScheme from '../tagging/idTaggingScheme';
+import { requestLines } from '../../components/FeaturePanel/PublicTransport/requestRoutes';
 
 const osm = (item) => ({ elements: [item] });
 const overpass = {
@@ -69,6 +70,20 @@ describe('fetchFeature', () => {
     const feature = await fetchFeature('r1234');
     expect(fetchJson).toHaveBeenCalledTimes(2);
     expect(feature).toEqual(relationFeature);
+  });
+
+  it('should return some fetched routes', async () => {
+    const features = await requestLines('node', 3862767512);
+
+    features.forEach((feature) => {
+      expect(feature).toHaveProperty('ref');
+      expect(feature.ref).not.toBe('');
+      expect(feature.ref).toEqual(expect.any(String));
+      expect(feature).toHaveProperty('colour');
+      expect(
+        typeof feature.colour === 'string' || feature.colour === undefined,
+      ).toBeTruthy();
+    });
   });
 
   it('should return cached center for a way in BROWSER', async () => {


### PR DESCRIPTION
## Overview

This PR partially fixes #168. When a public transport stop like an bus stop, train station, subway station or  tram station gets clicked the user can now see which train, bus... lines hold at that stop.

## Example

![Screen Shot 2023-08-07 at 00 11 31](https://github.com/zbycz/osmapp/assets/84224239/6dee0aac-1c0a-4235-9627-886f4caf3ddc)
