### PR TITLE
ObjectsAround: fix - use correct `getCenter`

### DIFF
--- a/src/components/FeaturePanel/ObjectsAround.tsx
+++ b/src/components/FeaturePanel/ObjectsAround.tsx
@@ -66,11 +66,8 @@ const AroundItem = ({ feature }: { feature: Feature }) => {
   );
 };
 
-// TODO quick fix #220
-/* eslint-disable */
-
 // TODO make SSR ?
-export const ObjectsAroundInner = ({ advanced }) => {
+export const ObjectsAround = ({ advanced }) => {
   const { feature } = useFeatureContext();
   const { around, loading, error, startAround, finishAround, failAround } =
     useLoadingState();
@@ -131,34 +128,10 @@ export const ObjectsAroundInner = ({ advanced }) => {
       )}
 
       <ul>
-        {features.map((item, idx) => (
-          <AroundItem key={idx} feature={item} />
-          // <AroundItem key={getOsmappLink(item)} feature={item} />
+        {features.map((item) => (
+          <AroundItem key={getOsmappLink(item)} feature={item} />
         ))}
       </ul>
     </Box>
   );
 };
-
-class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
-  state = { hasError: false };
-
-  static getDerivedStateFromError(error) {
-    console.log(error);
-    return { hasError: true };
-  }
-
-  componentDidCatch(error, errorInfo) {
-    console.log(error, errorInfo);
-  }
-
-  render() {
-    return this.state.hasError ? <span>error</span> : this.props.children;
-  }
-}
-
-export const ObjectsAround = (props) => (
-  <ErrorBoundary>
-    <ObjectsAroundInner {...props} />
-  </ErrorBoundary>
-);

--- a/src/components/FeaturePanel/ObjectsAround.tsx
+++ b/src/components/FeaturePanel/ObjectsAround.tsx
@@ -66,6 +66,9 @@ const AroundItem = ({ feature }: { feature: Feature }) => {
   );
 };
 
+// TODO quick fix #220
+/* eslint-disable */
+
 // TODO make SSR ?
 export const ObjectsAroundInner = ({ advanced }) => {
   const { feature } = useFeatureContext();
@@ -128,15 +131,14 @@ export const ObjectsAroundInner = ({ advanced }) => {
       )}
 
       <ul>
-        {features.map((item) => (
-          <AroundItem key={getOsmappLink(item)} feature={item} />
+        {features.map((item, idx) => (
+          <AroundItem key={idx} feature={item} />
+          // <AroundItem key={getOsmappLink(item)} feature={item} />
         ))}
       </ul>
     </Box>
   );
 };
-
-/* eslint-disable */
 
 class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
   state = { hasError: false };

--- a/src/components/FeaturePanel/ObjectsAround.tsx
+++ b/src/components/FeaturePanel/ObjectsAround.tsx
@@ -67,7 +67,7 @@ const AroundItem = ({ feature }: { feature: Feature }) => {
 };
 
 // TODO make SSR ?
-export const ObjectsAround = ({ advanced }) => {
+export const ObjectsAroundInner = ({ advanced }) => {
   const { feature } = useFeatureContext();
   const { around, loading, error, startAround, finishAround, failAround } =
     useLoadingState();
@@ -135,3 +135,28 @@ export const ObjectsAround = ({ advanced }) => {
     </Box>
   );
 };
+
+/* eslint-disable */
+
+class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(error) {
+    console.log(error);
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.log(error, errorInfo);
+  }
+
+  render() {
+    return this.state.hasError ? <span>error</span> : this.props.children;
+  }
+}
+
+export const ObjectsAround = (props) => (
+  <ErrorBoundary>
+    <ObjectsAroundInner {...props} />
+  </ErrorBoundary>
+);

--- a/src/services/getCenter.ts
+++ b/src/services/getCenter.ts
@@ -7,7 +7,7 @@ interface NamedBbox {
   n: number;
 }
 
-const getBbox = (coordinates: Position[]): NamedBbox => {
+export const getBbox = (coordinates: Position[]): NamedBbox => {
   const [firstX, firstY] = coordinates[0];
   const initialBbox = { w: firstX, s: firstY, e: firstX, n: firstY };
 

--- a/src/services/overpassAroundToSkeletons.ts
+++ b/src/services/overpassAroundToSkeletons.ts
@@ -1,6 +1,31 @@
-import { Feature, LineString, Point } from './types';
+import {
+  Feature,
+  LineString,
+  Point,
+  FeatureGeometry,
+  isPoint,
+  isWay,
+  Position,
+} from './types';
+
 import { getPoiClass } from './getPoiClass';
-import { getCenter } from './getCenter';
+import { getBbox } from './getCenter';
+
+export const getCenter = (geometry: FeatureGeometry): Position => {
+  if (isPoint(geometry)) {
+    return geometry.coordinates;
+  }
+
+  if (isWay(geometry) && geometry.coordinates?.length) {
+    const { w, s, e, n } = getBbox(geometry.coordinates); // [WSEN]
+    const lon = (w + e) / 2; // flat earth rulezz
+    const lat = (s + n) / 2;
+    return [lon, lat];
+  }
+
+  // relation
+  return undefined;
+};
 
 const notNull = (x) => x != null;
 


### PR DESCRIPTION
Causing ERROR PAGE to render for any coords clicked.