### PR TITLE
Search: Query wizard like overpass searches

### DIFF
--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -25,16 +25,16 @@ const overpassOptionSelected = (
   bbox: Bbox,
   showToast: ShowToast,
 ) => {
-  const tagsOrQuery =
+  const astOrQuery =
     option.type === 'preset'
       ? option.preset?.presetForSearch.tags
-      : (option.overpass.tags ?? option.overpass.query);
+      : (option.overpass.ast ?? option.overpass.query);
 
   const timeout = setTimeout(() => {
     setOverpassLoading(true);
   }, 300);
 
-  performOverpassSearch(bbox, tagsOrQuery)
+  performOverpassSearch(bbox, astOrQuery)
     .then((geojson) => {
       const count = geojson.features.length;
       const content = t('searchbox.overpass_success', { count });

--- a/src/components/SearchBox/options/overpass.tsx
+++ b/src/components/SearchBox/options/overpass.tsx
@@ -4,6 +4,7 @@ import { Grid, Typography } from '@mui/material';
 import type { OverpassOption } from '../types';
 import { t } from '../../../services/intl';
 import { IconPart } from '../utils';
+import { getAST, queryWizardLabel } from '../queryWizard/queryWizard';
 
 const OVERPASS_HISTORY_KEY = 'overpassQueryHistory';
 
@@ -40,19 +41,19 @@ export const getOverpassOptions = (inputValue: string): OverpassOption[] => {
     ];
   }
 
-  if (inputValue.match(/^[-:_a-zA-Z0-9]+=/)) {
-    const [key, value] = inputValue.split('=', 2);
+  try {
+    const ast = getAST(inputValue);
     return [
       {
         type: 'overpass',
         overpass: {
-          tags: { [key]: value || '*' },
-          label: `${key}=${value || '*'}`,
+          ast,
           inputValue,
+          label: queryWizardLabel(ast),
         },
       },
     ];
-  }
+  } catch {}
 
   return [];
 };

--- a/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
+++ b/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
@@ -1,0 +1,87 @@
+import { generateQuery } from '../generateQuery';
+import { getAST, queryWizardLabel } from '../queryWizard';
+
+describe('userInput -> query works', () => {
+  it('should work for simple queries', () => {
+    expect(generateQuery(getAST('amenity=bench'))).toBe(
+      'nwr["amenity"="bench"]',
+    );
+    expect(generateQuery(getAST('amenity=*'))).toBe('nwr["amenity"]');
+    expect(generateQuery(getAST('"amenity"="*"'))).toBe('nwr["amenity"="*"]');
+    expect(generateQuery(getAST('"name"    = "multiple words =)"'))).toBe(
+      'nwr["name"="multiple words =)"]',
+    );
+    expect(generateQuery(getAST('   diet:vegan=no '))).toBe(
+      'nwr["diet:vegan"="no"]',
+    );
+  });
+
+  it('should work for more complex queries', () => {
+    expect(generateQuery(getAST('tourism=museum and fee = no'))).toBe(
+      'nwr["tourism"="museum"]["fee"="no"]',
+    );
+    expect(generateQuery(getAST('amenity=restaurant or amenity = cafe'))).toBe(
+      'nwr["amenity"="restaurant"];nwr["amenity"="cafe"]',
+    );
+
+    expect(
+      generateQuery(getAST('tourism=museum and fee = no and museum=art')),
+    ).toBe('nwr["tourism"="museum"]["fee"="no"]["museum"="art"]');
+    expect(
+      generateQuery(
+        getAST('amenity=restaurant or amenity = cafe or historic=*'),
+      ),
+    ).toBe('nwr["amenity"="restaurant"];nwr["amenity"="cafe"];nwr["historic"]');
+  });
+
+  it('should work with groups', () => {
+    expect(
+      generateQuery(
+        getAST(
+          '(tourism=museum and fee = no) or (historic=castle and wikipedia=*)',
+        ),
+      ),
+    ).toBe(
+      'nwr["tourism"="museum"]["fee"="no"];nwr["historic"="castle"]["wikipedia"]',
+    );
+
+    expect(
+      generateQuery(
+        getAST(
+          '(tourism=museum or natural = tree) and (building=yes or height=*)',
+        ),
+      ),
+    ).toBe(
+      'nwr["tourism"="museum"]["building"="yes"];nwr["tourism"="museum"]["height"];nwr["natural"="tree"]["building"="yes"];nwr["natural"="tree"]["height"]',
+    );
+  });
+
+  it('should not work with invalid userInput', () => {
+    expect(() => generateQuery(getAST('amenity'))).toThrow(Error);
+    expect(() => generateQuery(getAST('amenity='))).toThrow(Error);
+    expect(() => generateQuery(getAST('amenity=* and'))).toThrow(Error);
+    expect(() =>
+      generateQuery(getAST('amenity=* and historic=* or natural=*')),
+    ).toThrow(Error);
+    expect(() => generateQuery(getAST('amenity=|*'))).toThrow(Error);
+  });
+});
+
+test('userInput (ast) -> label works', () => {
+  expect(queryWizardLabel(getAST('amenity=*'))).toBe('amenity=*');
+  expect(queryWizardLabel(getAST('amenity=bench'))).toBe('amenity=bench');
+  expect(queryWizardLabel(getAST('amenity=bench or speed_limit=30'))).toBe(
+    'amenity=bench or 1 other',
+  );
+  expect(queryWizardLabel(getAST('amenity=bench and material=wood'))).toBe(
+    'amenity=bench and 1 other',
+  );
+  expect(
+    queryWizardLabel(
+      getAST('(amenity=bench or aeroway=runway) and wikipedia=*'),
+    ),
+  ).toBe('2 with and combined expressions');
+  expect(queryWizardLabel(getAST('(amenity=bench or aeroway=runway)'))).toBe(
+    'amenity=bench or 1 other',
+  );
+});

--- a/src/components/SearchBox/queryWizard/ast.ts
+++ b/src/components/SearchBox/queryWizard/ast.ts
@@ -1,0 +1,104 @@
+import { Token, Operator } from './tokens';
+
+export type ASTNodeComparison = {
+  type: 'comparison';
+  key: string;
+  value: string;
+  operator: '=';
+};
+
+export type ASTNodeGroup = { type: 'group'; expression: ASTNode };
+
+export type ASTNodeExpression = {
+  type: 'expression';
+  operator: Operator;
+  expressions: ASTNode[];
+};
+
+export type ASTNode = ASTNodeExpression | ASTNodeComparison | ASTNodeGroup;
+
+const parseString = (tokens: Token[]) => {
+  const [keyToken, operatorToken, valueToken] = tokens;
+
+  if (operatorToken?.type !== 'operator') {
+    throw new Error('Expected an operator (like `=`) after key');
+  }
+  if (valueToken?.type !== 'string') {
+    throw new Error('Expected a value after "="');
+  }
+
+  return [
+    {
+      type: 'comparison',
+      key: keyToken.value,
+      value: valueToken.value,
+      operator: operatorToken.value,
+    },
+    3,
+  ] as const;
+};
+
+const parseTokens = (
+  tokens: Token[],
+  startIndex: number = 0,
+): [ASTNode, number] => {
+  const expressions: ASTNode[] = [];
+  let operator: Operator | null = null;
+  let i = startIndex;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+
+    switch (token.type) {
+      case 'string': {
+        const [expression, indexIncrease] = parseString(tokens.slice(i));
+
+        expressions.push(expression);
+        i += indexIncrease;
+        break;
+      }
+
+      case 'logical': {
+        if (operator && operator !== token.value) {
+          throw new Error(
+            `Mixed logical operators (${operator} and ${token.value}) are not supported`,
+          );
+        }
+        operator = token.value;
+        i++;
+        break;
+      }
+
+      case 'bracket': {
+        switch (token.value) {
+          case 'opening':
+            const [groupExpression, nextIndex] = parseTokens(tokens, i + 1);
+            expressions.push({ type: 'group', expression: groupExpression });
+            i = nextIndex;
+            break;
+          case 'closing':
+            return [
+              operator
+                ? { type: 'expression', operator, expressions }
+                : expressions[0],
+              i + 1,
+            ];
+        }
+        break;
+      }
+
+      default:
+        throw new Error(`Unexpected token type: ${token.type}`);
+    }
+  }
+
+  return [
+    operator ? { type: 'expression', operator, expressions } : expressions[0],
+    i,
+  ];
+};
+
+export const generateAst = (tokens: Token[]): ASTNode => {
+  const [node] = parseTokens(tokens);
+  return node;
+};

--- a/src/components/SearchBox/queryWizard/ast.ts
+++ b/src/components/SearchBox/queryWizard/ast.ts
@@ -21,7 +21,7 @@ export type ASTNodeExpression = {
 
 export type ASTNode = ASTNodeExpression | ASTNodeComparison | ASTNodeGroup;
 
-const parseString = (tokens: Token[]) => {
+const parseString = (tokens: Token[]): [ASTNodeComparison, number] => {
   const [keyToken, operatorToken, valueToken] = tokens;
 
   if (keyToken?.type !== 'string') {
@@ -43,7 +43,7 @@ const parseString = (tokens: Token[]) => {
       operator: operatorToken.value,
     },
     3,
-  ] as const;
+  ];
 };
 
 const parseTokens = (
@@ -98,6 +98,11 @@ const parseTokens = (
       default:
         throw new Error(`Unexpected token type: ${token.type}`);
     }
+  }
+
+  if (operator && expressions.length <= 1) {
+    const msg = `${operator} needs at least two expressions but only ${expressions.length} were provided`;
+    throw new Error(msg);
   }
 
   return [

--- a/src/components/SearchBox/queryWizard/ast.ts
+++ b/src/components/SearchBox/queryWizard/ast.ts
@@ -1,9 +1,13 @@
 import { Token, Operator } from './tokens';
 
+// When adding a ASTNode or SpecialValue also add it to `isAst`
+
+export type SpecialValue = { type: 'anything' };
+
 export type ASTNodeComparison = {
   type: 'comparison';
   key: string;
-  value: string;
+  value: SpecialValue | string;
   operator: '=';
 };
 
@@ -20,10 +24,13 @@ export type ASTNode = ASTNodeExpression | ASTNodeComparison | ASTNodeGroup;
 const parseString = (tokens: Token[]) => {
   const [keyToken, operatorToken, valueToken] = tokens;
 
+  if (keyToken?.type !== 'string') {
+    throw new Error('Expected an operator (like `=`) after key');
+  }
   if (operatorToken?.type !== 'operator') {
     throw new Error('Expected an operator (like `=`) after key');
   }
-  if (valueToken?.type !== 'string') {
+  if (!(valueToken.type === 'string' || valueToken.type === 'anything')) {
     throw new Error('Expected a value after "="');
   }
 
@@ -31,7 +38,8 @@ const parseString = (tokens: Token[]) => {
     {
       type: 'comparison',
       key: keyToken.value,
-      value: valueToken.value,
+      value:
+        valueToken.type === 'string' ? valueToken.value : { type: 'anything' },
       operator: operatorToken.value,
     },
     3,

--- a/src/components/SearchBox/queryWizard/generateQuery.ts
+++ b/src/components/SearchBox/queryWizard/generateQuery.ts
@@ -1,7 +1,43 @@
-import { ASTNode } from './ast';
+import { ASTNode, ASTNodeComparison, ASTNodeExpression } from './ast';
 
-// TODO: Implement it
+const processNode = (node: ASTNode): string[][] => {
+  switch (node.type) {
+    case 'comparison':
+      return [[generateComparison(node)]];
+    case 'group':
+      return processNode(node.expression);
+    case 'expression':
+      return generateExpression(node);
+  }
+};
 
-export const generateQuery = (ast: ASTNode) => {
-  return 'relation';
+const generateComparison = ({ key, value, operator }: ASTNodeComparison) => {
+  // Using switch to simplify adding more operators in the future
+  switch (operator) {
+    case '=':
+      return `["${key}"="${value}"]`;
+  }
+};
+
+const generateExpression = (node: ASTNodeExpression): string[][] => {
+  const subExpressions = node.expressions.map(processNode);
+
+  if (node.operator === 'and') {
+    return subExpressions.reduce(
+      (acc, exprGroup) =>
+        acc.flatMap((accGroup) =>
+          exprGroup.map((expr) => [...accGroup, ...expr]),
+        ),
+      [[]],
+    );
+  }
+  if (node.operator === 'or') {
+    return subExpressions.flat();
+  }
+};
+
+export const generateQuery = (ast: ASTNode): string => {
+  return processNode(ast)
+    .map((p) => `nwr${p.join('')}`)
+    .join(';');
 };

--- a/src/components/SearchBox/queryWizard/generateQuery.ts
+++ b/src/components/SearchBox/queryWizard/generateQuery.ts
@@ -15,7 +15,8 @@ const generateComparison = ({ key, value, operator }: ASTNodeComparison) => {
   // Using switch to simplify adding more operators in the future
   switch (operator) {
     case '=':
-      return `["${key}"="${value}"]`;
+      // Only { type=anything } isn't a string
+      return typeof value === 'string' ? `["${key}"="${value}"]` : `["${key}"]`;
   }
 };
 

--- a/src/components/SearchBox/queryWizard/generateQuery.ts
+++ b/src/components/SearchBox/queryWizard/generateQuery.ts
@@ -1,0 +1,7 @@
+import { ASTNode } from './ast';
+
+// TODO: Implement it
+
+export const generateQuery = (ast: ASTNode) => {
+  return 'relation';
+};

--- a/src/components/SearchBox/queryWizard/isAst.ts
+++ b/src/components/SearchBox/queryWizard/isAst.ts
@@ -6,7 +6,7 @@ import type {
   SpecialValue,
 } from './ast';
 
-const isSpecialComparisonValue = (obj: any): obj is SpecialValue => {
+export const isSpecialComparisonValue = (obj: any): obj is SpecialValue => {
   try {
     const { type } = obj;
     return type === 'anything';

--- a/src/components/SearchBox/queryWizard/isAst.ts
+++ b/src/components/SearchBox/queryWizard/isAst.ts
@@ -1,0 +1,46 @@
+import {
+  ASTNode,
+  ASTNodeComparison,
+  ASTNodeExpression,
+  ASTNodeGroup,
+} from './ast';
+
+const isComparisonAstNode = (obj: any): obj is ASTNodeComparison => {
+  try {
+    const { type, key, value, operator } = obj;
+    return (
+      type === 'comparison' &&
+      typeof key === 'string' &&
+      typeof value === 'string' &&
+      operator === '='
+    );
+  } catch {
+    return false;
+  }
+};
+
+const isGroupAstNode = (obj: any): obj is ASTNodeGroup => {
+  try {
+    return obj.type === 'group' && isAstNode(obj.expression);
+  } catch {
+    return false;
+  }
+};
+const isExpressionAstNode = (obj: any): obj is ASTNodeExpression => {
+  try {
+    const { type, expressions } = obj;
+    return (
+      type === 'expression' &&
+      Array.isArray(expressions) &&
+      expressions.every(isAstNode)
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const isAstNode = (obj: any): obj is ASTNode => {
+  return (
+    isComparisonAstNode(obj) || isGroupAstNode(obj) || isExpressionAstNode(obj)
+  );
+};

--- a/src/components/SearchBox/queryWizard/isAst.ts
+++ b/src/components/SearchBox/queryWizard/isAst.ts
@@ -1,9 +1,19 @@
-import {
+import type {
   ASTNode,
   ASTNodeComparison,
   ASTNodeExpression,
   ASTNodeGroup,
+  SpecialValue,
 } from './ast';
+
+const isSpecialComparisonValue = (obj: any): obj is SpecialValue => {
+  try {
+    const { type } = obj;
+    return type === 'anything';
+  } catch {
+    return false;
+  }
+};
 
 const isComparisonAstNode = (obj: any): obj is ASTNodeComparison => {
   try {
@@ -11,7 +21,7 @@ const isComparisonAstNode = (obj: any): obj is ASTNodeComparison => {
     return (
       type === 'comparison' &&
       typeof key === 'string' &&
-      typeof value === 'string' &&
+      (typeof value === 'string' || isSpecialComparisonValue(value)) &&
       operator === '='
     );
   } catch {

--- a/src/components/SearchBox/queryWizard/queryWizard.ts
+++ b/src/components/SearchBox/queryWizard/queryWizard.ts
@@ -1,0 +1,11 @@
+import { ASTNode, generateAst } from './ast';
+import { tokenize } from './tokens';
+
+export const getAST = (inputValue: string) => {
+  const tokens = tokenize(inputValue);
+  return generateAst(tokens);
+};
+
+export const queryWizardLabel = (ast: ASTNode) => {
+  return 'Query Wizard';
+};

--- a/src/components/SearchBox/queryWizard/queryWizard.ts
+++ b/src/components/SearchBox/queryWizard/queryWizard.ts
@@ -1,11 +1,32 @@
 import { ASTNode, generateAst } from './ast';
+import { isSpecialComparisonValue } from './isAst';
 import { tokenize } from './tokens';
+
+const FALLBACK_LABEL = 'Query Wizard';
 
 export const getAST = (inputValue: string) => {
   const tokens = tokenize(inputValue);
   return generateAst(tokens);
 };
 
-export const queryWizardLabel = (ast: ASTNode) => {
-  return 'Query Wizard';
+export const queryWizardLabel = (ast: ASTNode): string => {
+  switch (ast.type) {
+    case 'comparison':
+      if (!isSpecialComparisonValue(ast.value)) {
+        return `${ast.key}=${ast.value}`;
+      }
+
+      if (ast.value.type === 'anything') {
+        return `${ast.key}=*`;
+      }
+      break;
+    case 'expression':
+      if (ast.expressions[0].type === 'comparison') {
+        const remaining = ast.expressions.length - 1;
+        return `${queryWizardLabel(ast.expressions[0])} ${ast.operator} ${remaining} ${remaining > 1 ? 'others' : 'other'}`;
+      }
+      return `${ast.expressions.length} with ${ast.operator} combined expressions`;
+  }
+
+  return FALLBACK_LABEL;
 };

--- a/src/components/SearchBox/queryWizard/queryWizard.ts
+++ b/src/components/SearchBox/queryWizard/queryWizard.ts
@@ -2,8 +2,6 @@ import { ASTNode, generateAst } from './ast';
 import { isSpecialComparisonValue } from './isAst';
 import { tokenize } from './tokens';
 
-const FALLBACK_LABEL = 'Query Wizard';
-
 export const getAST = (inputValue: string) => {
   const tokens = tokenize(inputValue);
   return generateAst(tokens);
@@ -26,7 +24,7 @@ export const queryWizardLabel = (ast: ASTNode): string => {
         return `${queryWizardLabel(ast.expressions[0])} ${ast.operator} ${remaining} ${remaining > 1 ? 'others' : 'other'}`;
       }
       return `${ast.expressions.length} with ${ast.operator} combined expressions`;
+    case 'group':
+      return queryWizardLabel(ast.expression);
   }
-
-  return FALLBACK_LABEL;
 };

--- a/src/components/SearchBox/queryWizard/tokens.ts
+++ b/src/components/SearchBox/queryWizard/tokens.ts
@@ -60,7 +60,7 @@ export function tokenize(inputValue: string) {
     }
   });
 
-  if (!validateMatches(matches, inputValue).valid) {
+  if (!validateMatches(matches, trimmedInputValue).valid) {
     throw new Error('Invalid token encountered');
   }
 

--- a/src/components/SearchBox/queryWizard/tokens.ts
+++ b/src/components/SearchBox/queryWizard/tokens.ts
@@ -1,0 +1,36 @@
+export type Operator = 'and' | 'or';
+// TODO: Add a token for * (match any content)
+export type Token =
+  | { type: 'string'; value: string }
+  | { type: 'logical'; value: Operator }
+  | { type: 'operator'; value: '=' }
+  | { type: 'bracket'; value: 'opening' | 'closing' };
+
+const tokenRegex = /\s+and\s+|\s+or\s+|=|\(|\)|[\w:]+|"[^"]*"/g;
+
+// TODO: Throw when the string contains something that isn't parsed, currently it is just ignored
+
+export function tokenize(inputValue: string) {
+  const matches = Array.from(inputValue.matchAll(tokenRegex));
+
+  const tokens: Token[] = matches.map(([match]) => {
+    const value = match.trim();
+    switch (value) {
+      case 'and':
+      case 'or':
+        return { type: 'logical', value };
+      case '=':
+        return { type: 'operator', value };
+      case '(':
+      case ')':
+        const isOpening = value === '(';
+        return { type: 'bracket', value: isOpening ? 'opening' : 'closing' };
+      default:
+        const isQuoted = value.startsWith('"') && value.endsWith('"');
+        const string = isQuoted ? value.slice(1, -1) : value;
+        return { type: 'string', value: string };
+    }
+  });
+
+  return tokens;
+}

--- a/src/components/SearchBox/queryWizard/tokens.ts
+++ b/src/components/SearchBox/queryWizard/tokens.ts
@@ -1,12 +1,12 @@
 export type Operator = 'and' | 'or';
-// TODO: Add a token for * (match any content)
 export type Token =
   | { type: 'string'; value: string }
   | { type: 'logical'; value: Operator }
   | { type: 'operator'; value: '=' }
-  | { type: 'bracket'; value: 'opening' | 'closing' };
+  | { type: 'bracket'; value: 'opening' | 'closing' }
+  | { type: 'anything' };
 
-const tokenRegex = /\s+and\s+|\s+or\s+|=|\(|\)|[\w:]+|"[^"]*"/g;
+const tokenRegex = /\s+and\s+|\s+or\s+|\*|=|\(|\)|[\w:]+|"[^"]*"/g;
 
 // TODO: Throw when the string contains something that isn't parsed, currently it is just ignored
 
@@ -21,6 +21,8 @@ export function tokenize(inputValue: string) {
         return { type: 'logical', value };
       case '=':
         return { type: 'operator', value };
+      case '*':
+        return { type: 'anything' };
       case '(':
       case ')':
         const isOpening = value === '(';

--- a/src/components/SearchBox/types.ts
+++ b/src/components/SearchBox/types.ts
@@ -1,5 +1,6 @@
 import { LonLat } from '../../services/types';
 import { Star } from '../utils/StarsContext';
+import { ASTNode } from './queryWizard/ast';
 
 type GenericOption<T extends string, U extends Object | null> = {
   type: T;
@@ -39,7 +40,7 @@ export type OverpassOption = GenericOption<
   'overpass',
   {
     query?: string;
-    tags?: Record<string, string>;
+    ast?: ASTNode;
     inputValue: string;
     label: string;
   }


### PR DESCRIPTION
### Description

In #708 @govvin asked this:

> How do I combine this, for example: historic=* and tourism=* to find any feature having both tags?

About the overpass search option.

This lead to the idea of a overpass turbo query wizard like search.
This pull request introduces a limited version of that. Currently it only supports these:

- `and` to combine multiple things
- `or` to combine multiple things
- `key=value` for the actual key comparison, it is build in a way that other operators like `!=` are relatively easy to add
- `()` to group things combined via `and`/`or`

### Example searches

`(amenity=cafe or amenity=restaurant) and internet_access=yes`
`museum=art and fee=no`
`amenity=restaurant and diet:vegetarian=yes`

### ToDo

- [x] Better Labels
- [x] Let the tokenizer throw when there is an unexpected charachter
- [x] Allow for a `*` token to match anything
- [x] Add tests
