### PR TITLE
Map: Predefined views for landmarks

### DIFF
--- a/pages/camera-view.tsx
+++ b/pages/camera-view.tsx
@@ -1,0 +1,19 @@
+import { GetServerSideProps } from 'next';
+import { views } from '../src/services/landmarks/views';
+
+export const Config = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({
+  res,
+  query,
+}) => {
+  res.setHeader('Content-Type', 'application/json');
+
+  const responseBody = views[`${query.shortId}`] ?? null;
+  res.write(JSON.stringify(responseBody));
+  res.end();
+
+  return { props: {} };
+};
+
+export default Config;

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Cookies from 'js-cookie';
 
 import nextCookies from 'next-cookies';
@@ -59,16 +59,17 @@ export const getMapViewFromHash = (): View | undefined => {
 };
 
 const useUpdateViewFromFeature = () => {
-  const { feature } = useFeatureContext();
+  const { feature, accessMethod } = useFeatureContext();
   const { setView, setLandmarkPitch, setLandmarkBearing } =
     useMapStateContext();
 
   React.useEffect(() => {
     if (!feature) return;
-    const { landmarkView, center } = feature;
+    if (!feature.center) return;
+    if (getMapViewFromHash()) return;
+    if (accessMethod === 'click') return;
 
-    if (!center) return;
-    if (getMapViewFromHash() && !landmarkView) return;
+    const { landmarkView, center } = feature;
 
     const [lon, lat] = center.map((deg) => deg.toFixed(4));
     const zoom = landmarkView?.zoom ?? 17;
@@ -76,7 +77,7 @@ const useUpdateViewFromFeature = () => {
 
     setLandmarkBearing(landmarkView?.bearing);
     setLandmarkPitch(landmarkView?.pitch);
-  }, [feature, setView, setLandmarkBearing, setLandmarkPitch]);
+  }, [feature, setView, setLandmarkBearing, setLandmarkPitch, accessMethod]);
 };
 
 const useUpdateViewFromHash = () => {

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -60,15 +60,23 @@ export const getMapViewFromHash = (): View | undefined => {
 
 const useUpdateViewFromFeature = () => {
   const { feature } = useFeatureContext();
-  const { setView } = useMapStateContext();
+  const { setView, setLandmarkPitch, setLandmarkBearing } =
+    useMapStateContext();
 
   React.useEffect(() => {
-    if (!feature?.center) return;
-    if (getMapViewFromHash()) return;
+    if (!feature) return;
+    const { landmarkView, center } = feature;
 
-    const [lon, lat] = feature.center.map((deg) => deg.toFixed(4));
-    setView(['17.00', lat, lon]);
-  }, [feature, setView]);
+    if (!center) return;
+    if (getMapViewFromHash() && !landmarkView) return;
+
+    const [lon, lat] = center.map((deg) => deg.toFixed(4));
+    const zoom = landmarkView?.zoom ?? 17;
+    setView([`${zoom}`, lat, lon]);
+
+    setLandmarkBearing(landmarkView?.bearing);
+    setLandmarkPitch(landmarkView?.pitch);
+  }, [feature, setView, setLandmarkBearing, setLandmarkPitch]);
 };
 
 const useUpdateViewFromHash = () => {

--- a/src/components/FeaturePanel/FeaturePanelFooter.tsx
+++ b/src/components/FeaturePanel/FeaturePanelFooter.tsx
@@ -7,6 +7,7 @@ import Coordinates from './Coordinates';
 import { t } from '../../services/intl';
 import { ObjectsAround } from './ObjectsAround';
 import React from 'react';
+import { RecommendedView } from './RecommendedView';
 
 type Props = {
   advanced: boolean;
@@ -31,6 +32,12 @@ export const FeaturePanelFooter = ({
       <PanelSidePadding>
         <FeatureDescription advanced={advanced} setAdvanced={setAdvanced} />
         <Coordinates />
+        {feature.landmarkView && (
+          <>
+            <br />
+            <RecommendedView />
+          </>
+        )}
         <br />
         <a href={osmappLink}>{osmappLink}</a>
         <br />

--- a/src/components/FeaturePanel/RecommendedView.tsx
+++ b/src/components/FeaturePanel/RecommendedView.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { Button } from '@mui/material';
+import { useFeatureContext } from '../utils/FeatureContext';
+import { getGlobalMap } from '../../services/mapStorage';
+import isNumber from 'lodash/isNumber';
+import { t } from '../../services/intl';
+
+const SubtleButton = styled(Button)(({ theme }) => ({
+  textTransform: 'none',
+  backgroundColor: 'transparent',
+  color: theme.palette.text.primary,
+  border: `1px solid ${theme.palette.divider}`,
+  padding: '4px 8px',
+  margin: '4px 0',
+  fontSize: '0.75rem',
+  '&:hover': {
+    backgroundColor: theme.palette.action.hover,
+    borderColor: theme.palette.text.primary,
+  },
+}));
+
+export const RecommendedView = () => {
+  const { feature } = useFeatureContext();
+  return (
+    <SubtleButton
+      onClick={() => {
+        const { landmarkView } = feature;
+        const { zoom, pitch, bearing } = landmarkView;
+        const [lng, lat] = feature.center;
+        // flyTo breaks the map
+        getGlobalMap()?.jumpTo({
+          center: { lng, lat },
+          ...(isNumber(zoom) ? { zoom } : {}),
+          ...(isNumber(pitch) ? { pitch } : {}),
+          ...(isNumber(bearing) ? { bearing } : {}),
+        });
+      }}
+    >
+      {t('featurepanel.recommended_view')}
+    </SubtleButton>
+  );
+};

--- a/src/components/Map/BrowserMap.tsx
+++ b/src/components/Map/BrowserMap.tsx
@@ -57,12 +57,12 @@ const NotSupportedMessage = () => (
 const BrowserMap = () => {
   const { userLayers } = useMapStateContext();
   const mobileMode = useMobileMode();
-  const { setFeature } = useFeatureContext();
+  const { setFeature, setAccessMethod } = useFeatureContext();
   const { mapLoaded, setMapLoaded } = useMapStateContext();
 
   const [map, mapRef] = useInitMap();
   useAddTopRightControls(map, mobileMode);
-  useOnMapClicked(map, setFeature);
+  useOnMapClicked(map, setFeature, setAccessMethod);
   useOnMapLongPressed(map, setFeature);
   useOnMapLoaded(map, setMapLoaded);
   useFeatureMarker(map);

--- a/src/components/Map/BrowserMap.tsx
+++ b/src/components/Map/BrowserMap.tsx
@@ -18,6 +18,7 @@ import { useToggleTerrainControl } from './behaviour/useToggleTerrainControl';
 import { webglSupported } from './helpers';
 import { useOnMapLongPressed } from './behaviour/useOnMapLongPressed';
 import { useAddTopRightControls } from './useAddTopRightControls';
+import isNumber from 'lodash/isNumber';
 
 const useOnMapLoaded = createMapEventHook<'load', [MapEventHandler<'load'>]>(
   (_, onMapLoaded) => ({
@@ -35,8 +36,8 @@ const useUpdateMap = createMapEffectHook<[View, number, number]>(
     map.jumpTo({
       center,
       zoom: parseFloat(viewForMap[0]),
-      ...(pitch ? { pitch } : {}),
-      ...(bearing ? { bearing } : {}),
+      ...(isNumber(pitch) ? { pitch } : {}),
+      ...(isNumber(bearing) ? { bearing } : {}),
     });
   },
 );

--- a/src/components/Map/BrowserMap.tsx
+++ b/src/components/Map/BrowserMap.tsx
@@ -26,13 +26,20 @@ const useOnMapLoaded = createMapEventHook<'load', [MapEventHandler<'load'>]>(
   }),
 );
 
-const useUpdateMap = createMapEffectHook<[View]>((map, viewForMap) => {
-  const center: [number, number] = [
-    parseFloat(viewForMap[2]),
-    parseFloat(viewForMap[1]),
-  ];
-  map.jumpTo({ center, zoom: parseFloat(viewForMap[0]) });
-});
+const useUpdateMap = createMapEffectHook<[View, number, number]>(
+  (map, viewForMap, pitch, bearing) => {
+    const center: [number, number] = [
+      parseFloat(viewForMap[2]),
+      parseFloat(viewForMap[1]),
+    ];
+    map.jumpTo({
+      center,
+      zoom: parseFloat(viewForMap[0]),
+      ...(pitch ? { pitch } : {}),
+      ...(bearing ? { bearing } : {}),
+    });
+  },
+);
 
 const NotSupportedMessage = () => (
   <span
@@ -57,11 +64,17 @@ const BrowserMap = () => {
   useOnMapLoaded(map, setMapLoaded);
   useFeatureMarker(map);
 
-  const { viewForMap, setViewFromMap, setBbox, activeLayers } =
-    useMapStateContext();
+  const {
+    viewForMap,
+    setViewFromMap,
+    setBbox,
+    activeLayers,
+    landmarkPitch,
+    landmarkBearing,
+  } = useMapStateContext();
   useUpdateViewOnMove(map, setViewFromMap, setBbox);
   useToggleTerrainControl(map);
-  useUpdateMap(map, viewForMap);
+  useUpdateMap(map, viewForMap, landmarkPitch, landmarkBearing);
   useUpdateStyle(map, activeLayers, userLayers, mapLoaded);
 
   return <div ref={mapRef} style={{ height: '100%', width: '100%' }} />;

--- a/src/components/Map/behaviour/useOnMapClicked.tsx
+++ b/src/components/Map/behaviour/useOnMapClicked.tsx
@@ -64,7 +64,13 @@ export const useOnMapClicked = createMapEventHook<'click', [SetFeature]>(
       }
 
       const skeleton = getSkeleton(features[0], coords);
-      console.log(`clicked map feature (id=${features[0].id}): `, features[0]); // eslint-disable-line no-console
+      // eslint-disable-next-line no-console
+      console.log(
+        `clicked map feature (id=${features[0].id}): `,
+        features[0],
+        'shortId:',
+        getShortId(skeleton.osmMeta),
+      ); // eslint-disable-line no-console
       publishDbgObject('last skeleton', skeleton);
 
       if (skeleton.nonOsmObject) {

--- a/src/components/Map/helpers.ts
+++ b/src/components/Map/helpers.ts
@@ -80,3 +80,6 @@ const isWebglSupported = () => {
 };
 
 export const webglSupported = isBrowser() ? isWebglSupported() : true;
+
+export const supports3d = (activeLayers: string[]) =>
+  activeLayers.includes('basic') || activeLayers.includes('outdoor');

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -68,7 +68,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   autocompleteRef,
   setOverpassLoading,
 }) => {
-  const { setFeature, setPreview } = useFeatureContext();
+  const { setFeature, setPreview, setAccessMethod } = useFeatureContext();
   const { bbox } = useMapStateContext();
   const { showToast } = useSnackbar();
   const mapCenter = useMapCenter();
@@ -93,6 +93,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         showToast,
         setOverpassLoading,
         router,
+        setAccessMethod,
       })}
       onHighlightChange={onHighlightFactory(setPreview)}
       getOptionDisabled={(o) => o.type === 'loader'}

--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -18,6 +18,7 @@ import {
   StarOption,
 } from './types';
 import { osmOptionSelected } from './options/openstreetmap';
+import { AccessMethod } from '../utils/FeatureContext';
 
 const overpassOptionSelected = (
   option: OverpassOption | PresetOption,
@@ -67,6 +68,7 @@ type SetFeature = (feature: Feature | null) => void;
 const geocoderOptionSelected = (
   option: GeocoderOption,
   setFeature: SetFeature,
+  setAccessMethod: (accessMethod: AccessMethod) => void,
 ) => {
   if (!option?.geocoder.geometry?.coordinates) return;
 
@@ -75,6 +77,7 @@ const geocoderOptionSelected = (
 
   addFeatureCenterToCache(getShortId(skeleton.osmMeta), skeleton.center);
 
+  setAccessMethod('search');
   setFeature(skeleton);
   fitBounds(option);
   Router.push(`/${getUrlOsmId(skeleton.osmMeta)}`);
@@ -87,6 +90,7 @@ type OnSelectedFactoryProps = {
   showToast: ShowToast;
   setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>;
   router: NextRouter;
+  setAccessMethod: (accessMethod: AccessMethod) => void;
 };
 
 export const onSelectedFactory =
@@ -97,6 +101,7 @@ export const onSelectedFactory =
     showToast,
     setOverpassLoading,
     router,
+    setAccessMethod,
   }: OnSelectedFactoryProps) =>
   (_: never, option: Option) => {
     setPreview(null); // it could be stuck from onHighlight
@@ -110,7 +115,7 @@ export const onSelectedFactory =
         overpassOptionSelected(option, setOverpassLoading, bbox, showToast);
         break;
       case 'geocoder':
-        geocoderOptionSelected(option, setFeature);
+        geocoderOptionSelected(option, setFeature, setAccessMethod);
         break;
       case 'osm':
         osmOptionSelected(option, router);

--- a/src/components/utils/FeatureContext.tsx
+++ b/src/components/utils/FeatureContext.tsx
@@ -12,6 +12,8 @@ import { useBoolState } from '../helpers';
 import { publishDbgObject } from '../../utils';
 import { setLastFeature } from '../../services/lastFeatureStorage';
 
+export type AccessMethod = 'click' | 'search' | 'link';
+
 export type FeatureContextType = {
   feature: Feature | null;
   featureShown: boolean;
@@ -24,6 +26,8 @@ export type FeatureContextType = {
   persistShowHomepage: () => void;
   preview: Feature | null;
   setPreview: (feature: Feature | null) => void;
+  accessMethod: AccessMethod | null;
+  setAccessMethod: (method: AccessMethod | null) => void;
 };
 
 export const FeatureContext = createContext<FeatureContextType>(undefined);
@@ -41,6 +45,7 @@ export const FeatureProvider = ({
 }: Props) => {
   const [preview, setPreview] = useState<Feature>(null);
   const [feature, setFeature] = useState<Feature>(featureFromRouter);
+  const [accessMethod, setAccessMethod] = useState<AccessMethod | null>(null);
   const featureShown = feature != null;
 
   useEffect(() => {
@@ -72,7 +77,12 @@ export const FeatureProvider = ({
   const value: FeatureContextType = {
     feature,
     featureShown,
-    setFeature,
+    setFeature: (feature) => {
+      if (!feature) {
+        setAccessMethod(null);
+      }
+      return setFeature(feature);
+    },
     homepageShown,
     showHomepage,
     hideHomepage,
@@ -80,6 +90,8 @@ export const FeatureProvider = ({
     persistHideHomepage,
     preview,
     setPreview,
+    accessMethod,
+    setAccessMethod,
   };
   return (
     <FeatureContext.Provider value={value}>{children}</FeatureContext.Provider>

--- a/src/components/utils/MapStateContext.tsx
+++ b/src/components/utils/MapStateContext.tsx
@@ -43,6 +43,10 @@ type MapStateContextType = {
   setUserLayers: Setter<Layer[]>;
   mapLoaded: boolean;
   setMapLoaded: () => void;
+  landmarkPitch: number | undefined;
+  setLandmarkPitch: Setter<number | undefined>;
+  landmarkBearing: number | undefined;
+  setLandmarkBearing: Setter<number | undefined>;
 };
 
 export const MapStateContext = createContext<MapStateContextType>(undefined);
@@ -64,6 +68,12 @@ export const MapStateProvider: React.FC<{ initialMapView: View }> = ({
   const [userLayers, setUserLayers] = usePersistedState<Layer[]>(
     'userLayerIndex',
     [],
+  );
+  const [landmarkBearing, setLandmarkBearing] = useState<number | undefined>(
+    undefined,
+  );
+  const [landmarkPitch, setLandmarkPitch] = useState<number | undefined>(
+    undefined,
   );
 
   const [mapLoaded, setMapLoaded, setNotLoaded] = useBoolState(true);
@@ -87,6 +97,10 @@ export const MapStateProvider: React.FC<{ initialMapView: View }> = ({
     setUserLayers,
     mapLoaded,
     setMapLoaded,
+    landmarkBearing,
+    setLandmarkBearing,
+    landmarkPitch,
+    setLandmarkPitch,
   };
 
   return (

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -113,6 +113,7 @@ export default {
   'featurepanel.objects_around': 'Orte in der Nähe',
   'featurepanel.more_in_openplaceguide': 'Weitere Information auf __instanceName__',
   'featurepanel.climbing_restriction': 'Kletter Einschränkungen',
+  'featurepanel.recommended_view': 'Empfohlnene Ansicht ansehen',
 
   'opening_hours.all_day': '24 Stunden',
   'opening_hours.open': 'Geöffnet: __todayTime__',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -134,6 +134,7 @@ export default {
   'featurepanel.more_in_openplaceguide': 'More information on __instanceName__',
   'featurepanel.climbing_restriction': 'Climbing restriction',
   'featurepanel.login': 'Login',
+  'featurepanel.recommended_view': 'Go to recommended view',
 
   'opening_hours.all_day': '24 hours',
   'opening_hours.open': 'Open: __todayTime__',

--- a/src/services/landmarks/README.md
+++ b/src/services/landmarks/README.md
@@ -1,0 +1,15 @@
+# Landmark views
+
+Some important landmarks have predefined views, e.g. the Brandenburg Gate.
+
+To contribute some yourself you need to add the relevant entries into `views.ts`, please take inspiration from the values already defined.
+
+- **Key**: The shortId of a feature, you can see it in the console after clicking on a feature.
+- **bearing**: Which direction points upwards on the map, a value of `90` will make east up
+- **pitch**: The tilt angle of the map, 0 is a flat view from straight above and the maximum is 60
+- **zoom**: The zoom, A higher value is a zoomed in more then a low value. The maximum is 24
+
+`bearing`, `pitch` and `zoom` are all optional; leaving one out will simply not explicitly set that value
+
+Feel free to open a pr and ask for help
+Thanks for wanting to contribute :)

--- a/src/services/landmarks/addLandmarkView.ts
+++ b/src/services/landmarks/addLandmarkView.ts
@@ -1,0 +1,35 @@
+import { isServer } from '../../components/helpers';
+import { fetchJson } from '../fetch';
+import { getShortId, prod } from '../helpers';
+import { Feature } from '../types';
+import { LandmarkView } from './views';
+
+const getViewUrl = (shortId: string) => {
+  const end = `/camera-view?shortId=${shortId}`;
+  if (!isServer()) {
+    return end;
+  }
+  if (prod) {
+    return `https://osmapp.org${end}`;
+  }
+  // TODO: Find the *right* url also for preview deployments
+  return `http://localhost:3000${end}`;
+};
+
+const getView = async ({ osmMeta }: Feature) => {
+  const shortId = getShortId(osmMeta);
+  const cameraViewUrl = getViewUrl(shortId);
+  return fetchJson<LandmarkView | null>(cameraViewUrl);
+};
+
+export const addLandmarkView = async (feature: Feature): Promise<Feature> => {
+  try {
+    const view = await getView(feature);
+    return {
+      ...feature,
+      landmarkView: view,
+    };
+  } catch {
+    return feature;
+  }
+};

--- a/src/services/landmarks/views.ts
+++ b/src/services/landmarks/views.ts
@@ -5,6 +5,42 @@ export type LandmarkView = {
 };
 
 export const views: Record<string, LandmarkView> = {
+  ////////////
+  //// USA ///
+  ////////////
+  // Statue of liberty
+  w32965412: { bearing: 330, pitch: 60, zoom: 18.5 },
+  // White House
+  w238241022: { bearing: 0, pitch: 60, zoom: 18 },
+  // Lincoln Memorial
+  w398769543: { bearing: 270, pitch: 60, zoom: 18.75 },
+  // United States Capitol
+  w66418809: { bearing: 270, pitch: 60, zoom: 17.5 },
+  ////////////////
+  //// GERMANY ///
+  ////////////////
+  // Elbe Philharmonic Hall
+  w24981343: { bearing: 45, pitch: 50, zoom: 17.25 },
+  // Cologne Cathedral
+  w4532022: { bearing: 90, pitch: 55, zoom: 17.1 },
   // Brandenburg gate
-  w518071791: { bearing: 263, pitch: 55, zoom: 19 },
+  w518071791: { bearing: 263, pitch: 60, zoom: 19 },
+  // Reichstags Building
+  r2201742: { bearing: 90, pitch: 55, zoom: 17.5 },
+  // Soviet War Memorial Tiergarten
+  w41368167: { bearing: 353, pitch: 60, zoom: 19 },
+  // Siegessäule
+  n1097191894: { pitch: 45, zoom: 18.5 },
+  // Berlin Cathedral
+  w313670734: { bearing: 22, pitch: 55, zoom: 17.75 },
+  ///////////
+  // Italy //
+  ///////////
+  // Colosseum
+  r1834818: { bearing: 70, pitch: 50, zoom: 17.5 },
+  ////////////
+  // France //
+  ////////////
+  // Eiffel Tower
+  w5013364: { bearing: 315, pitch: 15, zoom: 17.5 },
 };

--- a/src/services/landmarks/views.ts
+++ b/src/services/landmarks/views.ts
@@ -1,0 +1,10 @@
+export type LandmarkView = {
+  zoom?: number;
+  bearing?: number;
+  pitch?: number;
+};
+
+export const views: Record<string, LandmarkView> = {
+  // Brandenburg gate
+  w518071791: { bearing: 263, pitch: 55, zoom: 19 },
+};

--- a/src/services/landmarks/views.ts
+++ b/src/services/landmarks/views.ts
@@ -20,7 +20,7 @@ export const views: Record<string, LandmarkView> = {
   //// GERMANY ///
   ////////////////
   // Elbe Philharmonic Hall
-  w24981343: { bearing: 45, pitch: 50, zoom: 17.25 },
+  w24981342: { bearing: 45, pitch: 50, zoom: 17.25 },
   // Cologne Cathedral
   w4532022: { bearing: 90, pitch: 55, zoom: 17.1 },
   // Brandenburg gate

--- a/src/services/landmarks/views.ts
+++ b/src/services/landmarks/views.ts
@@ -16,6 +16,9 @@ export const views: Record<string, LandmarkView> = {
   w398769543: { bearing: 270, pitch: 60, zoom: 18.75 },
   // United States Capitol
   w66418809: { bearing: 270, pitch: 60, zoom: 17.5 },
+  // Space needle
+  w12903132: { pitch: 30, zoom: 17.25 },
+
   ////////////////
   //// GERMANY ///
   ////////////////
@@ -33,14 +36,47 @@ export const views: Record<string, LandmarkView> = {
   n1097191894: { pitch: 45, zoom: 18.5 },
   // Berlin Cathedral
   w313670734: { bearing: 22, pitch: 55, zoom: 17.75 },
+  // Alte Oper Frankfurt
+  w384153099: { bearing: 20, pitch: 55, zoom: 18 },
+
   ///////////
   // Italy //
   ///////////
   // Colosseum
   r1834818: { bearing: 70, pitch: 50, zoom: 17.5 },
+
   ////////////
   // France //
   ////////////
   // Eiffel Tower
   w5013364: { bearing: 315, pitch: 15, zoom: 17.5 },
+
+  ////////////////////
+  // United Kingdom //
+  ////////////////////
+  // Big Ben & Elizabeth tower
+  n1802652184: { bearing: 225, pitch: 50, zoom: 17.5 },
+  w123557148: { bearing: 225, pitch: 50, zoom: 17.5 },
+  // Buckingham palace
+  r5208404: { bearing: 235, pitch: 60, zoom: 17.6 },
+
+  ////////////////////
+  // Czech republic //
+  ////////////////////
+  // Prague Castle
+  r3312247: { bearing: 51, pitch: 60, zoom: 16.5 },
+  // National museum
+  r85291: { bearing: 140, pitch: 50, zoom: 18 },
+
+  /////////////
+  // Iceland //
+  /////////////
+  // Hallgrímskirkja
+  r6184378: { bearing: 150, pitch: 40, zoom: 18 },
+
+  ///////////
+  // India //
+  ///////////
+  // Taj Mahal
+  w375257537: { bearing: 0, pitch: 50, zoom: 18 },
 };

--- a/src/services/osmApi.ts
+++ b/src/services/osmApi.ts
@@ -19,6 +19,7 @@ import {
   publishDbgObject,
 } from '../utils';
 import { getOverpassUrl } from './overpassSearch';
+import { addLandmarkView } from './landmarks/addLandmarkView';
 
 type GetOsmUrl = (object: OsmId) => string;
 
@@ -308,7 +309,8 @@ export const fetchFeature = async (apiId: OsmId): Promise<Feature> => {
     }
 
     const feature = await fetchFeatureWithCenter(apiId);
-    const finalFeature = await addMembersAndParents(feature);
+    const featureWithLandmarkView = await addLandmarkView(feature);
+    const finalFeature = await addMembersAndParents(featureWithLandmarkView);
 
     return finalFeature;
   } catch (e) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,4 +1,5 @@
 import type Vocabulary from '../locales/vocabulary';
+import { LandmarkView } from './landmarks/views';
 import type { getSchemaForFeature } from './tagging/idTaggingScheme';
 
 export type OsmType = 'node' | 'way' | 'relation';
@@ -114,6 +115,7 @@ export interface Feature {
   error?: 'network' | 'unknown' | '404' | '500'; // etc.
   deleted?: boolean;
   schema?: ReturnType<typeof getSchemaForFeature>; // undefined means error
+  landmarkView?: LandmarkView | null;
 
   // skeleton
   layer?: { id: string };


### PR DESCRIPTION
### Description

Some landmarks now have predefined views. These views include pitch, bearing and zoom. For towers the bearing might be irrelevant so any of these properties is optional.
When the user opens a link to a landmark with a defined view and without a position hash the view is automatically applied, when searching for a item the view is also applied.
When the user clicks on a landmark nothing happens by default but a button is shown to go to the recommended view.

### Example links

### Screenshots

<img src="https://github.com/user-attachments/assets/c09a1e1f-89fe-4281-bba9-d201858c8176" width="500">

### Problems

- The ideal zoom changes depending on the screen size and aspect ratio