### PR TITLE
Images: Multiple sources for images from center

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You may [add issues](https://github.com/zbycz/osmapp/issues) here on GitHub, or 
 
 - **clickable map** – poi, cities, localities, ponds (more coming soon)
 - **feature panel** – presets and fields from iD editor
-  - Display multiple images from Wikipedia, Wikidata, Commons, Mapillary, KartaView or Fody
+  - Display multiple images from Wikipedia, Wikidata, Commons, Mapillary, KartaView, Panoramax or Fody
   - Line numbers on public transport stops
   - Runway table on airports
 - **editing** – Save changes with osm login. Insert note for anonymous users.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You may [add issues](https://github.com/zbycz/osmapp/issues) here on GitHub, or 
 
 - **clickable map** – poi, cities, localities, ponds (more coming soon)
 - **feature panel** – presets and fields from iD editor
-  - Display multiple images from Wikipedia, Wikidata, Commons, Mapillary or Fody
+  - Display multiple images from Wikipedia, Wikidata, Commons, Mapillary, KartaView or Fody
   - Line numbers on public transport stops
   - Runway table on airports
 - **editing** – Save changes with osm login. Insert note for anonymous users.

--- a/flake.nix
+++ b/flake.nix
@@ -31,12 +31,15 @@
           yarn
           nodePackages.typescript-language-server
           prettierd
+
+          libuuid # For jest
         ];
         shellHook = ''
           if [ ! -d node_modules ]; then
             echo "Use yarn to install dependencies"
           fi
         '';
+        env = {LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.libuuid];};
       };
     });
   };

--- a/src/components/FeaturePanel/ImagePane/Image/InfoButton.tsx
+++ b/src/components/FeaturePanel/ImagePane/Image/InfoButton.tsx
@@ -16,7 +16,9 @@ const TooltipContent = ({ image }: { image: ImageType }) => (
       <>
         <br />
         <br />
-        {t('featurepanel.uncertain_image')}
+        {t('featurepanel.uncertain_image', {
+          from: image.provider ?? 'Mapillary',
+        })}
       </>
     )}
   </>

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -108,7 +108,7 @@ export default {
   'featurepanel.feature_description_point': 'Karten Koordinaten',
   'featurepanel.show_tags': 'Zeige Tags an',
   'featurepanel.show_objects_around': 'Zeige Orte in der Nähe an',
-  'featurepanel.uncertain_image': 'Dies ist das nächste Street View Bild von Mapillary. Es kann ein anders Objekt zeigen.',
+  'featurepanel.uncertain_image': 'Dies ist das nächste Street View Bild von __from__. Es kann ein anders Objekt zeigen.',
   'featurepanel.inline_edit_title': 'Bearbeiten',
   'featurepanel.objects_around': 'Orte in der Nähe',
   'featurepanel.more_in_openplaceguide': 'Weitere Information auf __instanceName__',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -128,7 +128,7 @@ export default {
   'featurepanel.feature_description_point': 'Map coordinates',
   'featurepanel.show_tags': 'Show tags',
   'featurepanel.show_objects_around': 'Show nearby objects',
-  'featurepanel.uncertain_image': 'This is the closest street view image from Mapillary. It may be inaccurate.',
+  'featurepanel.uncertain_image': 'This is the closest street view image from __from__. It may be inaccurate.',
   'featurepanel.inline_edit_title': 'Edit',
   'featurepanel.objects_around': 'Nearby objects',
   'featurepanel.more_in_openplaceguide': 'More information on __instanceName__',

--- a/src/services/__tests__/osmApi.fixture.ts
+++ b/src/services/__tests__/osmApi.fixture.ts
@@ -37,6 +37,8 @@ export const NODE_FEATURE = {
     amenity: 'library',
   },
   imageDefs: [
+    { type: 'center', service: 'panoramax', center: [14.3904481, 50.103985] },
+    { type: 'center', service: 'kartaview', center: [14.3904481, 50.103985] },
     { type: 'center', service: 'mapillary', center: [14.3904481, 50.103985] },
   ],
 };
@@ -70,7 +72,11 @@ export const WAY_FEATURE = {
   },
   properties: { class: 'school', subclass: 'school' },
   tags: { amenity: 'school' },
-  imageDefs: [{ type: 'center', service: 'mapillary', center: [14, 50] }],
+  imageDefs: [
+    { type: 'center', service: 'panoramax', center: [14, 50] },
+    { type: 'center', service: 'kartaview', center: [14, 50] },
+    { type: 'center', service: 'mapillary', center: [14, 50] },
+  ],
 };
 export const RELATION = {
   elements: [
@@ -134,5 +140,9 @@ export const RELATION_FEATURE = {
     amenity: 'university',
     type: 'multipolygon',
   },
-  imageDefs: [{ type: 'center', service: 'mapillary', center: [15, 51] }],
+  imageDefs: [
+    { type: 'center', service: 'panoramax', center: [15, 51] },
+    { type: 'center', service: 'kartaview', center: [15, 51] },
+    { type: 'center', service: 'mapillary', center: [15, 51] },
+  ],
 };

--- a/src/services/__tests__/osmApi.test.ts
+++ b/src/services/__tests__/osmApi.test.ts
@@ -97,7 +97,11 @@ describe('fetchFeature', () => {
     expect(feature).toMatchObject({
       ...WAY_FEATURE,
       center: [123, 456],
-      imageDefs: [{ type: 'center', service: 'mapillary', center: [123, 456] }],
+      imageDefs: [
+        { type: 'center', service: 'panoramax', center: [123, 456] },
+        { type: 'center', service: 'kartaview', center: [123, 456] },
+        { type: 'center', service: 'mapillary', center: [123, 456] },
+      ],
     });
   });
 });

--- a/src/services/__tests__/osmToFeature.test.ts
+++ b/src/services/__tests__/osmToFeature.test.ts
@@ -50,6 +50,16 @@ const imageDefs: ImageDef[] = [
   },
   {
     type: 'center',
+    service: 'panoramax',
+    center: [14.2523716, 49.6541269],
+  },
+  {
+    type: 'center',
+    service: 'kartaview',
+    center: [14.2523716, 49.6541269],
+  },
+  {
+    type: 'center',
     service: 'mapillary',
     center: [14.2523716, 49.6541269],
   },

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -18,7 +18,7 @@ interface FetchOpts extends RequestInit {
   nocache?: boolean;
 }
 
-export const fetchText = async (url, opts: FetchOpts = {}) => {
+export const fetchText = async (url: string, opts: FetchOpts = {}) => {
   const key = getKey(url, opts);
   const item = getCache(key);
   if (item) return item;

--- a/src/services/getCoordsFeature.ts
+++ b/src/services/getCoordsFeature.ts
@@ -1,3 +1,4 @@
+import { getImagesFromCenter } from './images/getImageDefs';
 import { Feature, LonLatRounded, OsmType } from './types';
 
 export const getCoordsFeature = ([lon, lat]: LonLatRounded): Feature => {
@@ -13,6 +14,6 @@ export const getCoordsFeature = ([lon, lat]: LonLatRounded): Feature => {
     },
     tags: {},
     properties: { class: 'marker', subclass: 'point' },
-    imageDefs: [{ type: 'center', service: 'mapillary', center }],
+    imageDefs: getImagesFromCenter({}, center),
   };
 };

--- a/src/services/images/__tests__/getBearing.test.ts
+++ b/src/services/images/__tests__/getBearing.test.ts
@@ -1,5 +1,5 @@
 import { Position } from '../../types';
-import { getBearing } from '../getMapillaryImage';
+import { getBearing } from '../getImageFromCenterFactory';
 
 jest.mock('maplibre-gl', () => ({}));
 

--- a/src/services/images/__tests__/getImageDefs.test.ts
+++ b/src/services/images/__tests__/getImageDefs.test.ts
@@ -57,6 +57,16 @@ test('conversion', () => {
     },
     {
       type: 'center',
+      service: 'panoramax',
+      center: [14, 50],
+    },
+    {
+      type: 'center',
+      service: 'kartaview',
+      center: [14, 50],
+    },
+    {
+      type: 'center',
       service: 'mapillary',
       center: [14, 50],
     },

--- a/src/services/images/__tests__/getImageFromApi.test.ts
+++ b/src/services/images/__tests__/getImageFromApi.test.ts
@@ -41,6 +41,7 @@ test('ImageFromCenter - mapillary', async () => {
     imageUrl: 'mapillary_url_1024',
     link: '321151246189360',
     linkUrl: 'https://www.mapillary.com/app/?focus=photo&pKey=321151246189360',
+    provider: 'Mapillary',
     uncertainImage: true,
     panoramaUrl: 'mapillary_url_original',
   });

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -20,6 +20,7 @@ export type ImageType = {
   uncertainImage?: true;
   sameUrlResolvedAlsoFrom?: ImageType[]; // only 1 level
   panoramaUrl?: string; // only for Mapillary (ImageDefFromCenter)
+  provider?: string;
 };
 
 const getSuffix = (y: string) => {
@@ -110,15 +111,22 @@ const getImagesFromTags = (tags: FeatureTags) => {
     .sort((a, b) => +b.instant - +a.instant);
 };
 
-const getImagesFromCenter = (tags: FeatureTags, center?: LonLat): ImageDef[] =>
-  !center
-    ? []
-    : [
-        ...(tags.information
-          ? [{ type: 'center', service: 'fody', center } as ImageDefFromCenter]
-          : []),
-        { type: 'center', service: 'mapillary', center } as ImageDefFromCenter,
-      ];
+const getImagesFromCenter = (
+  tags: FeatureTags,
+  center?: LonLat,
+): ImageDef[] => {
+  if (!center) {
+    return [];
+  }
+  return [
+    ...(tags.information
+      ? [{ type: 'center', service: 'fody', center } as ImageDefFromCenter]
+      : []),
+    { type: 'center', service: 'kartaview', center } as ImageDefFromCenter,
+    // it is annoying to scroll past a pano image - so we put it last
+    { type: 'center', service: 'mapillary', center } as ImageDefFromCenter,
+  ];
+};
 
 export const getImageDefs = (tags: FeatureTags, center?: LonLat) => [
   ...getImagesFromTags(tags),

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -122,6 +122,7 @@ const getImagesFromCenter = (
     ...(tags.information
       ? [{ type: 'center', service: 'fody', center } as ImageDefFromCenter]
       : []),
+    { type: 'center', service: 'panoramax', center } as ImageDefFromCenter,
     { type: 'center', service: 'kartaview', center } as ImageDefFromCenter,
     // it is annoying to scroll past a pano image - so we put it last
     { type: 'center', service: 'mapillary', center } as ImageDefFromCenter,

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -111,7 +111,7 @@ const getImagesFromTags = (tags: FeatureTags) => {
     .sort((a, b) => +b.instant - +a.instant);
 };
 
-const getImagesFromCenter = (
+export const getImagesFromCenter = (
   tags: FeatureTags,
   center?: LonLat,
 ): ImageDef[] => {

--- a/src/services/images/getImageFromApi.ts
+++ b/src/services/images/getImageFromApi.ts
@@ -6,6 +6,7 @@ import { getInstantImage, WIDTH, ImageType } from './getImageDefs';
 import { encodeUrl } from '../../helpers/utils';
 import { getCommonsImageUrl } from './getCommonsImageUrl';
 import { getKartaViewImage } from './getkartaViewImage';
+import { getPanoramaxImage } from './getPanoramaxImage';
 
 type ImagePromise = Promise<ImageType | null>;
 
@@ -116,6 +117,9 @@ export const getImageFromApiRaw = async (def: ImageDef): ImagePromise => {
     }
     if (service === 'kartaview') {
       return getKartaViewImage(center);
+    }
+    if (service === 'panoramax') {
+      return getPanoramaxImage(center);
     }
 
     if (service === 'fody') {

--- a/src/services/images/getImageFromApi.ts
+++ b/src/services/images/getImageFromApi.ts
@@ -5,6 +5,7 @@ import { getFodyImage } from './getFodyImage';
 import { getInstantImage, WIDTH, ImageType } from './getImageDefs';
 import { encodeUrl } from '../../helpers/utils';
 import { getCommonsImageUrl } from './getCommonsImageUrl';
+import { getKartaViewImage } from './getkartaViewImage';
 
 type ImagePromise = Promise<ImageType | null>;
 
@@ -112,6 +113,9 @@ export const getImageFromApiRaw = async (def: ImageDef): ImagePromise => {
     const { service, center } = def;
     if (service === 'mapillary') {
       return getMapillaryImage(center);
+    }
+    if (service === 'kartaview') {
+      return getKartaViewImage(center);
     }
 
     if (service === 'fody') {

--- a/src/services/images/getImageFromCenter.ts
+++ b/src/services/images/getImageFromCenter.ts
@@ -1,0 +1,73 @@
+import { Position } from '../types';
+import { ImageType } from './getImageDefs';
+
+const getBearing = ([aX, aY]: Position, [bX, bY]: Position): number => {
+  const angle = (Math.atan2(bX - aX, bY - aY) * 180) / Math.PI;
+  return angle < 0 ? angle + 360 : angle;
+};
+
+const subtractAngle = (a: number, b: number): number =>
+  Math.min(Math.abs(a - b), a - b + 360);
+
+type ImageProvider<T> = {
+  getImages: (pos: Position) => Promise<T[]>;
+  getImageCoords: (img: T) => Position;
+  getImageAngle: (img: T) => number;
+  isPano: (img: T) => boolean;
+  getImageUrl: (img: T) => string;
+  getImageDate: (img: T) => Date;
+  getImageLink: (img: T) => string;
+  getImageLinkUrl: (img: T) => string;
+  getPanoUrl: (img: T) => string;
+};
+
+export const getImageFromCenterFactory =
+  <T>(
+    provider: string,
+    {
+      getImages,
+      getImageCoords,
+      getImageAngle,
+      isPano,
+      getImageUrl,
+      getImageDate,
+      getImageLink,
+      getImageLinkUrl,
+      getPanoUrl,
+    }: ImageProvider<T>,
+  ) =>
+  async (poiCoords: Position): Promise<ImageType | null> => {
+    const apiImages = await getImages(poiCoords);
+    if (!apiImages.length) {
+      return null;
+    }
+
+    const photos = apiImages.map((pic) => {
+      const photoCoords = getImageCoords(pic);
+      return {
+        ...pic,
+        angleFromPhotoToPoi: getBearing(photoCoords, poiCoords),
+        deviationFromStraightSight: subtractAngle(
+          getBearing(photoCoords, poiCoords),
+          getImageAngle(pic),
+        ),
+      };
+    });
+
+    const panos = photos.filter(isPano);
+    const sorted = (panos.length ? panos : photos).sort(
+      (a, b) => a.deviationFromStraightSight - b.deviationFromStraightSight,
+    );
+
+    const imageToUse = sorted[0];
+
+    return {
+      provider,
+      imageUrl: getImageUrl(imageToUse),
+      description: `${provider} image from ${getImageDate(imageToUse).toLocaleString()}`,
+      linkUrl: getImageLinkUrl(imageToUse),
+      link: getImageLink(imageToUse),
+      uncertainImage: true,
+      panoramaUrl: isPano(imageToUse) ? getPanoUrl(imageToUse) : undefined,
+    };
+  };

--- a/src/services/images/getImageFromCenter.ts
+++ b/src/services/images/getImageFromCenter.ts
@@ -12,7 +12,7 @@ const subtractAngle = (a: number, b: number): number =>
 type ImageProvider<T> = {
   getImages: (pos: Position) => Promise<T[]>;
   getImageCoords: (img: T) => Position;
-  getImageAngle: (img: T) => number;
+  getImageAngle: (img: T) => number | undefined;
   isPano: (img: T) => boolean;
   getImageUrl: (img: T) => string;
   getImageDate: (img: T) => Date;
@@ -44,13 +44,14 @@ export const getImageFromCenterFactory =
 
     const photos = apiImages.map((pic) => {
       const photoCoords = getImageCoords(pic);
+      const angle = getImageAngle(pic);
       return {
         ...pic,
         angleFromPhotoToPoi: getBearing(photoCoords, poiCoords),
-        deviationFromStraightSight: subtractAngle(
-          getBearing(photoCoords, poiCoords),
-          getImageAngle(pic),
-        ),
+        deviationFromStraightSight:
+          angle === undefined
+            ? Infinity
+            : subtractAngle(getBearing(photoCoords, poiCoords), angle),
       };
     });
 

--- a/src/services/images/getImageFromCenterFactory.ts
+++ b/src/services/images/getImageFromCenterFactory.ts
@@ -1,7 +1,7 @@
 import { Position } from '../types';
 import { ImageType } from './getImageDefs';
 
-const getBearing = ([aX, aY]: Position, [bX, bY]: Position): number => {
+export const getBearing = ([aX, aY]: Position, [bX, bY]: Position): number => {
   const angle = (Math.atan2(bX - aX, bY - aY) * 180) / Math.PI;
   return angle < 0 ? angle + 360 : angle;
 };

--- a/src/services/images/getMapillaryImage.ts
+++ b/src/services/images/getMapillaryImage.ts
@@ -1,101 +1,49 @@
-import maplibregl from 'maplibre-gl';
 import { fetchJson } from '../fetch';
-import { Position } from '../types';
-import { getGlobalMap } from '../mapStorage';
-import { ImageType } from './getImageDefs';
+import { getImageFromCenterFactory } from './getImageFromCenter';
 
-const subtractAngle = (a: number, b: number): number =>
-  Math.min(Math.abs(a - b), a - b + 360);
-
-export const getBearing = ([aX, aY]: Position, [bX, bY]: Position): number => {
-  const angle = (Math.atan2(bX - aX, bY - aY) * 180) / Math.PI;
-  return angle < 0 ? angle + 360 : angle;
-};
-
-const debugOutput = (sorted) => {
-  if (global?.window?.localStorage.getItem('debug_mapillary')) {
-    console.log('Sorted photos:', sorted); // eslint-disable-line no-console
-    sorted.forEach((item) => {
-      new maplibregl.Marker({ rotation: item.compass_angle })
-        .setLngLat(
-          item.computed_geometry?.coordinates ?? item.geometry.coordinates,
-        )
-        .addTo(getGlobalMap());
-    });
-    new maplibregl.Marker({ rotation: sorted[0].compass_angle, color: '#f55' })
-      .setLngLat(
-        sorted[0].computed_geometry?.coordinates ??
-          sorted[0].geometry.coordinates,
-      )
-      .addTo(getGlobalMap());
-  }
+type MapillaryImage = {
+  compass_angle: number;
+  computed_geometry: {
+    type: string;
+    coordinates: number[];
+  };
+  geometry: {
+    type: string;
+    coordinates: number[];
+  };
+  captured_at: number;
+  thumb_1024_url: string;
+  thumb_original_url: string;
+  is_pano: boolean;
+  id: string;
 };
 
 type MapillaryResponse = {
-  data: {
-    compass_angle: number;
-    computed_geometry: {
-      type: string;
-      coordinates: number[];
-    };
-    geometry: {
-      type: string;
-      coordinates: number[];
-    };
-    captured_at: number;
-    thumb_1024_url: string;
-    thumb_original_url: string;
-    is_pano: boolean;
-    id: string;
-  }[];
+  data: MapillaryImage[];
 };
 
-export const getMapillaryImage = async (
-  poiCoords: Position,
-): Promise<ImageType | null> => {
-  // https://www.mapillary.com/developer/api-documentation/#image
-  const bbox = [
-    poiCoords[0] - 0.0004, // left, bottom, right, top (or minLon, minLat, maxLon, maxLat)
-    poiCoords[1] - 0.0004,
-    poiCoords[0] + 0.0004,
-    poiCoords[1] + 0.0004,
-  ];
-  // consider computed_compass_angle - but it is zero for many images, so we would have to fallback to compass_angle
-  const url = `https://graph.mapillary.com/images?access_token=MLY|4742193415884187|44e43b57d0211d8283a7ca1c3e6a63f2&fields=compass_angle,computed_geometry,geometry,captured_at,thumb_1024_url,thumb_original_url,is_pano&bbox=${bbox}`;
-  const { data } = await fetchJson<MapillaryResponse>(url);
-
-  if (!data.length) {
-    return null;
-  }
-
-  const photos = data.map((item) => {
-    const photoCoords =
-      item.computed_geometry?.coordinates ?? item.geometry.coordinates;
-    const angleFromPhotoToPoi = getBearing(photoCoords, poiCoords);
-    const deviationFromStraightSight = subtractAngle(
-      angleFromPhotoToPoi,
-      item.compass_angle,
-    );
-    return { ...item, angleFromPhotoToPoi, deviationFromStraightSight };
-  });
-
-  const panos = photos.filter((pic) => pic.is_pano);
-  const sorted = (panos.length ? panos : photos).sort(
-    (a, b) => a.deviationFromStraightSight - b.deviationFromStraightSight,
-  );
-
-  debugOutput(sorted);
-
-  const imageToUse = sorted[0]; // it is save to assume that it has at least one element
-  const timestamp = new Date(imageToUse.captured_at).toLocaleString();
-  const isPano = imageToUse.is_pano;
-
-  return {
-    imageUrl: imageToUse.thumb_1024_url,
-    description: `Mapillary image from ${timestamp}`,
-    linkUrl: `https://www.mapillary.com/app/?focus=photo&pKey=${sorted[0].id}`,
-    link: sorted[0].id,
-    uncertainImage: true,
-    panoramaUrl: isPano ? imageToUse.thumb_original_url : undefined,
-  };
-};
+export const getMapillaryImage = getImageFromCenterFactory('Mapillary', {
+  getImages: async (poiCoords) => {
+    // https://www.mapillary.com/developer/api-documentation/#image
+    const bbox = [
+      poiCoords[0] - 0.0004, // left, bottom, right, top (or minLon, minLat, maxLon, maxLat)
+      poiCoords[1] - 0.0004,
+      poiCoords[0] + 0.0004,
+      poiCoords[1] + 0.0004,
+    ];
+    // consider computed_compass_angle - but it is zero for many images, so we would have to fallback to compass_angle
+    const url = `https://graph.mapillary.com/images?access_token=MLY|4742193415884187|44e43b57d0211d8283a7ca1c3e6a63f2&fields=compass_angle,computed_geometry,geometry,captured_at,thumb_1024_url,thumb_original_url,is_pano&bbox=${bbox}`;
+    const { data } = await fetchJson<MapillaryResponse>(url);
+    return data;
+  },
+  getImageCoords: ({ computed_geometry, geometry }) =>
+    computed_geometry?.coordinates ?? geometry.coordinates,
+  getImageAngle: ({ compass_angle }) => compass_angle,
+  isPano: ({ is_pano }) => is_pano,
+  getImageUrl: ({ thumb_1024_url }) => thumb_1024_url,
+  getImageDate: ({ captured_at }) => new Date(captured_at),
+  getImageLink: ({ id }) => id,
+  getImageLinkUrl: ({ id }) =>
+    `https://www.mapillary.com/app/?focus=photo&pKey=${id}`,
+  getPanoUrl: ({ thumb_original_url }) => thumb_original_url,
+});

--- a/src/services/images/getMapillaryImage.ts
+++ b/src/services/images/getMapillaryImage.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from '../fetch';
-import { getImageFromCenterFactory } from './getImageFromCenter';
+import { getImageFromCenterFactory } from './getImageFromCenterFactory';
 
 type MapillaryImage = {
   compass_angle: number;

--- a/src/services/images/getPanoramaxImage.ts
+++ b/src/services/images/getPanoramaxImage.ts
@@ -1,5 +1,5 @@
 import { fetchJson } from '../fetch';
-import { getImageFromCenterFactory } from './getImageFromCenter';
+import { getImageFromCenterFactory } from './getImageFromCenterFactory';
 
 type PanoramaxImage = {
   id: string;

--- a/src/services/images/getPanoramaxImage.ts
+++ b/src/services/images/getPanoramaxImage.ts
@@ -1,0 +1,37 @@
+import { fetchJson } from '../fetch';
+import { getImageFromCenterFactory } from './getImageFromCenter';
+
+type PanoramaxImage = {
+  id: string;
+  assets: Record<'hd' | 'sd' | 'thumb', { href: string }>;
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  properties: {
+    datetime: string;
+    'view:azimuth': number;
+  };
+};
+
+type PanoramaxResponse = {
+  features: PanoramaxImage[];
+};
+
+export const getPanoramaxImage = getImageFromCenterFactory('Panoramax', {
+  getImages: async (poiCoords) => {
+    const apiResponse = await fetchJson<PanoramaxResponse>(
+      `https://api.panoramax.xyz/api/search?place_position=${poiCoords[0]},${poiCoords[1]}&place_distance=3-40&place_fov_tolerance=50`,
+    );
+    return apiResponse.features;
+  },
+  getImageCoords: ({ geometry }) => geometry.coordinates,
+  getImageAngle: ({ properties }) => properties['view:azimuth'],
+  isPano: () => false,
+  getImageUrl: ({ assets }) => assets.sd.href,
+  getImageDate: ({ properties }) => new Date(properties.datetime),
+  getImageLink: ({ id }) => id,
+  getImageLinkUrl: ({ id, geometry }) =>
+    `https://api.panoramax.xyz/#focus=pic&map=17.44/${geometry.coordinates[0]}/${geometry.coordinates[0]}&pic=${id}`,
+  getPanoUrl: ({ assets }) => assets.hd.href,
+});

--- a/src/services/images/getkartaViewImage.ts
+++ b/src/services/images/getkartaViewImage.ts
@@ -1,6 +1,6 @@
 import { parseInt } from 'lodash';
 import { fetchJson } from '../fetch';
-import { getImageFromCenterFactory } from './getImageFromCenter';
+import { getImageFromCenterFactory } from './getImageFromCenterFactory';
 
 const KARTAVIEW_BASE = 'https://kartaview.org';
 

--- a/src/services/images/getkartaViewImage.ts
+++ b/src/services/images/getkartaViewImage.ts
@@ -1,0 +1,69 @@
+import { parseInt } from 'lodash';
+import { fetchJson } from '../fetch';
+import { getImageFromCenterFactory } from './getImageFromCenter';
+
+const KARTAVIEW_BASE = 'https://kartaview.org';
+
+type KartaViewResponse = {
+  currentPageItems: KartaViewImage[];
+  totalFilteredItems: [string];
+};
+
+type KartaViewImage = {
+  id: string;
+  sequence_id: string;
+  sequence_index: string;
+  orgCode: string;
+  lat: string;
+  lng: string;
+  field_of_view: any;
+  name: string;
+  lth_name: string;
+  th_name: string;
+  date_added: string;
+  timestamp: string;
+  match_segment_id: any;
+  match_lat: string;
+  match_lng: string;
+  way_id: string;
+  shot_date: string;
+  heading: string;
+  headers: any;
+  gps_accuracy: any;
+  projection: string;
+  username: string;
+};
+
+export const getKartaViewImage = getImageFromCenterFactory('KartaView', {
+  getImages: async (poiCoords) => {
+    const bbox = {
+      left: poiCoords[0] - 0.0004,
+      bottom: poiCoords[1] - 0.0004,
+      right: poiCoords[0] + 0.0004,
+      top: poiCoords[1] + 0.0004,
+    };
+
+    const apiImages = await fetchJson<KartaViewResponse>(
+      `${KARTAVIEW_BASE}/1.0/list/nearby-photos/`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          ipp: '40',
+          page: '1',
+          bbTopLeft: `${bbox.top},${bbox.left}`,
+          bbBottomRight: `${bbox.bottom},${bbox.right}`,
+        }),
+      },
+    );
+    return apiImages.currentPageItems;
+  },
+  getImageCoords: ({ lng, lat }) => [parseInt(lng), parseInt(lat)],
+  getImageAngle: ({ heading }) => parseInt(heading),
+  isPano: () => false,
+  getImageUrl: ({ name }) => `${KARTAVIEW_BASE}/${name}`,
+  getImageDate: ({ timestamp }) => new Date(parseInt(timestamp) * 1000),
+  getImageLink: ({ id }) => id,
+  getImageLinkUrl: ({ sequence_id, sequence_index }) =>
+    `https://kartaview.org/details/${sequence_id}/${sequence_index}`,
+  getPanoUrl: () => '',
+});

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -22,7 +22,7 @@ export type ImageDefFromTag = {
 };
 export type ImageDefFromCenter = {
   type: 'center';
-  service: 'mapillary' | 'fody' | 'kartaview';
+  service: 'mapillary' | 'fody' | 'kartaview' | 'panoramax';
   center: LonLat;
 };
 export type ImageDef = ImageDefFromTag | ImageDefFromCenter;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -22,7 +22,7 @@ export type ImageDefFromTag = {
 };
 export type ImageDefFromCenter = {
   type: 'center';
-  service: 'mapillary' | 'fody';
+  service: 'mapillary' | 'fody' | 'kartaview';
   center: LonLat;
 };
 export type ImageDef = ImageDefFromTag | ImageDefFromCenter;


### PR DESCRIPTION
### Description

As discussed in #517 this implements kartaview and panoramax.

The kartaview url needs to be special and doesn't go to kartaview.org but to openstreetcam; I should definitely also open a pr at the iD editor as it has this bug.

### Example links

[Spicy's Gewürzmuseum, Hamburg](https://osmapp-dvhomadx0-osm-app-team.vercel.app/node/301998423#17.47/53.5427/9.9863)

### Screenshots

![image](https://github.com/user-attachments/assets/d291726a-75c3-4544-b2ae-0591dbede353)

