### PR TITLE
FeaturePanel: Add apple maps to the dropdown

### DIFF
--- a/src/components/FeaturePanel/helpers/externalLinks.ts
+++ b/src/components/FeaturePanel/helpers/externalLinks.ts
@@ -1,0 +1,27 @@
+import { getLabel } from '../../../helpers/featureLabel';
+import { Feature, PositionBoth } from '../../../services/types';
+import { View } from '../../utils/MapStateContext';
+
+export const getIdEditorLink = (feature: Feature, view?: View) => {
+  const query = feature?.osmMeta?.id
+    ? `?${feature.osmMeta.type}=${feature.osmMeta.id}`
+    : '';
+  const hash = view ? `#map=${view.join('/')}` : '';
+  return `https://www.openstreetmap.org/edit${query}${hash}`;
+};
+
+export const getAppleMapsLink = (
+  feature: Feature,
+  position: PositionBoth,
+  activeLayers: string[],
+) => {
+  // TODO: satelite detection on userLayers
+  const layer = activeLayers.some((layer) =>
+    ['sat', 'bingSat', 'cuzkSat'].includes(layer),
+  )
+    ? 'h' // satelite
+    : 'm'; // normal
+
+  const markerLabel = getLabel(feature);
+  return `https://maps.apple.com/?ll=${position[1]},${position[0]}&t=${layer}&q=${markerLabel}`;
+};

--- a/src/helpers/platforms.ts
+++ b/src/helpers/platforms.ts
@@ -1,5 +1,8 @@
+import { isBrowser } from '../components/helpers';
+
 export const isIOS = () =>
-  [
+  isBrowser() &&
+  ([
     'iPad Simulator',
     'iPhone Simulator',
     'iPod Simulator',
@@ -7,11 +10,11 @@ export const isIOS = () =>
     'iPhone',
     'iPod',
   ].includes(navigator.platform) ||
-  // iPad on iOS 13 detection
-  (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+    // iPad on iOS 13 detection
+    (navigator.userAgent.includes('Mac') && 'ontouchend' in document));
 
 export const isAndroid = () =>
-  navigator.userAgent.toLowerCase().indexOf('android') > -1;
+  isBrowser() && navigator.userAgent.toLowerCase().indexOf('android') > -1;
 
 export const getPlatform = () => {
   if (isIOS()) return 'ios';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import {
   Position,
   PositionBoth,
 } from './services/types';
-import type { View } from './components/utils/MapStateContext';
 
 // Accuracy = 1m, see https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude
 export const roundDeg = (deg) => (deg.toFixed ? deg.toFixed(5) : deg);
@@ -38,15 +37,7 @@ export const getRoundedPosition = (
 export const roundedToDegUrl = ([lon, lat]: LonLatRounded) => `${lat},${lon}`;
 export const roundedToDeg = ([lon, lat]: LonLatRounded) => `${lat}° ${lon}°`;
 
-export const getIdEditorLink = (feature: Feature, view?: View) => {
-  const query = feature?.osmMeta?.id
-    ? `?${feature.osmMeta.type}=${feature.osmMeta.id}`
-    : '';
-  const hash = view ? `#map=${view.join('/')}` : '';
-  return `https://www.openstreetmap.org/edit${query}${hash}`;
-};
-
-export const getUtfStrikethrough = (text) =>
+export const getUtfStrikethrough = (text: string) =>
   text
     .split('')
     .map((char) => `${char}\u0336`)


### PR DESCRIPTION
### Description

On iOS a link to apple maps is added in the feature panel dropdown.
When a satelite layer is used on OsmAPP, Apple Maps will be opened with the satelite layer else with the normal one.

### Example links

Any feature but only on iOS

### Screenshots

<img src="https://github.com/user-attachments/assets/ff109084-d66b-4d50-8d66-b40d353ae942" width="300">
