### PR TITLE
#387 Support Public Transport mapping without intermediate stop area relations

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -11,10 +11,15 @@ export async function requestLines(
 ) {
   // use the overpass api to request the lines in
   const overpassQuery = `[out:csv(ref, colour; false; ';')];
-  ${featureType}(${id});
-  rel(bn)["public_transport"="stop_area"];
-node(r: "stop") -> .stops;
-    rel(bn.stops)["route"~"bus|train|tram|subway|light_rail|ferry|monorail"];
+  ${featureType}(${id})-> .specific_feature;
+    // Try to find stop_area relations containing the specific node and get their stops
+    rel(bn.specific_feature)["public_transport"="stop_area"] -> .stop_areas;
+    node(r.stop_areas: "stop") -> .stops;
+    (
+      rel(bn.stops)["route"~"bus|train|tram|subway|light_rail|ferry|monorail"];
+      // If no stop_area, find routes that directly include the specific node
+      rel(bn.specific_feature)["route"~"bus|train|tram|subway|light_rail|ferry|monorail"];
+    );
     out;`;
 
   // send the request


### PR DESCRIPTION
* This tries to support nodes which are not contained in a stop_area relation but directly in a route relation, example: https://www.openstreetmap.org/node/11035607130 as of version 5

Fixes #387 


//edit:
Examples:
- stop relation /node/24569897
- without relation /node/11035607130