### PR TITLE
EditDialog Add a version check before uploading

### DIFF
--- a/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
+++ b/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
@@ -46,7 +46,7 @@ export const useGetHandleSave = () => {
         handleLogout();
       } else {
         showToast(
-          `${t('editdialog.save_refused')} ${err.responseText}`,
+          `${t('editdialog.save_refused')} ${err.responseText ?? err.message}`,
           'error',
         );
         console.error(err); // eslint-disable-line no-console

--- a/src/services/osmApiAuth.ts
+++ b/src/services/osmApiAuth.ts
@@ -15,6 +15,7 @@ import { join } from '../utils';
 import { clearFeatureCache } from './osmApi';
 import { isBrowser } from '../components/helpers';
 import { getLabel } from '../helpers/featureLabel';
+import { fetchJson } from './fetch';
 
 const PROD_CLIENT_ID = 'vWUdEL3QMBCB2O9q8Vsrl3i2--tcM34rKrxSHR9Vg68';
 
@@ -225,6 +226,15 @@ export const editOsmFeature = async (
   newTags: FeatureTags,
   isCancelled: boolean,
 ): Promise<SuccessInfo> => {
+  const newestVersion = await fetchJson(
+    `https://api.openstreetmap.org/api/0.6/${feature.osmMeta.type}/${feature.osmMeta.id}.json`,
+  ).then(({ elements }) => elements[0].version as number);
+  const loadedVersion = feature.osmMeta.version;
+
+  if (loadedVersion !== newestVersion) {
+    throw new Error('The object has been updated, reload and try again');
+  }
+
   const apiId = prod ? feature.osmMeta : TEST_OSM_ID;
   const changesetComment = getChangesetComment(comment, isCancelled, feature);
   const changesetXml = getChangesetXml({ changesetComment, feature });


### PR DESCRIPTION
### Description

This fixes #714. Before uploading a changeset to osm it now checks if the in osmapp loaded version is actually the newest one. If not the upload gets blocked to prevent data loss

### Screenshots

![image](https://github.com/user-attachments/assets/41cb6f17-2326-4298-91a3-c522dfb2e461)

