### PR TITLE
Map: add indoor tiles by indoorequal.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ yarn-error.log*
 /public/workbox-*.js
 /public/workbox-*.js.map
 /.vercel
+.env.local
 .env.sentry-build-plugin
+/public/icons-indoor

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prettify": "prettier . --write",
     "build": "next build",
     "start": "next start",
-    "dist": "next build && next export -o dist"
+    "dist": "next build && next export -o dist",
+    "postinstall": "copyfiles -u 2 node_modules/maplibre-gl-indoorequal/sprite/* public/icons-indoor/"
   },
   "husky": {
     "hooks": {
@@ -47,6 +48,7 @@
     "jss": "^10.10.0",
     "lodash": "^4.17.21",
     "maplibre-gl": "^4.7.1",
+    "maplibre-gl-indoorequal": "^1.2.0",
     "next": "^14.2.15",
     "next-codegrid": "^1.0.3",
     "next-cookies": "^2.0.3",
@@ -69,6 +71,7 @@
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/typescript-estree": "^8.8.1",
     "babel-eslint": "^10.1.0",
+    "copyfiles": "^2.4.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.15",
     "eslint-config-prettier": "^9.1.0",

--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -141,7 +141,7 @@ export const osmappLayers: Layers = {
   ...(process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL
     ? {
         indoor: {
-          name: t('layers.indoor'),
+          name: `${t('layers.indoor')} (beta)`,
           type: 'overlay',
           Icon: MapsHomeWorkIcon,
           attribution: [

--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -11,6 +11,7 @@ import { isBrowser } from '../helpers';
 import Maki from '../utils/Maki';
 import { useUserThemeContext } from '../../helpers/theme';
 import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
+import MapsHomeWorkIcon from '@mui/icons-material/MapsHomeWork';
 
 interface Layers {
   [key: string]: Layer;
@@ -137,6 +138,20 @@ export const osmappLayers: Layers = {
     darkUrl: `https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}${retina}.png?apikey=${process.env.NEXT_PUBLIC_API_KEY_THUNDERFOREST}`,
     Icon: DirectionsBusIcon,
   },
+  ...(process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL
+    ? {
+        indoor: {
+          name: t('layers.indoor'),
+          type: 'overlay',
+          Icon: MapsHomeWorkIcon,
+          attribution: [
+            '&copy; <a href="https://indoorequal.com/">indoor=</a>',
+            'osm',
+          ],
+          minzoom: 16,
+        },
+      }
+    : {}),
   snow: {
     name: t('layers.snow'),
     type: 'overlay',
@@ -149,7 +164,7 @@ export const osmappLayers: Layers = {
   },
   climbing: {
     name: t('layers.climbing'),
-    type: 'overlayClimbing',
+    type: 'overlay',
     Icon: ClimbingIcon,
     attribution: ['osm'],
   },

--- a/src/components/Map/MapFooter/AttributionLinks.tsx
+++ b/src/components/Map/MapFooter/AttributionLinks.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, useMediaQuery } from '@mui/material';
 import React from 'react';
 import uniq from 'lodash/uniq';
-import { Layer, useMapStateContext } from '../../utils/MapStateContext';
+import { Layer, useMapStateContext, View } from '../../utils/MapStateContext';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { Translation } from '../../../services/intl';
 import { usePersistedState } from '../../utils/usePersistedState';
@@ -37,13 +37,20 @@ const OsmAttribution = () => {
   );
 };
 
+const minZoomSatisfied = (osmappLayer: Layer, view: View) =>
+  !osmappLayer.minzoom || parseFloat(view[0]) >= osmappLayer.minzoom;
+
 export const AttributionLinks = () => {
-  const { activeLayers, userLayers } = useMapStateContext();
+  const { activeLayers, userLayers, view } = useMapStateContext();
 
   const attributions = uniq(
     activeLayers.flatMap((layerUrl) => {
       const osmappLayer = osmappLayers[layerUrl];
-      if (osmappLayer) return osmappLayer.attribution;
+      if (osmappLayer) {
+        return minZoomSatisfied(osmappLayer, view)
+          ? osmappLayer.attribution
+          : [];
+      }
 
       const userLayer = userLayers.find(({ url }) => url === layerUrl);
       return userLayer?.attribution || decodeURI(new URL(layerUrl)?.hostname);

--- a/src/components/Map/MapFooter/AttributionLinks.tsx
+++ b/src/components/Map/MapFooter/AttributionLinks.tsx
@@ -44,17 +44,19 @@ export const AttributionLinks = () => {
   const { activeLayers, userLayers, view } = useMapStateContext();
 
   const attributions = uniq(
-    activeLayers.flatMap((layerUrl) => {
-      const osmappLayer = osmappLayers[layerUrl];
-      if (osmappLayer) {
-        return minZoomSatisfied(osmappLayer, view)
-          ? osmappLayer.attribution
-          : [];
-      }
+    activeLayers
+      .flatMap((layerUrl) => {
+        const osmappLayer = osmappLayers[layerUrl];
+        if (osmappLayer) {
+          return minZoomSatisfied(osmappLayer, view)
+            ? osmappLayer.attribution
+            : [];
+        }
 
-      const userLayer = userLayers.find(({ url }) => url === layerUrl);
-      return userLayer?.attribution || decodeURI(new URL(layerUrl)?.hostname);
-    }),
+        const userLayer = userLayers.find(({ url }) => url === layerUrl);
+        return userLayer?.attribution || decodeURI(new URL(layerUrl)?.hostname);
+      })
+      .filter(Boolean),
   );
 
   const nodes: React.ReactNode[] = attributions.map((attribution) => {

--- a/src/components/Map/behaviour/indoor.tsx
+++ b/src/components/Map/behaviour/indoor.tsx
@@ -1,15 +1,23 @@
-import maplibregl from 'maplibre-gl';
 import IndoorEqual from 'maplibre-gl-indoorequal';
 import 'maplibre-gl-indoorequal/maplibre-gl-indoorequal.css';
+import { getGlobalMap, mapIdlePromise } from '../../../services/mapStorage';
+
+const timeout = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 let indoorEqual: IndoorEqual;
 
-export const addIndoorEqual = (map: maplibregl.Map) => {
+export const addIndoorEqual = async () => {
   if (!process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL) {
     throw new Error('Missing API key for IndoorEqual');
   }
 
-  console.log('Adding IndoorEqual');
+  // TODO this is brittle, we can probably get rid of the library and implement indoor ourselves
+  // TODO 2: doesnt work in hot reload mode (localhost)
+  await timeout(600);
+  const map = await mapIdlePromise;
+
+  console.log('Adding IndoorEqual'); // eslint-disable-line no-console
   indoorEqual = new IndoorEqual(map, {
     apiKey: process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL,
     heatmap: false,
@@ -19,9 +27,10 @@ export const addIndoorEqual = (map: maplibregl.Map) => {
   map.addControl(indoorEqual);
 };
 
-export const removeIndoorEqual = (map: maplibregl.Map) => {
+export const removeIndoorEqual = () => {
   if (indoorEqual && indoorEqual._control) {
-    console.log('Removing IndoorEquall', map, indoorEqual);
+    const map = getGlobalMap();
+    console.log('Removing IndoorEquall', map, indoorEqual); // eslint-disable-line no-console
     map.removeControl(indoorEqual);
     indoorEqual = null;
   }

--- a/src/components/Map/behaviour/indoor.tsx
+++ b/src/components/Map/behaviour/indoor.tsx
@@ -1,0 +1,28 @@
+import maplibregl from 'maplibre-gl';
+import IndoorEqual from 'maplibre-gl-indoorequal';
+import 'maplibre-gl-indoorequal/maplibre-gl-indoorequal.css';
+
+let indoorEqual: IndoorEqual;
+
+export const addIndoorEqual = (map: maplibregl.Map) => {
+  if (!process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL) {
+    throw new Error('Missing API key for IndoorEqual');
+  }
+
+  console.log('Adding IndoorEqual');
+  indoorEqual = new IndoorEqual(map, {
+    apiKey: process.env.NEXT_PUBLIC_API_KEY_INDOOREQUAL,
+    heatmap: false,
+  });
+  indoorEqual.loadSprite('/icons-indoor/sprite/indoorequal');
+
+  map.addControl(indoorEqual);
+};
+
+export const removeIndoorEqual = (map: maplibregl.Map) => {
+  if (indoorEqual && indoorEqual._control) {
+    console.log('Removing IndoorEquall', map, indoorEqual);
+    map.removeControl(indoorEqual);
+    indoorEqual = null;
+  }
+};

--- a/src/components/Map/behaviour/useOnMapClicked.tsx
+++ b/src/components/Map/behaviour/useOnMapClicked.tsx
@@ -65,7 +65,7 @@ export const getSkeleton = (
   feature /* TODO MapGeoJSONFeature*/,
   clickCoords: LonLat,
 ) => {
-    const { isOsmObject, osmMeta } = getId(feature);
+  const { isOsmObject, osmMeta } = getId(feature);
 
   const nameTags = pickBy(feature.properties, (_, key) =>
     key.startsWith('name'),

--- a/src/components/Map/behaviour/useOnMapClicked.tsx
+++ b/src/components/Map/behaviour/useOnMapClicked.tsx
@@ -10,7 +10,7 @@ import {
 import { getCenter } from '../../../services/getCenter';
 import { convertMapIdToOsmId, getIsOsmObject } from '../helpers';
 import { maptilerFix } from './maptilerFix';
-import { Feature, LonLat } from '../../../services/types';
+import { Feature, LonLat, OsmId } from '../../../services/types';
 import { createCoordsFeature, pushFeatureToRouter } from './utils';
 import { SetFeature } from '../../utils/FeatureContext';
 import maplibregl, { Map, MapGeoJSONFeature } from 'maplibre-gl';
@@ -18,6 +18,27 @@ import type { MapClickOverrideRef } from '../../utils/MapStateContext';
 
 const isSameOsmId = (feature: Feature, skeleton: Feature) =>
   feature && skeleton && getOsmappLink(feature) === getOsmappLink(skeleton);
+
+const getIndoorEqualId = (feature: Feature): OsmId | null => {
+  if (feature.layer.id?.startsWith('indoor-') && feature.properties.id) {
+    const [type, id] = `${feature.properties.id}`.split(':');
+    return { type, id: parseInt(id, 10) } as OsmId;
+  }
+  return null;
+};
+
+const getId = (feature) => {
+  const indoorId = getIndoorEqualId(feature);
+  if (indoorId) {
+    return { isOsmObject: true, osmMeta: indoorId };
+  }
+
+  const isOsmObject = getIsOsmObject(feature);
+  const osmMeta = isOsmObject
+    ? convertMapIdToOsmId(feature)
+    : { type: feature.layer.id, id: feature.id };
+  return { isOsmObject, osmMeta };
+};
 
 const getOnlyLabel = (
   features: MapGeoJSONFeature[],
@@ -44,10 +65,7 @@ export const getSkeleton = (
   feature /* TODO MapGeoJSONFeature*/,
   clickCoords: LonLat,
 ) => {
-  const isOsmObject = getIsOsmObject(feature);
-  const osmMeta = isOsmObject
-    ? convertMapIdToOsmId(feature)
-    : { type: feature.layer.id, id: feature.id };
+    const { isOsmObject, osmMeta } = getId(feature);
 
   const nameTags = pickBy(feature.properties, (_, key) =>
     key.startsWith('name'),

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -118,7 +118,7 @@ export const useUpdateStyle = createMapEffectHook(
     const userLayerMaxZoom = userLayers.find(({ url }) => url === key)?.maxzoom;
     map.setMaxZoom(osmappLayerMaxZoom ?? userLayerMaxZoom ?? 24); // TODO find a way how to zoom bing further (now it stops at 19)
 
-    removeIndoorEqual(map);
+    removeIndoorEqual();
 
     const osmappLayerMinZoom = osmappLayers[key]?.minzoom;
     const userLayerMinZoom = userLayers.find(({ url }) => url === key)?.minzoom;
@@ -135,8 +135,8 @@ export const useUpdateStyle = createMapEffectHook(
 
     setUpHover(map, layersWithOsmId(style));
 
-    if (overlays.includes('indoor')) {
-      addIndoorEqual(map);
+    if (mapLoaded && overlays.includes('indoor')) {
+      addIndoorEqual();
     }
   },
 );

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -21,6 +21,7 @@ import { Layer } from '../../utils/MapStateContext';
 import { setUpHover } from './featureHover';
 import { layersWithOsmId } from '../helpers';
 import { Theme } from '../../../helpers/theme';
+import { addIndoorEqual, removeIndoorEqual } from './indoor';
 
 const ofrBasicStyle = {
   ...basicStyle,
@@ -84,17 +85,22 @@ const addOverlaysToStyle = (
   overlays: string[],
   currentTheme: Theme,
 ) => {
-  overlays.forEach((overlayKey: string) => {
-    const overlay = osmappLayers[overlayKey];
+  overlays
+    .filter((key: string) => osmappLayers[key]?.type === 'overlay')
+    .forEach((key: string) => {
+      switch (key) {
+        case 'climbing':
+          addClimbingOverlay(style, map);
+          break;
 
-    if (overlay?.type === 'overlay') {
-      addRasterOverlay(style, overlayKey, currentTheme);
-    }
+        case 'indoor':
+          break; // indoorEqual must be added after setStyle()
 
-    if (overlay?.type === 'overlayClimbing') {
-      addClimbingOverlay(style, map);
-    }
-  });
+        default:
+          addRasterOverlay(style, key, currentTheme);
+          break;
+      }
+    });
 };
 
 export const useUpdateStyle = createMapEffectHook(
@@ -112,6 +118,8 @@ export const useUpdateStyle = createMapEffectHook(
     const userLayerMaxZoom = userLayers.find(({ url }) => url === key)?.maxzoom;
     map.setMaxZoom(osmappLayerMaxZoom ?? userLayerMaxZoom ?? 24); // TODO find a way how to zoom bing further (now it stops at 19)
 
+    removeIndoorEqual(map);
+
     const osmappLayerMinZoom = osmappLayers[key]?.minzoom;
     const userLayerMinZoom = userLayers.find(({ url }) => url === key)?.minzoom;
     map.setMinZoom(osmappLayerMinZoom ?? userLayerMinZoom ?? 0);
@@ -126,5 +134,9 @@ export const useUpdateStyle = createMapEffectHook(
     map.addControl(languageControl);
 
     setUpHover(map, layersWithOsmId(style));
+
+    if (overlays.includes('indoor')) {
+      addIndoorEqual(map);
+    }
   },
 );

--- a/src/components/Map/useAddTopRightControls.tsx
+++ b/src/components/Map/useAddTopRightControls.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import maplibregl from 'maplibre-gl';
 import { getGlobalMap } from '../../services/mapStorage';
 import { t } from '../../services/intl';
+import { isMobileDevice } from '../helpers';
 
 const navigation = {
   mobile: new maplibregl.NavigationControl({
@@ -42,7 +43,8 @@ const geolocation = new maplibregl.GeolocateControl({
 export const useAddTopRightControls = (map: any, mobileMode: boolean) => {
   useEffect(() => {
     if (map) {
-      const navControl = mobileMode ? navigation.mobile : navigation.desktop;
+      const navControl =
+        isMobileDevice() || mobileMode ? navigation.mobile : navigation.desktop;
 
       map.addControl(navControl);
       map.addControl(geolocation);

--- a/src/components/utils/MapStateContext.tsx
+++ b/src/components/utils/MapStateContext.tsx
@@ -19,7 +19,7 @@ export type LayerIcon = React.ComponentType<{ fontSize: 'small' }>;
 export type Bbox = [number, number, number, number];
 
 export interface Layer {
-  type: 'basemap' | 'overlay' | 'user' | 'spacer' | 'overlayClimbing';
+  type: 'basemap' | 'overlay' | 'user' | 'spacer';
   name?: string;
   description?: string;
   url?: string;
@@ -28,6 +28,7 @@ export interface Layer {
   Icon?: LayerIcon;
   attribution?: string[]; // missing in spacer TODO refactor ugly
   maxzoom?: number;
+  minzoom?: number;
   minzoom?: number;
   bboxes?: Bbox[];
 }
@@ -60,7 +61,9 @@ export const MapStateContext = createContext<MapStateContextType>(undefined);
 
 const useActiveLayersState = () => {
   const isClimbing = PROJECT_ID === 'openclimbing';
-  const initLayers = isClimbing ? ['outdoor', 'climbing'] : [DEFAULT_MAP];
+  const initLayers = isClimbing
+    ? ['outdoor', 'climbing']
+    : [DEFAULT_MAP, 'indoor'];
   return usePersistedState('activeLayers', initLayers);
 };
 

--- a/src/components/utils/MapStateContext.tsx
+++ b/src/components/utils/MapStateContext.tsx
@@ -29,7 +29,6 @@ export interface Layer {
   attribution?: string[]; // missing in spacer TODO refactor ugly
   maxzoom?: number;
   minzoom?: number;
-  minzoom?: number;
   bboxes?: Bbox[];
 }
 

--- a/src/helpers/GlobalStyle.tsx
+++ b/src/helpers/GlobalStyle.tsx
@@ -78,11 +78,19 @@ const globalStyle = (theme: Theme) => css`
     }
 
     @media ${isMobileMode} {
-      border-radius: 50% !important;
+      border-radius: 22px !important;
 
       button {
         width: 44px !important;
         height: 44px !important;
+
+        // indoor level control has multiple buttions
+        &:first-of-type {
+          border-radius: 22px 22px 0 0 !important;
+        }
+        &:last-of-type {
+          border-radius: 0 0 22px 22px !important;
+        }
       }
     }
     button + button {

--- a/src/helpers/GlobalStyle.tsx
+++ b/src/helpers/GlobalStyle.tsx
@@ -72,6 +72,11 @@ const globalStyle = (theme: Theme) => css`
     )} !important;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
+    max-height: calc(
+      100vh - 300px
+    ); // = top right controls + right bottom + safety margin (TEST also in landscape)
+    overflow-x: hidden;
+    overflow-y: auto; // especially for indoor selector at the Louvre #18/48.8610/2.3389 :)
 
     .maplibregl-ctrl-icon {
       filter: ${theme.palette.invertFilter};

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -213,6 +213,7 @@ export default {
   'layers.bike': 'Cyklo',
   'layers.transport': 'Dopravní',
   'layers.climbing': 'Sportovní lezení',
+  'layers.indoor': 'Vnitřky budov',
 
   'climbingareas.link': 'Seznam všech lezeckých oblastí',
   'climbingareas.title': 'Lezecké oblasti',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -268,6 +268,7 @@ export default {
   'layers.bike': 'Bike',
   'layers.transport': 'Transport',
   'layers.climbing': 'Climbing',
+  'layers.indoor': 'Indoor',
 
   'climbingpanel.create_climbing_route': 'Draw new route in schema',
   'climbingpanel.edit_climbing_route': 'Edit route in schema',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,6 +2458,11 @@ array-buffer-byte-length@^1.0.1:
     call-bind "^1.0.5"
     is-array-buffer "^3.0.4"
 
+array-equal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.2.tgz#a8572e64e822358271250b9156d20d96ef5dec04"
+  integrity sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==
+
 array-includes@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
@@ -2931,6 +2936,15 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -3035,6 +3049,19 @@ cookie@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+copyfiles@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.1.tgz#d2dcff60aaad1015f09d0b66e7f0f1c5cd3c5da5"
+  integrity sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^1.0.4"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    untildify "^4.0.0"
+    yargs "^16.1.0"
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3168,6 +3195,11 @@ date-fns@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
+debounce@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-2.1.1.tgz#8ae1d5233ec5abd1c8edf3e994a9286a73d0f4ff"
+  integrity sha512-+xRWxgel9LgTC4PwKlm7TJUK6B6qsEK77NaiNvXmeQ7Y3e6OVVsBC4a9BSptS/mAYceyAz37Oa8JTTuPRft7uQ==
 
 debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@~4.3.6:
   version "4.3.6"
@@ -4258,7 +4290,7 @@ glob@^10.4.1:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^7.1.3:
+glob@^7.0.5, glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4587,7 +4619,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5853,6 +5885,14 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+maplibre-gl-indoorequal@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl-indoorequal/-/maplibre-gl-indoorequal-1.2.0.tgz#a79380e901a69ec1fbf2657dc160c4f34331482d"
+  integrity sha512-SKbiwZSY2Ub/pyv1jjAPZq/FAmF5gxe45Zl7btBRXNUUZDtXBtGlxABdJ/il9E8sY4ORty2Gnj3idmOmVudFaA==
+  dependencies:
+    array-equal "^1.0.2"
+    debounce "^2.0.0"
+
 maplibre-gl@^4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-4.7.1.tgz#06a524438ee2aafbe8bcd91002a4e01468ea5486"
@@ -5948,7 +5988,7 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -6004,7 +6044,7 @@ minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -6129,6 +6169,14 @@ node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
+
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  integrity sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -6843,7 +6891,7 @@ react@^18.3.1:
   dependencies:
     loose-envify "^1.1.0"
 
-readable-stream@^2.0.2:
+readable-stream@^2.0.2, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -6865,7 +6913,7 @@ readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@~1.0.17, readable-stream@~1.0.27-1:
+readable-stream@~1.0.17, readable-stream@~1.0.27-1, readable-stream@~1.0.31:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==
@@ -7382,8 +7430,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7527,8 +7583,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7541,6 +7596,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -7679,6 +7741,14 @@ theming@^3.3.0:
     prop-types "^15.5.8"
     react-display-name "^0.2.4"
     tiny-warning "^1.0.2"
+
+through2@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 through2@~0.4.1:
   version "0.4.2"
@@ -7941,6 +8011,11 @@ unplugin@1.0.1:
     webpack-sources "^3.2.3"
     webpack-virtual-modules "^0.5.0"
 
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+
 update-browserslist-db@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
@@ -8157,7 +8232,16 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0, "wrap-ansi@npm:wrap-ansi@^7":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0, "wrap-ansi@npm:wrap-ansi@^7":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8207,7 +8291,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
@@ -8244,10 +8328,28 @@ yaml@~2.5.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.0.tgz#c6165a721cf8000e91c36490a41d7be25176cf5d"
   integrity sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.1.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.3.1:
   version "17.7.2"


### PR DESCRIPTION
DEMO: https://osmapp-git-indoor-osm-app-team.vercel.app/


Proof of concept for Indoor tiles 🎉 - aka #225

Thanks [contrapunctus](https://www.openstreetmap.org/user/contrapunctus) for heads up about indoorequal service. And @francois2metz for creating it ofc! 😃👍 

More links:
- https://github.com/indoorequal/maplibre-gl-indoorequal
- https://indoorequal.org/#map=18.28/50.083387/14.433989&level=-3
- https://status.indoorequal.org/


TODO

- [x] attribution
- [x] indoor disappears when switching layers
- [x] make indoor default (how?) 🤔 
- [x] tilting: _When I tried to tilt the map (via 2 finger swipe), I managed to break the indoor rendering. Rooms and corridors were no longer rendered, even though the Indoor layer was active. Once I turned the layer off and on again, the rooms and corridors were displayed once more, and tilting the map now tilted the indoor data too - pretty cool! I can reproduce this consistently in Fennec F-Droid 129.0.2 (Android) and Firefox 131 (desktop). I've attached the console output from the latter._
- [x] the Louvre https://osmapp-git-indoor-osm-app-team.vercel.app/#18.45/48.8610/2.3389 _Here, OsmAPP's level selector doesn't do too well on phones - it goes off-screen at the bottom. Could users scroll the level selector up and down? IndoorEqual does this on desktop, but on phones the pull-down motion conflicts with the pull-to-refresh gesture._
- [ ] maybe: consider if we can stack the floor to their relative height! _Speaking of tilting - currently, all indoor data is currently shown as if it was on the ground floor of the building. Would it be very difficult to show the data higher/lower, based on the value of level=* + the building height? (Building heights are not commonly tagged in OSM, so renderers usually assume a height of 3 meters per building level.)_
