### PR TITLE
general: add offline country resolution

### DIFF
--- a/__mocks__/next-codegrid.js
+++ b/__mocks__/next-codegrid.js
@@ -1,0 +1,3 @@
+module.exports = {
+  resolveCountryCode: jest.fn().mockReturnValue(undefined),
+};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.17.21",
     "maplibre-gl": "^3.3.1",
     "next": "^13.4.3",
+    "next-codegrid": "^1.0.2",
     "next-cookies": "^2.0.3",
     "next-pwa": "^5.2.21",
     "osm-auth": "^2.4.0",

--- a/src/components/FeaturePanel/Coordinates.tsx
+++ b/src/components/FeaturePanel/Coordinates.tsx
@@ -121,6 +121,7 @@ export const Coords = ({ coords }: Props) => {
   return (
     <span title="latitude, longitude (y, x)" ref={anchorRef}>
       {positionToDeg(coords)}
+      {feature.countryCode && ` (${feature.countryCode.toUpperCase()})`}
       <Menu
         anchorEl={anchorRef.current}
         open={opened}

--- a/src/services/osmApi.ts
+++ b/src/services/osmApi.ts
@@ -1,3 +1,4 @@
+import { resolveCountryCode } from 'next-codegrid';
 import {
   FetchError,
   getApiId,
@@ -102,6 +103,8 @@ const fetchFeatureWithCenter = async (apiId: OsmApiId) => {
   if (center) {
     feature.center = center;
   }
+
+  feature.countryCode = await resolveCountryCode(feature.center); // takes 0-100ms for first resolution, then instant
 
   return addSchemaToFeature(feature);
 };

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -105,6 +105,7 @@ export interface Feature {
     osmappLabel?: string;
   };
   center: Position;
+  countryCode?: string; // ISO3166-1 code, undefined = no country
   roundedCenter?: LonLatRounded;
   ssrFeatureImage?: Image;
   error?: 'network' | 'unknown' | '404' | '500'; // etc.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5742,6 +5742,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-codegrid@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/next-codegrid/-/next-codegrid-1.0.2.tgz#e36a297fd6b6eaf4425eb8736d96157bc59c09fc"
+  integrity sha512-7gp+Q49ies8UNczepSv9taS9ZcganKJYkjjWDjd718sOjAsP7m2xL2QyrxsH7xlUKR5SDX1YYfcv7+eKs6Iolg==
+
 next-cookies@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/next-cookies/-/next-cookies-2.0.3.tgz#5a3eabcb6afa9b4d4ade69dfaaad749d16cd4a9a"


### PR DESCRIPTION
Using [next-codegrid](https://github.com/zbycz/next-codegrid) package.

TODO: unfortunately the service worker caches all the tiles (we can live with 1.5 MB though 🙂 )


### How it works
Modification of the [codegrid-js](http://github.com/hlaw/codegrid-js) library for use in Next.js.

- bundles all tiles as javascript chunks – both for client and server
- this process adds 10 secs to the `next build` (TODO: optimize - store in /public ?)
    - output size is 10.5 MB (see .next/static/chunks), or 1.5 MB gzipped
- first resolve takes ~40ms (both client and server), subsequent resolves are instant if it falls to the same tile
    - fetches 35kb for worldgrid, then 100-300kb for tile (or 13kb gzipped, then ~50kB for tile)
