### PR TITLE
SearchBox: make fitBounds work on smaller screen

### DIFF
--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -56,7 +56,7 @@ const geocoderOptionSelected = (option, setFeature) => {
   addFeatureCenterToCache(getShortId(skeleton.osmMeta), skeleton.center);
 
   setFeature(skeleton);
-  fitBounds(option, true);
+  fitBounds(option);
   Router.push(`/${getUrlOsmId(skeleton.osmMeta)}`);
 };
 

--- a/src/components/SearchBox/utils.tsx
+++ b/src/components/SearchBox/utils.tsx
@@ -64,12 +64,12 @@ export const renderLoader = () => (
   </>
 );
 
-export const fitBounds = (option, panelShown = false) => {
+export const fitBounds = (option) => {
   // this condition is maybe not used in current API photon
   if (option.properties.extent) {
     const [w, s, e, n] = option.properties.extent;
     const bbox = new maplibregl.LngLatBounds([w, s], [e, n]);
-    const panelWidth = panelShown ? 410 : 0;
+    const panelWidth = window.innerWidth > 700 ? 410 : 0;
     getGlobalMap()?.fitBounds(bbox, {
       padding: { top: 5, bottom: 5, right: 5, left: panelWidth + 5 },
     });


### PR DESCRIPTION
Sentry Issue: [OSMAPP-H7](https://osmapp.sentry.io/issues/5716385613/?referrer=github_integration)

```
Map cannot fit within canvas with the given bounds, padding, and/or offset.
```