### PR TITLE
general: correct link to vercel on Homepage.tsx

### DIFF
--- a/src/components/HomepagePanel/Homepage.tsx
+++ b/src/components/HomepagePanel/Homepage.tsx
@@ -237,7 +237,10 @@ export function Homepage({
                 {` – ${t('homepage.maptiler')}`}
               </li>
               <li>
-                <a href="https://vercel.com/?utm_source=osm-app-team&utm_campaign=oss" target="_blank">
+                <a
+                  href="https://vercel.com/?utm_source=osm-app-team&utm_campaign=oss"
+                  target="_blank"
+                >
                   Vercel
                 </a>
                 {` – ${t('homepage.vercel')}`}
@@ -247,7 +250,10 @@ export function Homepage({
               <LogoMaptiler width={200} height={52} />
             </a>
             <br />
-            <a href="https://vercel.com" target="_blank">
+            <a
+              href="https://vercel.com/?utm_source=osm-app-team&utm_campaign=oss"
+              target="_blank"
+            >
               <img src="/vercel.svg" alt="Vercel" width="200" height="41" />
             </a>
 

--- a/src/components/HomepagePanel/Homepage.tsx
+++ b/src/components/HomepagePanel/Homepage.tsx
@@ -237,7 +237,7 @@ export function Homepage({
                 {` – ${t('homepage.maptiler')}`}
               </li>
               <li>
-                <a href="https://vercel.com" target="_blank">
+                <a href="https://vercel.com/?utm_source=osm-app-team&utm_campaign=oss" target="_blank">
                   Vercel
                 </a>
                 {` – ${t('homepage.vercel')}`}


### PR DESCRIPTION
This pull request includes updates to external links in the `Homepage` component to include UTM parameters for tracking purposes.

* [`src/components/HomepagePanel/Homepage.tsx`](diffhunk://#diff-13cc178133a09b0234d47cec116de1087cc29ce02cd2da36e09db718caa29004L240-R243): Updated the Vercel links to include UTM parameters for better tracking. [[1]](diffhunk://#diff-13cc178133a09b0234d47cec116de1087cc29ce02cd2da36e09db718caa29004L240-R243) [[2]](diffhunk://#diff-13cc178133a09b0234d47cec116de1087cc29ce02cd2da36e09db718caa29004L250-R256)