### PR TITLE
SearchBox: Add support for openstreetmap ids

### DIFF
--- a/src/components/Directions/DirectionsAutocomplete.tsx
+++ b/src/components/Directions/DirectionsAutocomplete.tsx
@@ -73,8 +73,13 @@ const useOptions = (inputValue: string, setOptions) => {
         return;
       }
 
-      const geocoderOptions = await fetchGeocoderOptions({ inputValue, view });
-      setOptions(geocoderOptions);
+      await fetchGeocoderOptions({
+        inputValue,
+        view,
+        before: [],
+        after: [],
+        setOptions,
+      });
     })();
   }, [inputValue, stars]); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/src/components/Directions/DirectionsAutocomplete.tsx
+++ b/src/components/Directions/DirectionsAutocomplete.tsx
@@ -73,7 +73,8 @@ const useOptions = (inputValue: string, setOptions) => {
         return;
       }
 
-      await fetchGeocoderOptions(inputValue, view, setOptions, [], []);
+      const geocoderOptions = await fetchGeocoderOptions({ inputValue, view });
+      setOptions(geocoderOptions);
     })();
   }, [inputValue, stars]); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -10,8 +10,10 @@ import { onHighlightFactory } from './onHighlightFactory';
 import { useMapCenter } from './utils';
 import { useSnackbar } from '../utils/SnackbarContext';
 import { useKeyDown } from '../../helpers/hooks';
-import { Option } from './types';
 import { getOptionLabel } from './getOptionLabel';
+import { useGetOptions } from './useGetOptions';
+import { useInputValueState } from './options/geocoder';
+import { useRouter } from 'next/router';
 
 const SearchBoxInput = ({ params, setInputValue, autocompleteRef }) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -48,17 +50,11 @@ const SearchBoxInput = ({ params, setInputValue, autocompleteRef }) => {
 };
 
 type AutocompleteInputProps = {
-  inputValue: string;
-  setInputValue: (value: string) => void;
-  options: Option[];
   autocompleteRef: React.MutableRefObject<undefined>;
   setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
-  inputValue,
-  setInputValue,
-  options,
   autocompleteRef,
   setOverpassLoading,
 }) => {
@@ -67,6 +63,10 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const { showToast } = useSnackbar();
   const mapCenter = useMapCenter();
   const { currentTheme } = useUserThemeContext();
+  const { inputValue, setInputValue } = useInputValueState();
+  const options = useGetOptions(inputValue);
+  const router = useRouter();
+
   return (
     <Autocomplete
       inputValue={inputValue}
@@ -76,13 +76,14 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       filterOptions={(o) => o}
       getOptionLabel={getOptionLabel}
       getOptionKey={(option) => JSON.stringify(option)}
-      onChange={onSelectedFactory(
+      onChange={onSelectedFactory({
         setFeature,
         setPreview,
         bbox,
         showToast,
         setOverpassLoading,
-      )}
+        router,
+      })}
       onHighlightChange={onHighlightFactory(setPreview)}
       getOptionDisabled={(o) => o.type === 'loader'}
       autoComplete

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -8,8 +8,6 @@ import { AutocompleteInput } from './AutocompleteInput';
 import { t } from '../../services/intl';
 import { ClosePanelButton } from '../utils/ClosePanelButton';
 import { useMobileMode } from '../helpers';
-import { useInputValueState } from './options/geocoder';
-import { useGetOptions } from './useGetOptions';
 import { HamburgerMenu } from '../Map/TopMenu/HamburgerMenu';
 import { UserMenu } from '../Map/TopMenu/UserMenu';
 import { DirectionsButton } from '../Directions/DirectionsButton';
@@ -43,12 +41,9 @@ const useOnClosePanel = () => {
 const SearchBox = () => {
   const isMobileMode = useMobileMode();
   const { featureShown } = useFeatureContext();
-  const { inputValue, setInputValue } = useInputValueState();
   const [overpassLoading, setOverpassLoading] = useState(false);
   const autocompleteRef = useRef();
   const onClosePanel = useOnClosePanel();
-
-  const options = useGetOptions(inputValue);
 
   return (
     <TopPanel $isMobileMode={isMobileMode}>
@@ -58,9 +53,6 @@ const SearchBox = () => {
         </SearchIconButton>
 
         <AutocompleteInput
-          inputValue={inputValue}
-          setInputValue={setInputValue}
-          options={options}
           autocompleteRef={autocompleteRef}
           setOverpassLoading={setOverpassLoading}
         />

--- a/src/components/SearchBox/getOptionLabel.tsx
+++ b/src/components/SearchBox/getOptionLabel.tsx
@@ -16,6 +16,8 @@ export const getOptionLabel = (option: Option | undefined) => {
     (option.type === 'geocoder' &&
       option.geocoder.properties &&
       buildPhotonAddress(option.geocoder.properties)) ||
+    (option.type === 'osm' &&
+      `OpenStreetMap ${option.osm.type}/${option.osm.id}`) ||
     ''
   );
 };

--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -1,4 +1,4 @@
-import Router from 'next/router';
+import Router, { NextRouter } from 'next/router';
 import { getApiId, getShortId, getUrlOsmId } from '../../services/helpers';
 import { addFeatureCenterToCache } from '../../services/osmApi';
 import { getOverpassSource } from '../../services/mapStorage';
@@ -17,6 +17,7 @@ import {
   PresetOption,
   StarOption,
 } from './types';
+import { osmOptionSelected } from './options/openstreetmap';
 
 const overpassOptionSelected = (
   option: OverpassOption | PresetOption,
@@ -79,14 +80,24 @@ const geocoderOptionSelected = (
   Router.push(`/${getUrlOsmId(skeleton.osmMeta)}`);
 };
 
+type OnSelectedFactoryProps = {
+  setFeature: SetFeature;
+  setPreview: SetFeature;
+  bbox: Bbox;
+  showToast: ShowToast;
+  setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  router: NextRouter;
+};
+
 export const onSelectedFactory =
-  (
-    setFeature: SetFeature,
-    setPreview: SetFeature,
-    bbox: Bbox,
-    showToast: ShowToast,
-    setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>,
-  ) =>
+  ({
+    setFeature,
+    setPreview,
+    bbox,
+    showToast,
+    setOverpassLoading,
+    router,
+  }: OnSelectedFactoryProps) =>
   (_: never, option: Option) => {
     setPreview(null); // it could be stuck from onHighlight
 
@@ -100,5 +111,9 @@ export const onSelectedFactory =
         break;
       case 'geocoder':
         geocoderOptionSelected(option, setFeature);
+        break;
+      case 'osm':
+        osmOptionSelected(option, router);
+        break;
     }
   };

--- a/src/components/SearchBox/options/openstreetmap.tsx
+++ b/src/components/SearchBox/options/openstreetmap.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { OsmOption } from '../types';
+import MapIcon from '@mui/icons-material/Map';
+import { Grid, Typography } from '@mui/material';
+import { IconPart } from '../utils';
+import { NextRouter } from 'next/router';
+
+const parseType = (rawType: string) => {
+  if (rawType === 'node' || rawType === 'n') {
+    return 'node';
+  }
+  if (rawType === 'way' || rawType === 'w') {
+    return 'way';
+  }
+  if (rawType === 'relation' || rawType === 'rel' || rawType === 'r') {
+    return 'relation';
+  }
+};
+
+const osmIdRegex = /\d{1,19}/;
+
+const getOsmIdOptions = (id: number): OsmOption[] => {
+  const types = ['node', 'way', 'relation'] as const;
+  return types.map((type) => ({
+    type: 'osm',
+    osm: { type, id },
+  }));
+};
+
+export const getOsmOptions = (inputValue: string): OsmOption[] => {
+  const splitted = inputValue.split(/[/\s,]/);
+
+  if (splitted.length === 1 && splitted[0].match(osmIdRegex)) {
+    return getOsmIdOptions(parseInt(splitted[0]));
+  }
+
+  const type = parseType(splitted[0]);
+  const idString = splitted[1];
+  const id = parseInt(idString);
+
+  if (!type || (!idString.match(osmIdRegex) && !Number.isNaN(id))) {
+    return [];
+  }
+
+  return [
+    {
+      type: 'osm',
+      osm: { type, id },
+    },
+  ];
+};
+
+export const renderOsm = ({ osm }: OsmOption) => (
+  <>
+    <IconPart>
+      <MapIcon />
+    </IconPart>
+    <Grid item xs>
+      <span style={{ fontWeight: 700 }}>
+        OpenStreetMap {osm.type}/{osm.id}
+      </span>
+      <Typography variant="body2" color="textSecondary">
+        OpenStreetMap Object
+      </Typography>
+    </Grid>
+  </>
+);
+
+export const osmOptionSelected = ({ osm }: OsmOption, router: NextRouter) => {
+  router.push(`${osm.type}/${osm.id}`);
+};

--- a/src/components/SearchBox/renderOptionFactory.tsx
+++ b/src/components/SearchBox/renderOptionFactory.tsx
@@ -7,6 +7,7 @@ import { renderGeocoder } from './options/geocoder';
 import { Option } from './types';
 import { Theme } from '../../helpers/theme';
 import { LonLat } from '../../services/types';
+import { renderOsm } from './options/openstreetmap';
 
 const renderOption = (
   inputValue: string,
@@ -25,6 +26,8 @@ const renderOption = (
       return renderPreset(option, inputValue);
     case 'geocoder':
       return renderGeocoder(option, currentTheme, inputValue, mapCenter);
+    case 'osm':
+      return renderOsm(option);
   }
 };
 

--- a/src/components/SearchBox/types.ts
+++ b/src/components/SearchBox/types.ts
@@ -70,6 +70,14 @@ export type CoordsOption = GenericOption<
   { center: LonLat; label: string }
 >;
 
+export type OsmOption = GenericOption<
+  'osm',
+  {
+    type: 'node' | 'way' | 'relation';
+    id: number;
+  }
+>;
+
 /*
  * A option for the searchbox
  */
@@ -79,4 +87,5 @@ export type Option =
   | OverpassOption
   | PresetOption
   | LoaderOption
-  | GeocoderOption;
+  | GeocoderOption
+  | OsmOption;

--- a/src/components/SearchBox/types.ts
+++ b/src/components/SearchBox/types.ts
@@ -73,7 +73,7 @@ export type CoordsOption = GenericOption<
 export type OsmOption = GenericOption<
   'osm',
   {
-    type: 'node' | 'way' | 'relation';
+    type: string;
     id: number;
   }
 >;

--- a/src/components/SearchBox/useGetOptions.tsx
+++ b/src/components/SearchBox/useGetOptions.tsx
@@ -10,6 +10,7 @@ import { getStarsOptions } from './options/stars';
 import { getOverpassOptions } from './options/overpass';
 import { getPresetOptions } from './options/preset';
 import { Option } from './types';
+import { getOsmOptions } from './options/openstreetmap';
 
 export const useGetOptions = (inputValue: string) => {
   const { view } = useMapStateContext();
@@ -27,6 +28,12 @@ export const useGetOptions = (inputValue: string) => {
         return;
       }
 
+      const osmOptions = getOsmOptions(inputValue);
+      if (osmOptions.length) {
+        setOptions(osmOptions);
+        return;
+      }
+
       const overpassOptions = getOverpassOptions(inputValue);
       if (overpassOptions.length) {
         setOptions(overpassOptions);
@@ -37,13 +44,11 @@ export const useGetOptions = (inputValue: string) => {
       const beforeWithStars = [...starOptions, ...before];
       setOptions([...beforeWithStars, { type: 'loader' }]);
 
-      fetchGeocoderOptions(
-        inputValue,
-        view,
-        setOptions, // TODO refactor to await options instead of setOptions
-        beforeWithStars,
-        after,
-      );
+      const geocoderOptions = await fetchGeocoderOptions({ inputValue, view });
+
+      if (geocoderOptions) {
+        setOptions([...beforeWithStars, ...geocoderOptions, ...after]);
+      }
     })();
   }, [inputValue, stars]); // eslint-disable-line react-hooks/exhaustive-deps
   return options;

--- a/src/components/SearchBox/useGetOptions.tsx
+++ b/src/components/SearchBox/useGetOptions.tsx
@@ -44,11 +44,13 @@ export const useGetOptions = (inputValue: string) => {
       const beforeWithStars = [...starOptions, ...before];
       setOptions([...beforeWithStars, { type: 'loader' }]);
 
-      const geocoderOptions = await fetchGeocoderOptions({ inputValue, view });
-
-      if (geocoderOptions) {
-        setOptions([...beforeWithStars, ...geocoderOptions, ...after]);
-      }
+      fetchGeocoderOptions({
+        inputValue,
+        view,
+        setOptions, // TODO refactor to await options instead of setOptions
+        before: beforeWithStars,
+        after,
+      });
     })();
   }, [inputValue, stars]); // eslint-disable-line react-hooks/exhaustive-deps
   return options;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -11,3 +11,12 @@ export const encodeUrl = (
     const value = values[i];
     return result + string + (value ? encodeURIComponent(value) : '');
   }, '');
+
+export const isUrl = (url: string) => {
+  try {
+    new URL(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
### Description

It is now possible to search for OpenStreetMap ids in the following formats:
- type + id: `node/660921`, `way 10568134` or `relation,406091`
- url: `http://localhost:3000/relation/406091#17.00/59.9722/10.7203` or `https://www.openstreetmap.org/node/660921`
