### PR TITLE
Publictransport: Support stop_areas in stop_areas

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/routes/requestRoutes.ts
+++ b/src/components/FeaturePanel/PublicTransport/routes/requestRoutes.ts
@@ -58,7 +58,10 @@ export async function requestLines(featureType: string, id: number) {
     ${featureType}(${id})-> .specific_feature;
 
     // Try to find stop_area relations containing the specific node and get their stops
-    rel(bn.specific_feature)["public_transport"="stop_area"] -> .stop_areas;
+    (
+      rel(bn.specific_feature)["public_transport"="stop_area"];
+      rel(r._)["public_transport"="stop_area"] -> .stop_areas;
+    ) -> .stop_areas;
     node(r.stop_areas: "stop") -> .stops;
     (
       rel(bn.stops)["route"~"bus|train|tram|subway|light_rail|ferry|monorail"];


### PR DESCRIPTION
### Description

Introduce support for stop_areas in stop_areas.

### Example links

[Amsterdam central station](https://osmapp-git-fork-dlurak-double-stopareas-osm-app-team.vercel.app/node/4290854847#14.98/52.3762/4.9015)

