### PR TITLE
General: Add a flake.nix file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "OsmAPP development enviroment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forEachSupportedSystem = f:
+      nixpkgs.lib.genAttrs supportedSystems (system:
+        f {
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [self.overlays.default];
+          };
+        });
+  in {
+    overlays.default = final: prev: rec {
+      nodejs = prev.nodejs_20;
+      yarn = prev.yarn.override {inherit nodejs;};
+    };
+
+    devShells = forEachSupportedSystem ({pkgs}: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          nodejs
+          yarn
+          nodePackages.typescript-language-server
+        ];
+        shellHook = ''
+          if [ ! -d node_modules ]; then
+            echo "Use yarn to install dependencies"
+          fi
+        '';
+      };
+    });
+  };
+}


### PR DESCRIPTION
### Description

This PR adds a `flake.nix` file. This file simplifies the on boarding process for Nix users by defining all necessary dependencies, including Node (with the correct version), Yarn and the TypeScript language server. Users can simply run `nix develop` which will drop them into a pre-configured shell ready to work on OsmAPP.
