### PR TITLE
SearchBox: Lower threshold for stars and correct sorting for presets

### DIFF
--- a/src/components/SearchBox/options/preset.tsx
+++ b/src/components/SearchBox/options/preset.tsx
@@ -84,12 +84,12 @@ export const getPresetOptions = async (
   const allResults = orderBy(
     filtered,
     [
-      // some bestMatches are the same for many items, then sort by name. Try out *dog*
+      // some bestMatches are the same for many items, then sort by name. Try out *restaurant*
       ({ nameSimilarity, bestMatch }) => Math.max(nameSimilarity, bestMatch),
       ({ nameSimilarity }) => nameSimilarity,
       ({ bestMatch }) => bestMatch,
     ],
-    'desc',
+    ['desc', 'desc', 'desc'],
   ).map((result) => ({
     type: 'preset' as const,
     preset: result,

--- a/src/components/SearchBox/options/stars.tsx
+++ b/src/components/SearchBox/options/stars.tsx
@@ -18,9 +18,13 @@ export const getStarsOptions = (
   if (inputValue === '') {
     return stars.map((star) => ({ type: 'star', star }));
   }
-  return diceCoefficientSort(stars, ({ label }) => label, inputValue).map(
-    (star) => ({ type: 'star', star }),
+  const sorted = diceCoefficientSort(
+    stars,
+    ({ label }) => label,
+    inputValue,
+    0.25,
   );
+  return sorted.map((star) => ({ type: 'star', star }));
 };
 
 export const renderStar = (


### PR DESCRIPTION
### Description

@zbycz noticed two more issues with the searchbox and described them [here](https://github.com/zbycz/osmapp/issues/657#issuecomment-2416618328).
This PR lowers the threshold for stars to 0.25 so they are easier to find and prefers `name` in the preset sorting.

### Screenshots

![osmapp-search](https://github.com/user-attachments/assets/aba88c0f-800c-4506-90f9-58d4f540cfcc)

The internal sorting and ratings for the search term "Restaurant"
![internal](https://private-user-images.githubusercontent.com/84224239/377066325-75e6a19c-92b1-4a77-9b8e-120dca3b5504.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjkwODU1NjgsIm5iZiI6MTcyOTA4NTI2OCwicGF0aCI6Ii84NDIyNDIzOS8zNzcwNjYzMjUtNzVlNmExOWMtOTJiMS00YTc3LTliOGUtMTIwZGNhM2I1NTA0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDE2VDEzMjc0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZjYjQ3ZWMwMjI1ZDNmOTY4MTA3OGQ2NGU1MjhiZjJhZmY5Y2Q5ZjVkYjIxZjhiZDc2ZjA4ODg3MDM2N2MwMjYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.SJ4Av6_AySQ-yPQUvK1rYDE0IcStJ9_F_FUJCtDrDYY)

