### PR TITLE
FeaturePanel: Reliable public transport cateegories

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransport.tsx
@@ -53,7 +53,7 @@ const PublicTransportInner = () => {
   const { feature } = useFeatureContext();
   const { id, type } = feature.osmMeta;
 
-  const { data, status } = useQuery('publictransport', () =>
+  const { data, status } = useQuery([id, type], () =>
     requestLines(type, Number(id)),
   );
 

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -29,9 +29,24 @@ const getTagValue = (
   }
   const altElement = routes.find(({ tags }) => tags[key]);
   if (altElement) {
-    return altElement[key];
+    return altElement.tags[key];
   }
   return undefined;
+};
+
+const getService = (tags: Record<string, string>, routes: WithTags[]) => {
+  const getVal = (key: string) => getTagValue(key, tags, routes);
+  const serviceTagValue = getTagValue('service', tags, routes);
+  const serviceTag =
+    serviceTagValue === 'highspeed' ? 'high_speed' : serviceTagValue;
+  const isHighspeed = getVal('highspeed') === 'yes';
+
+  return (
+    serviceTag ||
+    (isHighspeed && 'high_speed') ||
+    getVal('route') ||
+    getVal('route_master')
+  );
 };
 
 export async function requestLines(featureType: string, id: number) {
@@ -74,7 +89,7 @@ export async function requestLines(featureType: string, id: number) {
       return {
         ref: `${tags.ref || tags.name}`,
         colour: getVal('colour'),
-        service: getVal('service') || getVal('route') || getVal('route_master'),
+        service: getService(tags, directionRouteTags),
         osmId: `${id}`,
         osmType: type,
       };


### PR DESCRIPTION
### Description

The public transport categories are now more reliable by changing these things:

- Actually using routes and route_masters and not only route_master relations
- Using `highspeed=yes` tags
- Accepting both `service=high_speed` and `service=highspeed` (372 uses for the correct `high_speed` and 18 for `highspeed`)

### Example links

[Frankfurt central station](https://osmapp.org/node/205364328)

### Screenshots

| Old                                                                                       | New                                                                                       |
| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| ![image](https://github.com/user-attachments/assets/b495cd8c-f6bd-4554-a1b1-932fc464326f) | ![image](https://github.com/user-attachments/assets/e908e72b-ae35-47db-80d1-ae44c76066f8) |
