### PR TITLE
OpenPlaceGuide integration

### DIFF
--- a/src/components/FeaturePanel/FeatureOpenPlaceGuideLink.tsx
+++ b/src/components/FeaturePanel/FeatureOpenPlaceGuideLink.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { t } from '../../services/intl';
+import { fetchJson } from '../../services/fetch';
+
+const Spacer = styled.div`
+  padding-bottom: 10px;
+`;
+
+const getData = async (center, osmId) => {
+  if (center === undefined || !center.length) {
+    return null;
+  }
+  const body = await fetchJson(
+    `https://discover.openplaceguide.org/v2/discover?lat=${center[1]}&lon=${center[0]}&osmId=${osmId}`,
+  );
+  return body;
+};
+
+export const FeatureOpenPlaceGuideLink = ({ center, osmId }) => {
+  const [instances, setInstances] = useState([]);
+
+  useEffect(() => {
+    getData(center, osmId).then(setInstances);
+  }, [osmId]);
+
+  if (instances.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {instances.map((instance) => (
+        <>
+          <a href={instance.url}>
+            {t('featurepanel.more_in_openplaceguide', {
+              instanceName: instance.name,
+            })}
+          </a>
+          <Spacer />
+        </>
+      ))}
+    </>
+  );
+};

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -19,6 +19,7 @@ import { OsmError } from './OsmError';
 import { Members } from './Members';
 import { EditButton } from './EditButton';
 import { FeaturedTags } from './FeaturedTags';
+import { FeatureOpenPlaceGuideLink } from './FeatureOpenPlaceGuideLink';
 import { getLabel } from '../../helpers/featureLabel';
 import { ImageSection } from './ImageSection/ImageSection';
 
@@ -63,6 +64,11 @@ const FeaturePanel = () => {
           />
 
           <OsmError />
+
+          <FeatureOpenPlaceGuideLink
+            center={feature.center}
+            osmId={getUrlOsmId(osmMeta)}
+          />
 
           <FeaturedTags
             featuredTags={deleted ? [] : featuredTags}

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -73,6 +73,7 @@ export default {
   'featurepanel.uncertain_image': 'This is the closest street view image from Mapillary. It may be inaccurate.',
   'featurepanel.inline_edit_title': 'Edit',
   'featurepanel.objects_around': 'Nearby objects',
+  'featurepanel.more_in_openplaceguide': 'More information on __instanceName__',
 
   'opening_hours.open': 'Open: __todayTime__',
   'opening_hours.now_closed_but_today': 'Closed now - Open __todayTime__',


### PR DESCRIPTION
OpenPlaceGuide is meant to be a federated network of pages that provide more details for OpenStreetMap places.

There is the https://discover.openplaceguide.org/ service which provides links to those "instances"

Currently there is only AddisMap.com registered. Everyone could run a similar service for their area using https://github.com/OpenPlaceGuide/opg-pages

(Actually AddisMap.com currently runs on older proprietary code, but the idea is to port it's main features to opg-pages)

An OPG instance uses URLs of the format `$domain/$osmType/$osmId` which lead to a micropage of the place.

Place place information can be enriched via different sources (currently the OPG database - a [Git Repository](https://github.com/OpenPlaceGuide/data)) with all kind of information which does not directly belong to the OSM database.

This pull request implements the following:

* Fetch federation instance(s) for the current feature from OpenPlaceGuide discover
* Add links to the specific detail pages, if available

You can test it by clicking on some features in Ethiopia

Example: /way/50833484


Known issues: When using the back button, an undefined variable error is thrown
