### PR TITLE
general: Update Dockerfile build node to version 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:18-alpine AS base
+FROM node:20 AS base
 
 # Install dependencies only when needed
 FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager


### PR DESCRIPTION
Project was updated to node 20, this makes the `Dockerimage` compatible

* we switch the image to a Debian based one, because some node binaries are not available directly for alpine and would need to be built

The docker image is currently not automatically build in this repo, we might add an action like this:

https://github.com/OpenPlaceGuide/osmapp/blob/opg-master/.github/workflows/docker-image.yml

But we can also leave it semi-supported in here and I will take care of it, when I spot problems.