### PR TITLE
FeaturePanel: Make the star button clickable in the collapsed FeaturePanel drawer

### DIFF
--- a/src/components/FeaturePanel/helpers/StarButton.tsx
+++ b/src/components/FeaturePanel/helpers/StarButton.tsx
@@ -13,6 +13,8 @@ const StyledActionButton = styled(IconButton)<{ $color?: string }>`
     height: 20px;
     color: ${({ theme }) => (theme.palette.mode === 'dark' ? '#fff' : '#000')};
   }
+  /* Used to overwrite pointer-events: none from the collapsed featurepanel drawer */
+  pointer-events: all;
 `;
 
 const StarButtonPure = ({ isStarred, toggleStar }) => (


### PR DESCRIPTION
### Description

This fixes #712 
On mui there is a two year old issue where the author explains how to have pointer-events in the collapsed drawer. The star button now has `pointe-events: all` to override the inherited `pointer-events: none` from the collapsed drawer.

It is now possible to star a feature from the collapsed FeaturePanel

### Example links

It can be tried on any feature