### PR TITLE
Search: Make multipolygons and areas geojson polygons

### DIFF
--- a/src/services/getCenter.ts
+++ b/src/services/getCenter.ts
@@ -4,6 +4,7 @@ import {
   isGeometryCollection,
   isLineString,
   isPoint,
+  isPolygon,
   Position,
 } from './types';
 
@@ -64,6 +65,10 @@ export const getCenter = (geometry: FeatureGeometry): Position => {
   if (isGeometryCollection(geometry)) {
     const allPoints = getPointsRecursive(geometry);
     return getCenterOfBbox(allPoints);
+  }
+  if (isPolygon(geometry)) {
+    const outerCoords = geometry.coordinates[0];
+    return getCenterOfBbox(outerCoords);
   }
 
   return undefined;

--- a/src/services/overpassSearch.ts
+++ b/src/services/overpassSearch.ts
@@ -1,14 +1,14 @@
-import { GeometryCollection, LineString, Point, OsmId } from './types';
+import { LineString, OsmId, Point, GeometryCollection } from './types';
 import { getPoiClass } from './getPoiClass';
 import { getCenter } from './getCenter';
 import { fetchJson } from './fetch';
-import { Feature, FeatureCollection } from 'geojson';
+import { Feature, FeatureCollection, Polygon } from 'geojson';
 import { ASTNode } from '../components/SearchBox/queryWizard/ast';
 import { Bbox } from '../components/utils/MapStateContext';
 import { generateQuery } from '../components/SearchBox/queryWizard/generateQuery';
 import { isAstNode } from '../components/SearchBox/queryWizard/isAst';
 
-const getOverpassQuery = ([a, b, c, d], query) =>
+const getOverpassQuery = ([a, b, c, d], query: string) =>
   `[out:json][timeout:25][bbox:${[d, a, b, c]}];(${query};);out geom qt;`;
 
 export const getOverpassUrl = (fullQuery: string) =>
@@ -16,32 +16,98 @@ export const getOverpassUrl = (fullQuery: string) =>
     fullQuery,
   )}`;
 
+type OverpassObject = {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat?: number;
+  lon?: number;
+  tags?: Record<string, string>;
+  bounds?: {
+    minlat: number;
+    minlon: number;
+    maxlat: number;
+    maxlon: number;
+  };
+  nodes?: number[];
+  geometry?: {
+    lon: number;
+    lat: number;
+  }[];
+  members?: any[];
+};
+
+const geojsonCoords = ({ geometry }: OverpassObject): [number, number][] =>
+  geometry.map(({ lon, lat }) => [lon, lat]);
+
 const GEOMETRY = {
-  node: ({ lat, lon }): Point => ({ type: 'Point', coordinates: [lon, lat] }),
-
-  way: ({ geometry }): LineString => ({
-    type: 'LineString',
-    coordinates: geometry.map(({ lat, lon }) => [lon, lat]),
+  node: ({ lat, lon }: OverpassObject): Point => ({
+    type: 'Point',
+    coordinates: [lon, lat],
   }),
 
-  relation: ({ members }): GeometryCollection => ({
-    type: 'GeometryCollection',
-    geometries:
-      members
-        ?.map((el) =>
-          el.type === 'node'
-            ? GEOMETRY.node(el)
-            : el.type === 'way'
-              ? GEOMETRY.way(el)
-              : null,
-        )
-        .filter(Boolean) ?? [],
-  }),
+  way: (element: OverpassObject): LineString | Polygon => {
+    if (isClosedWay(element)) {
+      return {
+        type: 'Polygon',
+        coordinates: [geojsonCoords(element)],
+      };
+    }
+
+    return {
+      type: 'LineString',
+      coordinates: geojsonCoords(element),
+    };
+  },
+
+  relation: ({
+    members,
+    tags = {},
+  }: OverpassObject): GeometryCollection | Polygon => {
+    if (tags.type === 'multipolygon') {
+      const outer = members
+        .filter(({ role }) => role === 'outer')
+        .flatMap(geojsonCoords);
+
+      const inner = members
+        .filter(({ role }) => role === 'inner')
+        .map(geojsonCoords);
+
+      return {
+        type: 'Polygon',
+        coordinates: [[...outer], ...inner],
+      };
+    }
+
+    return {
+      type: 'GeometryCollection',
+      geometries:
+        members
+          ?.map((el) =>
+            el.type === 'node'
+              ? GEOMETRY.node(el)
+              : el.type === 'way'
+                ? GEOMETRY.way(el)
+                : null,
+          )
+          .filter(Boolean) ?? [],
+    };
+  },
 };
 
 const convertOsmIdToMapId = (apiId: OsmId) => {
   const osmToMapType = { node: 0, way: 1, relation: 4 };
   return parseInt(`${apiId.id}${osmToMapType[apiId.type]}`, 10);
+};
+
+const isClosedWay = (element: OverpassObject) => {
+  const nodes = element.geometry;
+  if (nodes.length < 4) {
+    return false;
+  }
+
+  const first = nodes[0];
+  const last = nodes[nodes.length - 1];
+  return first.lat === last.lat && first.lon === last.lon;
 };
 
 type OverpassFeature = Feature & {
@@ -50,7 +116,7 @@ type OverpassFeature = Feature & {
 
 // TODO use our own implementaion from fetchCrags, which handles recursive geometries
 export const overpassGeomToGeojson = (response: {
-  elements: any[];
+  elements: OverpassObject[];
 }): OverpassFeature[] =>
   response.elements.map((element) => {
     const { type, id, tags = {} } = element;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,5 +1,6 @@
 import type Vocabulary from '../locales/vocabulary';
 import type { getSchemaForFeature } from './tagging/idTaggingScheme';
+import type { Polygon } from 'geojson';
 
 export type OsmType = 'node' | 'way' | 'relation';
 export type OsmId = {
@@ -51,10 +52,10 @@ export interface LineString {
 
 export interface GeometryCollection {
   type: 'GeometryCollection';
-  geometries: Array<Point | LineString | GeometryCollection>;
+  geometries: Array<Point | LineString | GeometryCollection | Polygon>;
 }
 
-export type FeatureGeometry = Point | LineString | GeometryCollection;
+export type FeatureGeometry = Point | LineString | GeometryCollection | Polygon;
 
 export const isPoint = (geometry: FeatureGeometry): geometry is Point =>
   geometry?.type === 'Point';
@@ -64,6 +65,8 @@ export const isLineString = (
 export const isGeometryCollection = (
   geometry: FeatureGeometry,
 ): geometry is GeometryCollection => geometry?.type === 'GeometryCollection';
+export const isPolygon = (geometry: FeatureGeometry): geometry is Polygon =>
+  geometry?.type === 'Polygon';
 
 export type FeatureTags = {
   [key: string]: string;


### PR DESCRIPTION
### Description

When using the overpass or preset search areas and ways were displayed as lines instead of polygons. Now they are displayed as filled polygons on the map, this makes it easier to see and click them. It is also a first step for #710 

### Example links

### Screenshots

<img src="https://github.com/user-attachments/assets/cc6873db-4a13-4459-b52b-393a3919c58c" width="750">

![image](https://github.com/user-attachments/assets/884f26dd-2d66-4f26-a5ac-b3f5d746541b)
