### PR TITLE
PublicTransport: Add a tooltip to public transport lines

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
+++ b/src/components/FeaturePanel/PublicTransport/LineNumber.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { useUserThemeContext } from '../../../helpers/theme';
 import styled from '@emotion/styled';
 import { osmColorToHex, whiteOrBlackText } from '../helpers/color';
+import { Tooltip } from '@mui/material';
+import Link from 'next/link';
+import { LineInformation } from './requestRoutes';
 
 const getBgColor = (color: string | undefined, darkmode: boolean) => {
   if (color) return osmColorToHex(color);
@@ -9,7 +12,7 @@ const getBgColor = (color: string | undefined, darkmode: boolean) => {
   return darkmode ? '#898989' : '#dddddd';
 };
 
-const LineNumberWrapper = styled.a<{
+const LineNumberWrapper = styled(Link)<{
   color: string | undefined;
   darkmode: boolean;
 }>`
@@ -21,29 +24,44 @@ const LineNumberWrapper = styled.a<{
   display: inline;
 `;
 
-interface LineNumberProps {
-  name: string;
-  color: string;
-  osmType: string;
-  osmId: string | number;
-}
+type Tags = Record<string, string>;
+const formatTooltip = (tags: Tags, routes: { tags: Tags }[]) => {
+  const formatTags = (tags: Tags) => {
+    const parts = [tags.from, ...(tags.via ? [tags.via] : []), tags.to];
+    return parts.flatMap((str) => str.split(';')).join(' - ');
+  };
 
-export const LineNumber: React.FC<LineNumberProps> = ({
-  name,
-  color,
-  osmType,
-  osmId,
-}) => {
+  if (tags.from && tags.to) {
+    return formatTags(tags);
+  }
+
+  const relevantRoute =
+    routes.find(({ tags }) => tags.from && tags.via && tags.to) ||
+    routes.find(({ tags }) => tags.from && tags.to);
+  if (!relevantRoute) {
+    return undefined;
+  }
+
+  return formatTags(relevantRoute.tags);
+};
+
+export const LineNumber = ({ line }: { line: LineInformation }) => {
   const { currentTheme } = useUserThemeContext();
   const darkmode = currentTheme === 'dark';
 
   return (
-    <LineNumberWrapper
-      href={`/${osmType}/${osmId}`}
-      color={color}
-      darkmode={darkmode}
+    <Tooltip
+      title={formatTooltip(line.tags, line.routes)}
+      arrow
+      placement="top"
     >
-      {name}
-    </LineNumberWrapper>
+      <LineNumberWrapper
+        href={`/${line.osmType}/${line.osmId}`}
+        color={line.colour}
+        darkmode={darkmode}
+      >
+        {line.ref}
+      </LineNumberWrapper>
+    </Tooltip>
   );
 };

--- a/src/components/FeaturePanel/PublicTransport/PublicTransportWrapper.tsx
+++ b/src/components/FeaturePanel/PublicTransport/PublicTransportWrapper.tsx
@@ -59,13 +59,7 @@ export const PublicTransportCategory: React.FC<CategoryProps> = ({
     {showHeading && <h4>{fmtCategory(category)}</h4>}
     <PublicTransportWrapper>
       {lines.map((line) => (
-        <LineNumber
-          key={line.ref}
-          name={line.ref}
-          color={line.colour}
-          osmType={line.osmType}
-          osmId={line.osmId}
-        />
+        <LineNumber key={line.ref} line={line} />
       ))}
     </PublicTransportWrapper>
   </>

--- a/src/components/FeaturePanel/PublicTransport/__tests__/requestRoutes.test.ts
+++ b/src/components/FeaturePanel/PublicTransport/__tests__/requestRoutes.test.ts
@@ -46,15 +46,20 @@ test('conversion', async () => {
 
   const features = await requestLines('node', 3862767512);
 
-  expect(features.routes).toEqual([
-    {
-      colour: '#880088',
-      osmId: '6818857',
-      osmType: 'relation',
-      ref: '89',
-      service: 'bus',
-    },
-  ]);
+  expect(features.routes.length).toBe(1);
+  expect(features.routes[0].colour).toBe('#880088');
+  expect(features.routes[0].osmId).toBe('6818857');
+  expect(features.routes[0].osmType).toBe('relation');
+  expect(features.routes[0].ref).toBe('89');
+  expect(features.routes[0].service).toBe('bus');
+  expect(features.routes[0].tags).toEqual({
+    colour: '#880088',
+    ref: '89',
+    route_master: 'bus',
+    type: 'route_master',
+  });
+  expect(Array.isArray(features.routes[0].routes)).toBe(true);
+
   expect(features.geoJson.features).toEqual([
     {
       center: undefined,

--- a/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/requestRoutes.ts
@@ -6,15 +6,17 @@ import {
 } from '../../../services/overpassSearch';
 import { intl } from '../../../services/intl';
 
+type WithTags = { tags: Record<string, string> };
+
 export interface LineInformation {
+  tags: Record<string, string>;
+  routes: WithTags[];
   ref: string;
   colour: string | undefined;
   service: string | undefined;
   osmType: string;
   osmId: string;
 }
-
-type WithTags = { tags: Record<string, string> };
 
 const filterRoutesByRef = (routes: WithTags[], ref: string) =>
   routes.filter(({ tags }) => tags.ref === ref);
@@ -87,6 +89,8 @@ export async function requestLines(featureType: string, id: number) {
         getTagValue(key, tags, directionRouteTags);
 
       return {
+        tags,
+        routes: directionRouteTags,
         ref: `${tags.ref || tags.name}`,
         colour: getVal('colour'),
         service: getService(tags, directionRouteTags),


### PR DESCRIPTION
### Description
Add a tooltip showing the route from the `from`, `via` and `to`tags.