### PR TITLE
FeaturePanel: Better value for yes/no groups

### DIFF
--- a/src/components/FeaturePanel/Properties/TagsTableInner.tsx
+++ b/src/components/FeaturePanel/Properties/TagsTableInner.tsx
@@ -8,20 +8,33 @@ import { ToggleButton } from '../helpers/ToggleButton';
 import { renderValue } from './renderValue';
 import { Position } from '../../../services/types';
 
-const isAddr = (k) => k.match(/^addr:|uir_adr|:addr/);
-const isName = (k) => k.match(/^name(:|$)/);
-const isShortName = (k) => k.match(/^short_name(:|$)/);
-const isAltName = (k) => k.match(/^alt_name(:|$)/);
-const isOfficialName = (k) => k.match(/^official_name(:|$)/);
-const isOldName = (k) => k.match(/^old_name(:|$)/);
-const isBuilding = (k) =>
+const isAddr = (k: string) => k.match(/^addr:|uir_adr|:addr/);
+const isName = (k: string) => k.match(/^name(:|$)/);
+const isShortName = (k: string) => k.match(/^short_name(:|$)/);
+const isAltName = (k: string) => k.match(/^alt_name(:|$)/);
+const isOfficialName = (k: string) => k.match(/^official_name(:|$)/);
+const isOldName = (k: string) => k.match(/^old_name(:|$)/);
+const isBuilding = (k: string) =>
   k.match(/building|roof|^min_level|^max_level|height$/);
-const isNetwork = (k) => k.match(/network/);
-const isBrand = (k) => k.match(/^brand/);
-const isOperator = (k) => k.match(/^operator/);
-const isPayment = (k) => k.match(/^payment/);
+const isNetwork = (k: string) => k.match(/network/);
+const isBrand = (k: string) => k.match(/^brand/);
+const isOperator = (k: string) => k.match(/^operator/);
+const isPayment = (k: string) => k.match(/^payment/);
+const isDiet = (k: string) => k.match(/^diet/);
 
-const TagsGroup = ({ tags, label, value, hideArrow = false }) => {
+type TagsGroupProps = {
+  tags: [string, string][];
+  label: string;
+  value: string;
+  hideArrow?: boolean;
+};
+
+const TagsGroup = ({
+  tags,
+  label,
+  value,
+  hideArrow = false,
+}: TagsGroupProps) => {
   const [isShown, toggle] = useToggleState(false);
 
   if (!tags.length) {
@@ -58,6 +71,31 @@ const TagsGroup = ({ tags, label, value, hideArrow = false }) => {
   );
 };
 
+const join = (values: string[], maxElements = 3) => {
+  if (values.length > maxElements) {
+    return values.slice(0, maxElements).join(', ') + ', ...';
+  }
+  return values.join(', ');
+};
+
+const previewYesNoGroup = (
+  tags: [string, string][],
+  preffered: 'yes' | 'no' = 'yes',
+) => {
+  const yesKeys = tags
+    .filter(([_, value]) => value === 'yes')
+    .map(([key]) => key.split(':', 2)[1]);
+  const noKeys = tags
+    .filter(([_, value]) => value === 'no')
+    .map(([key]) => `No ${key.split(':', 2)[1]}`);
+
+  const joined =
+    preffered === 'yes'
+      ? join(yesKeys) || join(noKeys)
+      : join(noKeys) || join(yesKeys);
+  return joined || tags[0]?.[1] || '';
+};
+
 // TODO make it dynamic - count how many "first parts before :" are there, and group all >= 2
 
 type TagsTableInnerProps = {
@@ -84,6 +122,7 @@ export const TagsTableInner = ({
   const brands = tagsEntries.filter(([k]) => isBrand(k));
   const operator = tagsEntries.filter(([k]) => isOperator(k));
   const payments = tagsEntries.filter(([k]) => isPayment(k));
+  const diets = tagsEntries.filter(([k]) => isDiet(k));
   const rest = tagsEntries.filter(
     ([k]) =>
       !isName(k) &&
@@ -96,6 +135,7 @@ export const TagsTableInner = ({
       !isNetwork(k) &&
       !isOperator(k) &&
       !isPayment(k) &&
+      !isDiet(k) &&
       !isBrand(k),
   );
 
@@ -151,7 +191,12 @@ export const TagsTableInner = ({
       <TagsGroup tags={buildings} label="building:*" value={tags.building} />
       <TagsGroup tags={networks} label="network:*" value={tags.network} />
       <TagsGroup tags={operator} label="operator:*" value={tags.operator} />
-      <TagsGroup tags={payments} label="payment:*" value={tags.payment} />
+      <TagsGroup
+        tags={payments}
+        label="payment:*"
+        value={previewYesNoGroup(payments)}
+      />
+      <TagsGroup tags={diets} label="diet:*" value={previewYesNoGroup(diets)} />
     </>
   );
 };


### PR DESCRIPTION
### Description

Tag groups like `payment` previously only showed the value of the first tag in the group. Most of the time it looked like this: `payment:* yes` which only shows the user that information exists but not yet any actual information.
Now `diet` and `payment` groups directly show actual information.

### Example links

- [/node/9999389413](https://osmapp-ey3bct4dh-osm-app-team.vercel.app/node/9999389413)
- [/node/6632052287](https://osmapp-ey3bct4dh-osm-app-team.vercel.app/node/6632052287)
- [/node/656931109](https://osmapp-ey3bct4dh-osm-app-team.vercel.app/node/656931109)
- [/node/2351691628](https://osmapp-ey3bct4dh-osm-app-team.vercel.app/node/2351691628)
- [/node/7033879367](https://osmapp-ey3bct4dh-osm-app-team.vercel.app/node/7033879367)

### Screenshots

![image](https://github.com/user-attachments/assets/9fac5860-9976-406b-be69-c60b3f8a69bd)
![image](https://github.com/user-attachments/assets/5ad1ebe3-a920-4a88-aad8-782b1fba476a)

