### PR TITLE
osmApi: Display error on save for 409/412 responses

### DIFF
--- a/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
+++ b/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
@@ -45,6 +45,10 @@ export const useGetHandleSave = () => {
         showToast(t('editdialog.osm_session_expired'), 'error');
         handleLogout();
       } else {
+        showToast(
+          `${t('editdialog.save_refused')} ${err.responseText}`,
+          'error',
+        );
         console.error(err); // eslint-disable-line no-console
       }
       setTimeout(() => setIsSaving(false), 500);

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -149,6 +149,7 @@ export default {
   'editdialog.tags_editor': 'Všechny vlastnosti – tagy',
   'editdialog.tags_editor_info': `Tagy popisují vlastnosti mapového prvku v dohodnutém formátu. Zde naleznete úplný
         <a href="https://wiki.openstreetmap.org/wiki/Cs:Map_Features" target="_blank">přehled všech tagů v OpenStreetMap</a>.`,
+  'editdialog.save_refused': 'Změny se nepodařilo uložit.',
 
   'editsuccess.close_button': 'Zavřít',
   'editsuccess.note.heading': 'Děkujeme za Váš návrh!',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -187,6 +187,7 @@ export default {
   'editdialog.tags_editor': 'All properties – Tags',
   'editdialog.tags_editor_info': `Tags contain the data used to display objects on the map.<br>You can find <a href="https://wiki.openstreetmap.org/wiki/Map_Features" target="_blank">a reference for all tags on the OpenStreetMap Wiki</a>.`,
   'editdialog.login_in_progress': `Logging in...`,
+  'editdialog.save_refused': 'Unable to save your changes.',
 
   'editsuccess.close_button': 'Done',
   'editsuccess.note.heading': 'Thank you for your suggestion!',


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

When OSM API returns Response 409 or 412, osmapp stops saving without explanation.

### Example links

Try to remove this Relation https://osmapp.org/relation/5250576
OSM returns 412 _Precondition failed: The relation 5250576 is used in relation 237270._

Same can be with 409 - conflict, see https://wiki.openstreetmap.org/wiki/API_v0.6#Error_codes_15

### Screenshots

Error 404, responseText is empty:
![image](https://github.com/user-attachments/assets/3f157726-c34f-40f1-9f50-cd4360156bc7)

Error 412:
![image](https://github.com/user-attachments/assets/198aea31-8e94-4af0-9bdb-e261f6519e91)
![image](https://github.com/user-attachments/assets/3743f343-07a9-47fc-b336-4a578fdbd578)

Error 410:
![image](https://github.com/user-attachments/assets/f4277697-b306-40f5-be98-42418f67cd30)

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
