### PR TITLE
Publictransport: Individual colors for routes on the map

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/routes/useShowOnMap.ts
+++ b/src/components/FeaturePanel/PublicTransport/routes/useShowOnMap.ts
@@ -1,25 +1,65 @@
 import { useEffect } from 'react';
-import { getOverpassSource } from '../../../../services/mapStorage';
+import { getGlobalMap } from '../../../../services/mapStorage';
+import { GeoJSONSource } from 'maplibre-gl';
+import { getBgColor } from './LineNumber';
+
+const SOURCE_NAME = 'publictransport';
+const COLOR_ATTRIBUTE = 'mapColor';
+
+const getPublictransportSource = () => {
+  const map = getGlobalMap();
+  if (!map) {
+    return undefined;
+  }
+
+  if (map.getSource(SOURCE_NAME)) {
+    return map.getSource<GeoJSONSource>(SOURCE_NAME);
+  }
+
+  map.addSource(SOURCE_NAME, {
+    type: 'geojson',
+    data: {
+      type: 'FeatureCollection',
+      features: [],
+    },
+  });
+  map.addLayer({
+    id: `${SOURCE_NAME}-lines`,
+    type: 'line',
+    source: SOURCE_NAME,
+    paint: {
+      'line-color': ['get', COLOR_ATTRIBUTE],
+      'line-width': 4,
+    },
+  });
+
+  return map.getSource<GeoJSONSource>(SOURCE_NAME);
+};
 
 export const useShowOnMap = (
   routes: GeoJSON.FeatureCollection,
   visiblCategories: string[],
 ) => {
   useEffect(() => {
-    if (!routes) {
+    const source = getPublictransportSource();
+    if (!routes || !source) {
       return;
     }
 
-    const filteredRoutes = routes.features.filter(({ properties }) =>
-      visiblCategories.includes(properties.service),
-    );
-    const source = getOverpassSource();
-    source?.setData({
-      type: 'FeatureCollection',
-      features: filteredRoutes,
-    });
+    const filteredRoutes = routes.features
+      .filter(({ properties }) => visiblCategories.includes(properties.service))
+      .map((route) => ({
+        ...route,
+        properties: {
+          ...route.properties,
+          // The light mode color has very low contrast
+          [COLOR_ATTRIBUTE]: getBgColor(route.properties.colour, true),
+        },
+      }));
+
+    source.setData({ type: 'FeatureCollection', features: filteredRoutes });
     return () => {
-      source?.setData({ type: 'FeatureCollection', features: [] });
+      source.setData({ type: 'FeatureCollection', features: [] });
     };
   }, [routes, visiblCategories]);
 };


### PR DESCRIPTION
### Description

- Publictransport routes now use a own source and layer instead of the generic overpass layer
- The routes are colored on the map

### Example links

### Screenshots

![image](https://github.com/user-attachments/assets/282f807b-835c-4ef5-964e-2e792f5a9731)