### PR TITLE
OpeningHoursEditor: handle `Mo-Su 0:00-24:00` as `24/7`

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/OpeningHoursEditor/parser/__tests__/parser.test.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/OpeningHoursEditor/parser/__tests__/parser.test.ts
@@ -69,6 +69,16 @@ describe('Mo off', () => {
   });
 });
 
+describe('24/7', () => {
+  test.each([{ input: 'Mo-Su 0:00-24:00' }, { input: 'Mo-Su 00:00-24:00' }])(
+    `$input`,
+    ({ input }) => {
+      expect(buildString(getDaysTable(input))).toEqual('24/7');
+      expect(canItHandle(input)).toBe(true);
+    },
+  );
+});
+
 describe('daysPart conversion', () => {
   test.each([
     { input: 'Mo,Th' },

--- a/src/components/FeaturePanel/EditDialog/EditContent/OpeningHoursEditor/parser/canItHandle.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/OpeningHoursEditor/parser/canItHandle.ts
@@ -8,7 +8,7 @@ const splitByFirstSpace = (str: string) => {
 };
 
 const sanitizeDaysParts = (value: string) => {
-  return (value ?? '')
+  return value
     .split(/ *; */)
     .map((part) => {
       if (part.match(/^(Mo|Tu|We|Th|Fr|Sa|Su) off$/)) {
@@ -18,9 +18,14 @@ const sanitizeDaysParts = (value: string) => {
         const [daysPart, timePart] = splitByFirstSpace(part);
         const days = parseDaysPart(daysPart);
         const sanitizedDays = buildDaysPart(days);
-        return (
-          (sanitizedDays === 'Mo-Su' ? '' : `${sanitizedDays} `) + `${timePart}`
-        );
+
+        if (sanitizedDays === 'Mo-Su' && timePart.match(/^0?0:00-24:00$/)) {
+          return '24/7';
+        }
+        if (sanitizedDays === 'Mo-Su') {
+          return timePart;
+        }
+        return `${sanitizedDays} ${timePart}`;
       }
       return part;
     })


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links
https://osmapp.org/way/303646533

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
