### PR TITLE
Weather: Add a weather widget

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -11,6 +11,7 @@ import { LayerSwitcherButton } from '../LayerSwitcher/LayerSwitcherButton';
 import { MaptilerLogo } from './MapFooter/MaptilerLogo';
 import { TopMenu } from './TopMenu/TopMenu';
 import { useMapStateContext } from '../utils/MapStateContext';
+import { Weather } from './Weather/Weather';
 
 const BrowserMapDynamic = dynamic(() => import('./BrowserMap'), {
   ssr: false,
@@ -52,6 +53,12 @@ const BottomRight = styled.div`
   text-align: right;
   pointer-events: none;
   z-index: 999;
+
+  display: flex;
+  gap: 4px;
+  flex-direction: column;
+  align-items: end;
+  padding: 0 4px 4px 4px;
 `;
 
 const BugReportButton = () => (
@@ -84,6 +91,7 @@ const Map = () => {
       <BottomRight>
         {SHOW_PROTOTYPE_UI && <BugReportButton />}
         <MaptilerLogo />
+        <Weather />
         <MapFooter />
       </BottomRight>
     </>

--- a/src/components/Map/MapFooter/MapFooter.tsx
+++ b/src/components/Map/MapFooter/MapFooter.tsx
@@ -21,7 +21,6 @@ const StyledIconButton = styled(IconButton)`
 `;
 
 const FooterContainer = styled.div<{ $hasShadow: boolean }>`
-  margin: 0 4px 4px 4px;
   pointer-events: all;
   border-radius: 8px;
   padding: 6px;

--- a/src/components/Map/Weather/Weather.tsx
+++ b/src/components/Map/Weather/Weather.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from 'react-query';
+import { useMapStateContext } from '../../utils/MapStateContext';
+import styled from '@emotion/styled';
+import { DotLoader } from '../../helpers';
+import { convertHexToRgba } from '../../utils/colorUtils';
+import { loadWeather } from './loadWeather';
+import { WeatherInner } from './WeatherInner';
+import { LonLat } from '../../../services/types';
+import React from 'react';
+import { getDistance } from '../../SearchBox/utils';
+
+const WeatherWrapper = styled.div`
+  color: ${({ theme }) => theme.palette.text.primary};
+  background-color: ${({ theme }) =>
+    convertHexToRgba(theme.palette.background.paper, 0.7)};
+  backdrop-filter: blur(15px);
+  padding: 0.5rem 1rem;
+  width: fit-content;
+  border-radius: 8px;
+  font-size: 0.85rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  pointer-events: all;
+`;
+
+type WeatherProps = {
+  lat: number;
+  lon: number;
+};
+
+const useLoadWeather = ({ lat, lon }: WeatherProps) => {
+  const lastFetchedLocation = React.useRef<LonLat | null>(null);
+
+  const { status, data, error } = useQuery(
+    ['weather', lat, lon],
+    () => loadWeather({ lat, lon }),
+    {
+      enabled:
+        lastFetchedLocation.current === null ||
+        getDistance(lastFetchedLocation.current, [lon, lat]) > 5_000,
+      onSuccess: () => {
+        lastFetchedLocation.current = [lon, lat];
+      },
+      keepPreviousData: true
+    },
+  );
+
+  return { status, data, error };
+};
+
+export const WeatherLoader = (props: WeatherProps) => {
+  const { status, data } = useLoadWeather(props);
+
+  switch (status) {
+    case 'success':
+    case 'idle':
+      return (
+        <WeatherWrapper>
+          <WeatherInner response={data.current} />
+        </WeatherWrapper>
+      );
+    case 'error':
+      return <WeatherWrapper>An error occured</WeatherWrapper>;
+    case 'loading':
+      return (
+        <WeatherWrapper>
+          <span>
+            <DotLoader />
+          </span>
+        </WeatherWrapper>
+      );
+  }
+};
+
+export const Weather = () => {
+  const { view } = useMapStateContext();
+  const [zoom, lat, lon] = view;
+
+  if (parseFloat(zoom) < 13) {
+    return null;
+  }
+
+  return <WeatherLoader lat={parseFloat(lat)} lon={parseFloat(lon)} />;
+};

--- a/src/components/Map/Weather/WeatherInner.tsx
+++ b/src/components/Map/Weather/WeatherInner.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { WeatherResponse } from './loadWeather';
+import { icons } from './icons';
+import { Tooltip } from '@mui/material';
+import { isImperial } from '../../helpers';
+import { celsiusToFahrenheit } from './helpers';
+
+const StyledImg = styled.img`
+  max-width: 35px;
+  max-height: 35px;
+`;
+
+type Props = {
+  response: WeatherResponse['current'];
+};
+
+export const WeatherInner = ({ response }: Props) => {
+  const isDay = response.is_day === 1;
+  const icon = icons[response.weather_code];
+  const iconDescription =
+    icon.description ?? icon[response.is_day ? 'day' : 'night'].description;
+  const temperature = isImperial()
+    ? celsiusToFahrenheit(response.temperature_2m)
+    : response.temperature_2m;
+
+  return (
+    <>
+      <Tooltip arrow title={iconDescription} placement="top">
+        <StyledImg
+          src={icon[isDay ? 'day' : 'night'].image}
+          alt={iconDescription}
+        />
+      </Tooltip>
+      {Math.round(temperature)} {isImperial() ? '°F' : '°C'}
+    </>
+  );
+};

--- a/src/components/Map/Weather/helpers.ts
+++ b/src/components/Map/Weather/helpers.ts
@@ -1,0 +1,1 @@
+export const celsiusToFahrenheit = (celsius: number) => celsius * 1.8 + 32;

--- a/src/components/Map/Weather/icons.ts
+++ b/src/components/Map/Weather/icons.ts
@@ -1,0 +1,261 @@
+type Icon = Record<'day' | 'night', { description?: string; image: string }> & {
+  description?: string;
+};
+
+// From https://gist.github.com/stellasphere/9490c195ed2b53c707087c8c2db4ec0c
+export const icons: Record<number, Icon> = {
+  0: {
+    day: {
+      description: 'Sunny',
+      image: 'http://openweathermap.org/img/wn/01d@2x.png',
+    },
+    night: {
+      description: 'Clear',
+      image: 'http://openweathermap.org/img/wn/01n@2x.png',
+    },
+  },
+  1: {
+    day: {
+      description: 'Mainly Sunny',
+      image: 'http://openweathermap.org/img/wn/01d@2x.png',
+    },
+    night: {
+      description: 'Mainly Clear',
+      image: 'http://openweathermap.org/img/wn/01n@2x.png',
+    },
+  },
+  2: {
+    description: 'Partly Cloudy',
+    day: {
+      image: 'http://openweathermap.org/img/wn/02d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/02n@2x.png',
+    },
+  },
+  3: {
+    description: 'Cloudy',
+    day: {
+      image: 'http://openweathermap.org/img/wn/03d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/03n@2x.png',
+    },
+  },
+  45: {
+    description: 'Foggy',
+    day: {
+      image: 'http://openweathermap.org/img/wn/50d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/50n@2x.png',
+    },
+  },
+  48: {
+    description: 'Rime Fog',
+    day: {
+      image: 'http://openweathermap.org/img/wn/50d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/50n@2x.png',
+    },
+  },
+  51: {
+    description: 'Light Drizzle',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  53: {
+    description: 'Drizzle',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  55: {
+    description: 'Heavy Drizzle',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  56: {
+    description: 'Light Freezing Drizzle',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  57: {
+    description: 'Freezing Drizzle',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  61: {
+    description: 'Light Rain',
+    day: {
+      image: 'http://openweathermap.org/img/wn/10d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/10n@2x.png',
+    },
+  },
+  63: {
+    description: 'Rain',
+    day: {
+      image: 'http://openweathermap.org/img/wn/10d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/10n@2x.png',
+    },
+  },
+  65: {
+    description: 'Heavy Rain',
+    day: {
+      image: 'http://openweathermap.org/img/wn/10d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/10n@2x.png',
+    },
+  },
+  66: {
+    description: 'Light Freezing Rain',
+    day: {
+      image: 'http://openweathermap.org/img/wn/10d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/10n@2x.png',
+    },
+  },
+  67: {
+    description: 'Freezing Rain',
+    day: {
+      image: 'http://openweathermap.org/img/wn/10d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/10n@2x.png',
+    },
+  },
+  71: {
+    description: 'Light Snow',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  73: {
+    description: 'Snow',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  75: {
+    description: 'Heavy Snow',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  77: {
+    description: 'Snow Grains',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  80: {
+    description: 'Light Showers',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  81: {
+    description: 'Showers',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  82: {
+    description: 'Heavy Showers',
+    day: {
+      image: 'http://openweathermap.org/img/wn/09d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/09n@2x.png',
+    },
+  },
+  85: {
+    description: 'Light Snow Showers',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  86: {
+    description: 'Snow Showers',
+    day: {
+      image: 'http://openweathermap.org/img/wn/13d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/13n@2x.png',
+    },
+  },
+  95: {
+    description: 'Thunderstorm',
+    day: {
+      image: 'http://openweathermap.org/img/wn/11d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/11n@2x.png',
+    },
+  },
+  96: {
+    description: 'Light Thunderstorms With Hail',
+    day: {
+      image: 'http://openweathermap.org/img/wn/11d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/11n@2x.png',
+    },
+  },
+  99: {
+    description: 'Thunderstorm With Hail',
+    day: {
+      image: 'http://openweathermap.org/img/wn/11d@2x.png',
+    },
+    night: {
+      image: 'http://openweathermap.org/img/wn/11n@2x.png',
+    },
+  },
+};

--- a/src/components/Map/Weather/loadWeather.tsx
+++ b/src/components/Map/Weather/loadWeather.tsx
@@ -1,0 +1,36 @@
+import { fetchJson } from '../../../services/fetch';
+
+export type WeatherResponse = {
+  latitude: number;
+  longitude: number;
+  generationtime_ms: number;
+  utc_offset_seconds: number;
+  timezone: string;
+  timezone_abbreviation: string;
+  elevation: number;
+  current_units: {
+    time: string;
+    interval: string;
+    temperature_2m: '°C';
+    weather_code: 'wmo code';
+    is_day: '';
+  };
+  current: {
+    time: string;
+    interval: number;
+    temperature_2m: number;
+    weather_code: number;
+    is_day: 0 | 1;
+  };
+};
+
+type Props = {
+  lat: number;
+  lon: number;
+};
+
+export const loadWeather = ({ lat, lon }: Props) => {
+  const currentFields = ['temperature_2m', 'weather_code', 'is_day'];
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=${currentFields.join(',')}`;
+  return fetchJson<WeatherResponse>(url);
+};

--- a/src/components/SearchBox/utils.tsx
+++ b/src/components/SearchBox/utils.tsx
@@ -26,6 +26,7 @@ const EARTH_RADIUS = 6372795;
 
 const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180;
 
+/** Returns the distance between two points in meters */
 export const getDistance = (point1: LonLat, point2: LonLat) => {
   const latdiff = degreesToRadians(point2[1]) - degreesToRadians(point1[1]);
   const lngdiff = degreesToRadians(point2[0]) - degreesToRadians(point1[0]);


### PR DESCRIPTION
### Description

This fixes #730 by introducing a weather widget.

- It uses [Open-Meteo](https://open-meteo.com/)
- Icons are from [OpenWeather](https://openweathermap.org/weather-conditions)
- It only fetches for zoom levels > 13 and refetches once the user moves 5km

### Screenshots

<img src="https://github.com/user-attachments/assets/9951ede1-48b9-42cd-97cc-ae9974e3481e" alt="Cloud" width="350">
<img src="https://github.com/user-attachments/assets/ed24642a-e129-4f83-88af-6c242a3b4148" alt="Snow" width="350">
<img src="https://github.com/user-attachments/assets/d5737927-dd4e-4d07-8b0d-703083646375" alt="Sun" width="350">

### ToDo

- [ ] Make it react to changes between the imperial and the metric system without reloading
   - The label already uses celsius/fahrenheit but only reacts to a settings change on reload
   -  It needs a context to react to this change, related to #572 
   - Maybe allow for celsius and miles or for fahrenheit and kilometers at the same time, so decouple temperature from length
 - [ ] Open-Meteo requires attribution but I don't know where to put it, maybe we can create a `/acknowledgment` route where we can put attributions?