### PR TITLE
Images: Use panellum for panoramax and kartaview panoramas

### DIFF
--- a/src/services/images/getPanoramaxImage.ts
+++ b/src/services/images/getPanoramaxImage.ts
@@ -11,6 +11,9 @@ type PanoramaxImage = {
   properties: {
     datetime: string;
     'view:azimuth': number;
+    'pers:interior_orientation': {
+      field_of_view: number;
+    };
   };
 };
 
@@ -27,7 +30,8 @@ export const getPanoramaxImage = getImageFromCenterFactory('Panoramax', {
   },
   getImageCoords: ({ geometry }) => geometry.coordinates,
   getImageAngle: ({ properties }) => properties['view:azimuth'],
-  isPano: () => false,
+  isPano: ({ properties }) =>
+    properties['pers:interior_orientation'].field_of_view === 360,
   getImageUrl: ({ assets }) => assets.sd.href,
   getImageDate: ({ properties }) => new Date(properties.datetime),
   getImageLink: ({ id }) => id,

--- a/src/services/images/getkartaViewImage.ts
+++ b/src/services/images/getkartaViewImage.ts
@@ -16,7 +16,7 @@ type KartaViewImage = {
   orgCode: string;
   lat: string;
   lng: string;
-  field_of_view: any;
+  field_of_view: string | null;
   name: string;
   lth_name: string;
   th_name: string;
@@ -60,7 +60,7 @@ export const getKartaViewImage = getImageFromCenterFactory('KartaView', {
   },
   getImageCoords: ({ lng, lat }) => [parseInt(lng), parseInt(lat)],
   getImageAngle: ({ heading }) => (heading ? parseInt(heading) : undefined),
-  isPano: () => false,
+  isPano: ({ field_of_view }) => field_of_view === '360',
   getImageUrl: ({ lth_name }) => {
     const [storage, uri] = lth_name.split(/\/(.*)/);
     return `https://${storage}.openstreetcam.org/${uri}`;
@@ -69,5 +69,8 @@ export const getKartaViewImage = getImageFromCenterFactory('KartaView', {
   getImageLink: ({ id }) => id,
   getImageLinkUrl: ({ sequence_id, sequence_index }) =>
     `https://kartaview.org/details/${sequence_id}/${sequence_index}`,
-  getPanoUrl: () => '',
+  getPanoUrl: ({ name }) => {
+    const [storage, uri] = name.split(/\/(.*)/);
+    return `https://${storage}.openstreetcam.org/${uri}`;
+  },
 });


### PR DESCRIPTION
### Description

@kudlav noticed that 360° panoramas from panoramax aren't displayed using the panellum viewer.
This fixes that for KartaView and panoramax

### Example links

https://osmapp.org/node/2087588051
https://osmapp.org/node/451558193

### Screenshots

![image](https://github.com/user-attachments/assets/26577628-a94f-4c41-a208-1b3e003d9eba)