### PR TITLE
SearchBox: fix broken showToast in overpass search

### DIFF
--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -7,12 +7,13 @@ import { t } from '../../services/intl';
 import { fitBounds } from './utils';
 import { getSkeleton } from './onHighlightFactory';
 import { GeoJSONSource } from 'maplibre-gl';
+import { SnackbarContextType } from '../utils/SnackbarContext';
 
 const overpassOptionSelected = (
   option,
   setOverpassLoading,
   bbox,
-  showToast,
+  showToast: SnackbarContextType['showToast'],
 ) => {
   const tagsOrQuery =
     option.preset?.presetForSearch.tags ??
@@ -27,13 +28,13 @@ const overpassOptionSelected = (
     .then((geojson) => {
       const count = geojson.features.length;
       const content = t('searchbox.overpass_success', { count });
-      showToast({ content });
+      showToast(content);
       getOverpassSource()?.setData(geojson);
     })
     .catch((e) => {
       const message = `${e}`.substring(0, 100);
       const content = t('searchbox.overpass_error', { message });
-      showToast({ content, type: 'error' });
+      showToast(content, 'error');
     })
     .finally(() => {
       clearTimeout(timeout);

--- a/src/components/SearchBox/renderOptionFactory.tsx
+++ b/src/components/SearchBox/renderOptionFactory.tsx
@@ -27,8 +27,8 @@ const renderOption = (inputValue, currentTheme, mapCenter, option) => {
 };
 
 export const renderOptionFactory = (inputValue, currentTheme, mapCenter) => {
-  const Option = (props, option) => (
-    <li {...props}>
+  const Option = ({ key, ...props }, option) => (
+    <li key={key} {...props}>
       {renderOption(inputValue, currentTheme, mapCenter, option)}
     </li>
   );

--- a/src/components/utils/SnackbarContext.tsx
+++ b/src/components/utils/SnackbarContext.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 
 type Severity = 'success' | 'info' | 'warning' | 'error' | undefined;
-type SnackbarContextType = {
+export type SnackbarContextType = {
   showToast: (message: string, severity?: Severity) => void;
 };
 

--- a/src/services/overpassSearch.ts
+++ b/src/services/overpassSearch.ts
@@ -12,8 +12,7 @@ const getQueryFromTags = (tags) => {
 };
 
 const getOverpassQuery = ([a, b, c, d], query) =>
-  `[out:json][timeout:25][bbox:40.74646,-73.99195,40.75074,-73.98165];(nwr["amenity"="restaurant"]["cuisine"="vietnamese"];);out geom qt;`;
-// `[out:json][timeout:25][bbox:${[d, a, b, c]}];(${query};);out geom qt;`;
+  `[out:json][timeout:25][bbox:${[d, a, b, c]}];(${query};);out geom qt;`;
 
 export const getOverpassUrl = (fullQuery) =>
   `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(

--- a/src/services/overpassSearch.ts
+++ b/src/services/overpassSearch.ts
@@ -12,7 +12,8 @@ const getQueryFromTags = (tags) => {
 };
 
 const getOverpassQuery = ([a, b, c, d], query) =>
-  `[out:json][timeout:25][bbox:${[d, a, b, c]}];(${query};);out geom qt;`;
+  `[out:json][timeout:25][bbox:40.74646,-73.99195,40.75074,-73.98165];(nwr["amenity"="restaurant"]["cuisine"="vietnamese"];);out geom qt;`;
+// `[out:json][timeout:25][bbox:${[d, a, b, c]}];(${query};);out geom qt;`;
 
 export const getOverpassUrl = (fullQuery) =>
   `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(


### PR DESCRIPTION
Sentry Issue: [OSMAPP-ZT](https://osmapp.sentry.io/issues/5734120987/?referrer=github_integration)

```
Error: Objects are not valid as a React child (found: object with keys {content}). If you meant to render a collection of children, use an array instead.
  at o (app:///_next/static/chunks/framework-8c133e52ff743bc3.js:9:52797)
  at uu (app:///_next/static/chunks/framework-8c133e52ff743bc3.js:9:71062)
  at i (app:///_next/static/chunks/framework-8c133e52ff743bc3.js:9:121187)
  at oO (app:///_next/static/chunks/framework-8c133e52ff743bc3.js:9:99022)
  at 64448/oF/< (app:///_next/static/chunks/framework-8c133e52ff743bc3.js:9:98890)
...
(5 additional frame(s) were not displayed)
```