### PR TITLE
general: sitemap experiment

### DIFF
--- a/pages/sitemap.txt.tsx
+++ b/pages/sitemap.txt.tsx
@@ -1,0 +1,19 @@
+import { fetchText } from '../src/services/fetch';
+
+const Sitemap = () => null;
+
+export const getServerSideProps = async ({ res }) => {
+  const content = await fetchText(
+    'https://zbycz.github.io/osm-static/sitemap.txt',
+  );
+
+  res.setHeader('Content-Type', 'text/plain');
+  res.write(content);
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default Sitemap;


### PR DESCRIPTION
Since we have id-tagging-scheme in place, every feature URL should eventually be submitted to search engines. 

I started with items having `name=*`in Beroun. Their urls are here: https://osmapp.org/sitemap.txt

```
[out:json][timeout:25];
// [out:csv(::count, ::"count:nodes", ::"count:ways", ::"count:relations")][timeout:25];

area(id:3600442333)->.searchArea;
(
  nwr["name"](area.searchArea);
);
out;
```