### PR TITLE
FeaturePanel: make social media usernames clickable

### DIFF
--- a/src/components/FeaturePanel/Properties/getUrlForTag.tsx
+++ b/src/components/FeaturePanel/Properties/getUrlForTag.tsx
@@ -1,6 +1,6 @@
 const urlRegExp = /^https?:\/\/.+/;
 
-export const getUrlForTag = (k, v) => {
+export const getUrlForTag = (k: string, v: string) => {
   if (k.match(/:?wikipedia$/)) {
     if (v.match(/:/)) {
       const [lang, article] = v.split(':');
@@ -40,6 +40,40 @@ export const getUrlForTag = (k, v) => {
   }
   if (v.match(urlRegExp)) {
     return v;
+  }
+
+  if (k === 'contact:facebook') {
+    return `https://facebook.com/${v}`;
+  }
+  if (k === 'contact:youtube') {
+    return v.startsWith('@')
+      ? `https://youtube.com/${v}`
+      : `https://youtube.com/@${v}`;
+  }
+  if (k === 'contact:instagram') {
+    return `https://instagram.com/${v}`;
+  }
+  if (k === 'contact:vk') {
+    return `https://vk.com/${v}`;
+  }
+  if (k === 'contact:twitter') {
+    return `https://twitter.com/${v}`;
+  }
+  if (k === 'contact:matrix') {
+    return `https://matrix.to/#/${v}`;
+  }
+  if (k === 'contact:mastodon') {
+    return v.startsWith('@')
+      ? `https://mastodon.social/${v}`
+      : `https://mastodon.social/@${v}`;
+  }
+  if (k === 'contact:pinterest') {
+    return `https://pinterest.com/${v}`;
+  }
+  if (k === 'contact:tiktok') {
+    return v.startsWith('@')
+      ? `https://tiktok.com/${v}`
+      : `https://tiktok.com/@${v}`;
   }
 
   return null;


### PR DESCRIPTION
Like discussed in #378 this makes social media usernames clickable.

- [Instagram, Pinterest, Tiktok, Youtube](https://osmapp-git-fork-dlurak-contactlinks-osm-app-team.vercel.app/way/1257446762)
- [Facebook](https://osmapp-git-fork-dlurak-contactlinks-osm-app-team.vercel.app/node/11396781351)
- [vk](https://osmapp-git-fork-dlurak-contactlinks-osm-app-team.vercel.app/node/312453742)
- [Twitter, Matrix, Mastodon](https://osmapp-git-fork-dlurak-contactlinks-osm-app-team.vercel.app/node/3342079613)