### PR TITLE
climbing: More precise grading system

### DIFF
--- a/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
+++ b/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
@@ -9,6 +9,7 @@ type Props = {
   selectedGradeSystem: GradeSystem;
   setGradeSystem: (GradeSystem: GradeSystem) => void;
   onClick?: (e: any) => void;
+  allowUnsetValue?: boolean;
 };
 
 const Row = styled.div`
@@ -26,6 +27,7 @@ export const GradeSystemSelect = ({
   selectedGradeSystem,
   setGradeSystem,
   onClick,
+  allowUnsetValue = true,
 }: Props) => (
   <Select
     value={selectedGradeSystem}
@@ -36,6 +38,7 @@ export const GradeSystemSelect = ({
       setGradeSystem(event.target.value);
     }}
   >
+    {allowUnsetValue && <MenuItem value={null}>Original grade</MenuItem>}
     {GRADE_SYSTEMS.map(({ key, name, description }) => (
       <MenuItem value={key}>
         <Row>

--- a/src/components/FeaturePanel/Climbing/RouteDifficultySelect.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteDifficultySelect.tsx
@@ -74,6 +74,7 @@ export const RouteDifficultySelect = ({
         setGradeSystem={setTempGradeSystem}
         selectedGradeSystem={tempGradeSystem}
         onClick={onClick}
+        allowUnsetValue={false}
       />
     </Flex>
   );

--- a/src/components/FeaturePanel/Climbing/RouteDistribution.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteDistribution.tsx
@@ -46,7 +46,7 @@ const getGroupingLabel = (label: string) => String(parseFloat(label));
 
 export const RouteDistribution = () => {
   const { userSettings, setUserSetting } = useUserSettingsContext();
-  const gradeSystem = userSettings['climbing.gradeSystem'];
+  const gradeSystem = userSettings['climbing.gradeSystem'] || 'uiaa';
 
   const theme = useTheme();
   const { routes } = useClimbingContext();

--- a/src/components/FeaturePanel/Climbing/RouteList/RouteListRow.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/RouteListRow.tsx
@@ -14,7 +14,7 @@ import { ExpandedRow } from './ExpandedRow';
 import { RouteDifficultyBadge } from '../RouteDifficultyBadge';
 import { getShortId } from '../../../../services/helpers';
 import { isTicked } from '../../../../services/ticks';
-import { getDifficulty } from '../utils/grades/routeGrade';
+import { getDifficulties } from '../utils/grades/routeGrade';
 
 const DEBOUNCE_TIME = 1000;
 const Container = styled.div`
@@ -128,7 +128,7 @@ export const RenderListRow = ({
     isExpanded,
     osmId,
   };
-  const routeDifficulty = getDifficulty(tempRoute.feature?.tags);
+  const routeDifficulties = getDifficulties(tempRoute.feature?.tags);
 
   return (
     <Container ref={ref}>
@@ -162,7 +162,7 @@ export const RenderListRow = ({
           )}
         </NameCell>
         <DifficultyCell $width={50}>
-          <RouteDifficultyBadge routeDifficulty={routeDifficulty} />
+          <RouteDifficultyBadge routeDifficulties={routeDifficulties} />
         </DifficultyCell>
 
         <Cell $width={50}>

--- a/src/components/FeaturePanel/Climbing/TickRow.tsx
+++ b/src/components/FeaturePanel/Climbing/TickRow.tsx
@@ -15,18 +15,14 @@ import {
   tickStyles,
 } from '../../../services/ticks';
 import { DEFAULT_DATA_FORMAT } from '../../../config';
-import { RouteDifficultyBadge } from './RouteDifficultyBadge';
 import { Tick } from './types';
-import { GradeSystem } from './utils/grades/gradeData';
 
 type TickRowProps = {
-  grade?: GradeSystem;
-  gradeSystem?: string;
   tick: Tick;
   index: number;
 };
 
-export const TickRow = ({ grade, gradeSystem, tick, index }: TickRowProps) => {
+export const TickRow = ({ tick, index }: TickRowProps) => {
   const deleteTick = (deteledIndex) => {
     onTickDelete({ osmId: tick.osmId, index: deteledIndex });
   };
@@ -41,18 +37,8 @@ export const TickRow = ({ grade, gradeSystem, tick, index }: TickRowProps) => {
 
   const formattedDate = tick.date ? format(tick.date, DEFAULT_DATA_FORMAT) : '';
 
-  const routeDifficulty = {
-    grade,
-    gradeSystem,
-  };
-
   return (
     <TableRow>
-      {grade && gradeSystem && (
-        <TableCell>
-          <RouteDifficultyBadge routeDifficulty={routeDifficulty} />
-        </TableCell>
-      )}
       <TableCell>
         <FormControl size="small">
           <Select

--- a/src/components/FeaturePanel/Climbing/utils/grades/routeGrade.ts
+++ b/src/components/FeaturePanel/Climbing/utils/grades/routeGrade.ts
@@ -53,6 +53,21 @@ export const getDifficulty = (
   return undefined;
 };
 
+export const getDifficulties = (tags: FeatureTags): RouteDifficulty[] => {
+  if (!tags) {
+    return undefined;
+  }
+
+  const gradeKeys = Object.keys(tags).filter((key) =>
+    key.startsWith('climbing:grade'),
+  );
+
+  return gradeKeys.map((gradeKey) => ({
+    grade: tags[gradeKey],
+    gradeSystem: gradeKey.split(':', 3)[2] ?? '?',
+  }));
+};
+
 export const getDifficultyColor = (routeDifficulty, theme) => {
   const DEFAULT_COLOR = '#555';
   if (!routeDifficulty) {
@@ -66,23 +81,32 @@ export const getDifficultyColor = (routeDifficulty, theme) => {
   return gradeColors[uiaaGrade]?.[mode] || DEFAULT_COLOR;
 };
 
-export const getRouteGrade = (
-  grades: Partial<{ [key in `climbing:grade:${GradeSystem}`]: string }>,
-  convertTo: GradeSystem,
-) => {
-  if (!grades) return null;
-  const availableGrades = Object.keys(grades);
-  return availableGrades.reduce((convertedGrade, availableGrade) => {
-    const convertFrom = availableGrade.split(':').pop();
-    const value = grades[availableGrade];
-    const grade = convertGrade(convertFrom, convertTo, value);
-    if (grade) return grade;
-    return convertedGrade;
-  }, null);
-};
-
 export const getGradeSystemName = (gradeSystemKey: GradeSystem) =>
   GRADE_SYSTEMS.find((item) => item.key === gradeSystemKey)?.name;
 
 export const getOsmTagFromGradeSystem = (gradeSystemKey: GradeSystem) =>
   `climbing:grade:${gradeSystemKey}`;
+
+export const findOrConvertRouteGrade = (
+  routeDifficulties: RouteDifficulty[],
+  selectedRouteSystem: string,
+) => {
+  const difficultyDiscoveredFromTag = routeDifficulties?.find(
+    (routeDifficulty) =>
+      routeDifficulty?.gradeSystem === selectedRouteSystem ||
+      !selectedRouteSystem,
+  );
+  const routeDifficulty = difficultyDiscoveredFromTag || {
+    grade:
+      convertGrade(
+        routeDifficulties?.[0]?.gradeSystem,
+        selectedRouteSystem,
+        routeDifficulties?.[0]?.grade,
+      ) ?? '?',
+    gradeSystem: selectedRouteSystem,
+  };
+  return {
+    isConverted: difficultyDiscoveredFromTag === undefined,
+    routeDifficulty,
+  };
+};

--- a/src/components/MyTicksPanel/MyTicksRow.tsx
+++ b/src/components/MyTicksPanel/MyTicksRow.tsx
@@ -3,16 +3,16 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import React from 'react';
 import { TickRowType } from '../../services/my-ticks/getMyTicks';
-import { useUserSettingsContext } from '../utils/UserSettingsContext';
 import { getUrlOsmId } from '../../services/helpers';
 import { RouteDifficultyBadge } from '../FeaturePanel/Climbing/RouteDifficultyBadge';
 import { DEFAULT_DATA_FORMAT } from '../../config';
 import { useMapStateContext } from '../utils/MapStateContext';
+import { getDifficulties } from '../FeaturePanel/Climbing/utils/grades/routeGrade';
 
 export const MyTicksRow = ({ tickRow }: { tickRow: TickRowType }) => {
-  const { userSettings } = useUserSettingsContext();
+  const routeDifficulties = getDifficulties(tickRow.tags);
   const { view } = useMapStateContext();
-  const { name, grade, style, date, apiId } = tickRow;
+  const { name, style, date, apiId } = tickRow;
 
   return (
     <TableRow>
@@ -20,12 +20,7 @@ export const MyTicksRow = ({ tickRow }: { tickRow: TickRowType }) => {
         <Link href={`/${getUrlOsmId(apiId)}#${view.join('/')}`}>{name}</Link>
       </TableCell>
       <TableCell>
-        <RouteDifficultyBadge
-          routeDifficulty={{
-            grade,
-            gradeSystem: userSettings['climbing.gradeSystem'],
-          }}
-        />
+        <RouteDifficultyBadge routeDifficulties={routeDifficulties} />
       </TableCell>
       <TableCell>{style}</TableCell>
       <TableCell>{format(date, DEFAULT_DATA_FORMAT)}</TableCell>

--- a/src/components/utils/UserSettingsContext.tsx
+++ b/src/components/utils/UserSettingsContext.tsx
@@ -13,7 +13,7 @@ type UserSettingsContextType = {
 };
 
 const initialUserSettings: UserSettingsType = {
-  'climbing.gradeSystem': 'uiaa',
+  'climbing.gradeSystem': null,
 };
 
 export const UserSettingsContext =

--- a/src/services/my-ticks/getMyTicks.ts
+++ b/src/services/my-ticks/getMyTicks.ts
@@ -3,7 +3,11 @@ import { fetchJson } from '../fetch';
 import { getOverpassUrl, overpassGeomToGeojson } from '../overpassSearch';
 import { getAllTicks } from '../ticks';
 import { Tick, TickStyle } from '../../components/FeaturePanel/Climbing/types';
-import { getRouteGrade } from '../../components/FeaturePanel/Climbing/utils/grades/routeGrade';
+import {
+  findOrConvertRouteGrade,
+  getDifficulties,
+} from '../../components/FeaturePanel/Climbing/utils/grades/routeGrade';
+import { FeatureTags } from '../types';
 
 export type TickRowType = {
   key: string;
@@ -14,6 +18,7 @@ export type TickRowType = {
   date: string;
   style: TickStyle;
   apiId: OsmApiId;
+  tags: FeatureTags;
 };
 
 export const getMyTicks = async (userSettings): Promise<TickRowType[]> => {
@@ -40,15 +45,22 @@ export const getMyTicks = async (userSettings): Promise<TickRowType[]> => {
 
   return allTicks.map((tick: Tick, index) => {
     const feature = featureMap[tick.osmId];
+    const difficulties = getDifficulties(feature?.tags);
+    const { routeDifficulty } = findOrConvertRouteGrade(
+      difficulties,
+      userSettings['climbing.gradeSystem'],
+    );
+
     return {
       key: `${tick.osmId}-${tick.date}`,
       name: feature?.tags?.name,
-      grade: getRouteGrade(feature?.tags, userSettings['climbing.gradeSystem']),
+      grade: routeDifficulty.grade,
       center: feature?.center,
       index,
       date: tick.date,
       style: tick.style,
       apiId: getApiId(tick.osmId),
+      tags: feature?.tags,
     };
   });
 };


### PR DESCRIPTION
**Allows to show original grade from grade system select:**

<img width="506" alt="image" src="https://github.com/user-attachments/assets/395734c2-3cbf-429a-a7ad-3fabec4e6067">

**Show multiple grades in the table:**

there are few UIAA routes:
<img width="403" alt="image" src="https://github.com/user-attachments/assets/f03d8d52-b88f-4f3d-8df7-204ca4ff64b5">

rest is in french:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/0021fea0-a802-4cc4-860e-23345b7b39ac">



**Show original gradings + converted value according to selected grade system:**

Zebra doesn't have YDS, so it's converted:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/429ebedd-130f-4d1b-a029-345ff6a9722f">

Zebra route has UIAA grade:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/313aa01d-824d-4184-821a-1fe89f59f9ba">

Kojot doesn't have UIAA grade:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/18312a2c-7697-4202-9f5c-b8107858b30d">

But Kojot has french:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/bd2e79dc-af91-4d1e-9dfc-f43235dac1ad">

Zebra has also french:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/e79bc4c8-fa7c-43ba-8f31-5a47617ceacf">

**We can sort it in My ticks according to visible items:**
<img width="406" alt="image" src="https://github.com/user-attachments/assets/21ca0f5a-111d-4c5c-855f-9958eba3c269">

