### PR TITLE
FeaturePanel: Add a socket:* view

### DIFF
--- a/public/sockets/schuko.svg
+++ b/public/sockets/schuko.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="63.831657mm"
+   height="64.945374mm"
+   viewBox="0 0 63.831657 64.945374"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="schuko.svg"
+   inkscape:export-filename="schuko.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-2.1867288e-4,-0.05295581)">
+    <path
+       id="path1"
+       style="fill:none;stroke:#000000;stroke-width:2.90787;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.805637,1.5465741 V 5.6118333 H 31.02646 V 1.5485777 A 31.507651,31.042792 0 0 0 5.1537599,16.217772 V 27.392226 H 1.4541537 V 37.658558 H 5.1537599 V 48.833513 A 31.507651,31.042792 0 0 0 31.02646,63.502707 v -4.063256 h 1.779177 V 63.50471 A 31.507651,31.042792 0 0 0 58.693363,48.881598 V 37.547359 h 3.684579 V 27.281528 H 58.693363 V 16.169185 A 31.507651,31.042792 0 0 0 32.805637,1.5465741 Z" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.90787;stroke-dasharray:none"
+       id="path2"
+       cx="19.354511"
+       cy="32.525646"
+       r="4.0067487" />
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.90787;stroke-dasharray:none"
+       id="path2-1"
+       cx="44.477581"
+       cy="32.525646"
+       r="4.0067487" />
+  </g>
+</svg>

--- a/public/sockets/type1.svg
+++ b/public/sockets/type1.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="120"
+   height="120"
+   viewBox="0 0 120 120"
+   version="1.1"
+   id="svg1"
+   inkscape:export-filename="type1.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:none;stroke:#000000;stroke-width:7.42978;stroke-dasharray:none"
+       id="path1"
+       cx="60"
+       cy="60"
+       r="56.28511" />
+    <g
+       id="g3"
+       transform="translate(-0.09843254)">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:17.4395;stroke-dasharray:none"
+         id="path2"
+         cx="36.300175"
+         cy="37.984859"
+         r="15" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:17.4395;stroke-dasharray:none"
+         id="path2-5"
+         cx="83.89669"
+         cy="37.984859"
+         r="15" />
+    </g>
+    <circle
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:17.4395;stroke-dasharray:none"
+       id="path2-5-2"
+       cx="60"
+       cy="92.508392"
+       r="15" />
+    <g
+       id="g4"
+       transform="translate(1.0381823,1.9953518)">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:9.86378;stroke-dasharray:none"
+         id="path3"
+         cx="29.255697"
+         cy="69.501274"
+         r="8.75" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:9.86378;stroke-dasharray:none"
+         id="path3-7"
+         cx="88.667938"
+         cy="69.501274"
+         r="8.75" />
+    </g>
+  </g>
+</svg>

--- a/public/sockets/type2.svg
+++ b/public/sockets/type2.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="120.0014"
+   height="95.206482"
+   viewBox="0 0 120.0014 95.206482"
+   version="1.1"
+   id="svg1"
+   inkscape:export-filename="type2.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   sodipodi:docname="type2.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(7.030766e-4,-24.79422)">
+    <path
+       id="path1"
+       style="fill:none;stroke:#000000;stroke-width:3.685;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 12.511719,26.636719 A 58.157429,58.157429 0 0 0 1.8417969,60 58.157429,58.157429 0 0 0 60,118.1582 58.157429,58.157429 0 0 0 118.1582,60 58.157429,58.157429 0 0 0 107.61523,26.636719 Z" />
+    <g
+       id="g2"
+       transform="translate(2.3330917)"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:4.47529;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2"
+         cx="57.666908"
+         cy="69.470871"
+         r="10.262356" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:4.47529;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2-9"
+         cx="93.31501"
+         cy="69.470871"
+         r="10.262356" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:4.47529;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2-9-6"
+         cx="22.018806"
+         cy="69.470871"
+         r="10.262356" />
+    </g>
+    <g
+       id="g3"
+       transform="translate(14.675948,1.2000007)"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-opacity:1">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:4.47529;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2-7"
+         cx="63.148102"
+         cy="94.5"
+         r="10.262356" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:4.47529;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2-9-6-2"
+         cx="27.500002"
+         cy="94.5"
+         r="10.262356" />
+    </g>
+    <g
+       id="g4"
+       transform="matrix(1.2037156,0,0,1.2037156,-15.109766,-10.465392)"
+       style="fill:#000000;fill-opacity:1">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:3.685;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path3"
+         cx="47.14286"
+         cy="44.311058"
+         r="5.2190065" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:3.685;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path3-7"
+         cx="77.653671"
+         cy="44.311058"
+         r="5.2190065" />
+    </g>
+  </g>
+</svg>

--- a/public/sockets/unknown.svg
+++ b/public/sockets/unknown.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="65.854042mm"
+   height="67.003044mm"
+   viewBox="0 0 65.854042 67.003045"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="unknown.svg"
+   inkscape:export-filename="unknown.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(1.0261271,1.0014387)">
+    <path
+       id="path1"
+       style="fill:none;stroke:#000000;stroke-width:3;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.818669,0.53950195 V 4.7335612 H 30.983122 V 0.54156901 A 32.505912,32.026325 0 0 0 4.2906942,15.675529 V 27.204024 H 0.47387288 V 37.795626 H 4.2906942 v 11.529012 a 32.505912,32.026325 0 0 0 26.6924278,15.13396 v -4.191992 h 1.835547 v 4.194059 A 32.505912,32.026325 0 0 0 59.526599,49.374247 V 37.680904 h 3.801318 V 27.089819 H 59.526599 V 15.625403 A 32.505912,32.026325 0 0 0 32.818669,0.53950195 Z" />
+    <path
+       d="m 29.505692,40.34457 h 3.147094 v 3.937744 h -3.147094 z m 3.054077,-2.278931 h -2.96106 v -2.387451 q 0,-1.565796 0.434082,-2.573486 0.434082,-1.00769 1.829346,-2.340942 l 1.395264,-1.379761 q 0.883667,-0.821655 1.27124,-1.550293 0.403076,-0.728638 0.403076,-1.488281 0,-1.379761 -1.023193,-2.232422 -1.007691,-0.852661 -2.682007,-0.852661 -1.224732,0 -2.619995,0.542602 -1.379761,0.542603 -2.883545,1.581299 v -2.914551 q 1.457275,-0.883667 2.945556,-1.317749 1.503785,-0.434082 3.100586,-0.434082 2.852539,0 4.573365,1.503784 1.736328,1.503785 1.736328,3.96875 0,1.178223 -0.558106,2.247925 -0.558105,1.054199 -1.953369,2.387451 l -1.364258,1.333252 q -0.728637,0.728638 -1.038696,1.147217 -0.294556,0.403076 -0.418579,0.790649 -0.09302,0.325562 -0.139527,0.79065 -0.04651,0.465088 -0.04651,1.27124 z"
+       id="text7"
+       style="font-size:31.75px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-dasharray:none"
+       aria-label="?" />
+  </g>
+</svg>

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -25,6 +25,7 @@ import { Box } from '@mui/material';
 import { ClimbingGuideInfo } from './Climbing/ClimbingGuideInfo';
 import { ClimbingStructuredData } from './Climbing/ClimbingStructuredData';
 import { isPublictransportRoute } from '../../utils';
+import { Sockets } from './Sockets/Sockets';
 
 const Flex = styled.div`
   flex: 1;
@@ -84,12 +85,10 @@ export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
                 {!isPublictransportRoute(feature) && <MemberFeatures />}
                 {advanced && <Members />}
                 {isClimbingCrag && <PropertiesComponent />}
-
                 <PublicTransport />
                 <Runways />
-
+                <Sockets />
                 <FeatureOpenPlaceGuideLink />
-
                 <EditButton />
                 <EditDialog />
               </PanelSidePadding>

--- a/src/components/FeaturePanel/Sockets/README.md
+++ b/src/components/FeaturePanel/Sockets/README.md
@@ -1,5 +1,0 @@
-# Sockets
-
-`socket:*` tags are shown in the feature panel.  
-
-If no image is available 

--- a/src/components/FeaturePanel/Sockets/README.md
+++ b/src/components/FeaturePanel/Sockets/README.md
@@ -1,0 +1,5 @@
+# Sockets
+
+`socket:*` tags are shown in the feature panel.  
+
+If no image is available 

--- a/src/components/FeaturePanel/Sockets/Socket.tsx
+++ b/src/components/FeaturePanel/Sockets/Socket.tsx
@@ -5,7 +5,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
   TableRow,
 } from '@mui/material';
 import { useUserThemeContext } from '../../../helpers/theme';
@@ -21,10 +20,6 @@ const Container = styled.div`
 
   th {
     text-transform: capitalize;
-  }
-
-  p {
-    margin: 4px 0;
   }
 `;
 
@@ -61,6 +56,7 @@ export const Socket = ({ type, details }: Props) => {
   // quantity exists always
   const { quantity } = details;
   const entries = Object.entries(details).filter(([key]) => key !== 'quantity');
+  const prettifiedType = type.replace(/_/, ' ');
 
   return (
     <Container>
@@ -73,11 +69,12 @@ export const Socket = ({ type, details }: Props) => {
             objectFit: 'contain',
             filter: currentTheme === 'dark' ? 'invert(1)' : '',
           }}
+          alt={`Illustration of a ${prettifiedType} socket`}
         />
         {/^\d+$/.test(quantity) && <span>{quantity} times</span>}
       </Stack>
       <div>
-        <StyledHeading>{type.replace(/_/, ' ')}</StyledHeading>
+        <StyledHeading>{prettifiedType}</StyledHeading>
         {entries.length > 0 && (
           <TableContainer>
             <Table>

--- a/src/components/FeaturePanel/Sockets/Socket.tsx
+++ b/src/components/FeaturePanel/Sockets/Socket.tsx
@@ -1,0 +1,98 @@
+import styled from '@emotion/styled';
+import {
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { useUserThemeContext } from '../../../helpers/theme';
+import { getImageSrc } from './img';
+
+const Container = styled.div`
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  border-radius: 8px;
+  padding: 8px;
+  background-color: ${({ theme }) => theme.palette.background.elevation};
+
+  th {
+    text-transform: capitalize;
+  }
+
+  p {
+    margin: 4px 0;
+  }
+`;
+
+const StyledHeading = styled.h3`
+  text-transform: capitalize;
+  margin-top: 0;
+  margin-bottom: 9px;
+`;
+
+const addUnit = (key: string, value: string) => {
+  if (!/^[\d.]+$/.test(value)) {
+    return value;
+  }
+
+  switch (key) {
+    case 'current':
+      return `${value} A`;
+    case 'output':
+      return `${value} kW`;
+    case 'voltage':
+      return `${value} V`;
+    default:
+      return value;
+  }
+};
+
+type Props = {
+  type: string;
+  details: Record<string, string>;
+};
+
+export const Socket = ({ type, details }: Props) => {
+  const { currentTheme } = useUserThemeContext();
+  // quantity exists always
+  const { quantity } = details;
+  const entries = Object.entries(details).filter(([key]) => key !== 'quantity');
+
+  return (
+    <Container>
+      <Stack alignItems="center" spacing={1}>
+        <img
+          src={getImageSrc(type)}
+          style={{
+            width: 75,
+            height: 75,
+            objectFit: 'contain',
+            filter: currentTheme === 'dark' ? 'invert(1)' : '',
+          }}
+        />
+        {/^\d+$/.test(quantity) && <span>{quantity} times</span>}
+      </Stack>
+      <div>
+        <StyledHeading>{type.replace(/_/, ' ')}</StyledHeading>
+        {entries.length > 0 && (
+          <TableContainer>
+            <Table>
+              <TableBody>
+                {entries.map(([key, value]) => (
+                  <TableRow key={key}>
+                    <TableCell component="th">{key}</TableCell>
+                    <TableCell>{addUnit(key, value)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </div>
+    </Container>
+  );
+};

--- a/src/components/FeaturePanel/Sockets/Sockets.tsx
+++ b/src/components/FeaturePanel/Sockets/Sockets.tsx
@@ -1,0 +1,15 @@
+import { Stack } from '@mui/material';
+import { useSocketTags } from './useSocketTags';
+import { Socket } from './Socket';
+
+export const Sockets = () => {
+  const socketTags = useSocketTags();
+
+  return (
+    <Stack spacing={1}>
+      {Object.entries(socketTags).map(([type, details]) => (
+        <Socket key={type} type={type} details={details} />
+      ))}
+    </Stack>
+  );
+};

--- a/src/components/FeaturePanel/Sockets/img.ts
+++ b/src/components/FeaturePanel/Sockets/img.ts
@@ -1,10 +1,14 @@
+const typeToFilename = {
+  type1: 'type1',
+  type1_cable: 'type1',
+  type2: 'type2',
+  type2_cable: 'type2',
+  schuko: 'schuko',
+};
+
 export const getImageSrc = (type: string) => {
-  switch (type) {
-    case 'type2':
-      return '/sockets/type2.svg';
-    case 'schuko':
-      return '/sockets/schuko.svg';
-    default:
-      return '/sockets/unknown.svg';
+  if (typeToFilename[type]) {
+    return `/sockets/${typeToFilename[type]}.svg`;
   }
+  return '/sockets/unknown.svg';
 };

--- a/src/components/FeaturePanel/Sockets/img.ts
+++ b/src/components/FeaturePanel/Sockets/img.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
 const typeToFilename = {
   type1: 'type1',
   type1_cable: 'type1',
@@ -10,5 +12,9 @@ export const getImageSrc = (type: string) => {
   if (typeToFilename[type]) {
     return `/sockets/${typeToFilename[type]}.svg`;
   }
+  Sentry.captureMessage('Missing Icon for EV Socket', {
+    level: 'info',
+    tags: { socketType: type },
+  });
   return '/sockets/unknown.svg';
 };

--- a/src/components/FeaturePanel/Sockets/img.ts
+++ b/src/components/FeaturePanel/Sockets/img.ts
@@ -1,0 +1,10 @@
+export const getImageSrc = (type: string) => {
+  switch (type) {
+    case 'type2':
+      return '/sockets/type2.svg';
+    case 'schuko':
+      return '/sockets/schuko.svg';
+    default:
+      return '/sockets/unknown.svg';
+  }
+};

--- a/src/components/FeaturePanel/Sockets/useSocketTags.tsx
+++ b/src/components/FeaturePanel/Sockets/useSocketTags.tsx
@@ -1,0 +1,32 @@
+import { useFeatureContext } from '../../utils/FeatureContext';
+import pickBy from 'lodash/pickBy';
+import mapKeys from 'lodash/mapKeys';
+import groupBy from 'lodash/groupBy';
+import { mapValues } from 'lodash';
+
+export const useSocketTags = () => {
+  const { feature } = useFeatureContext();
+  const { tags } = feature;
+  if (!tags) {
+    return null;
+  }
+
+  const socketTags = mapKeys(
+    pickBy(tags, (_, k) => k.startsWith('socket:')),
+    (_, key) => key.replace(/^socket:/, ''),
+  );
+  const groupedEntries = groupBy(
+    Object.entries(socketTags),
+    ([key]) => key.split(':')[0],
+  );
+  const grouped = mapValues(groupedEntries, (value) =>
+    Object.fromEntries(
+      value.map(([key, value]) => {
+        const [_, detail] = key.split(':', 2);
+        return [detail ?? 'quantity', value];
+      }),
+    ),
+  );
+
+  return grouped;
+};


### PR DESCRIPTION
### Description

As proposed in #732 I've added some boxes for the `socket:*` tags.
I've created the vector graphics myself. When no specific graphic is available it fallsback to a generic one which features a question mark, in this case it is reported to sentry so we can see which socket types need to get custom graphics.

### Example links

[Tesla Supercharger (No image yet)](https://osmapp-git-fork-dlurak-sockets-osm-app-team.vercel.app/node/11902579098)
[Tesla destination and type 1 charger (No images yet)](https://osmapp-git-fork-dlurak-sockets-osm-app-team.vercel.app/node/10137915436)
[Schuko and type 2](https://osmapp-git-fork-dlurak-sockets-osm-app-team.vercel.app/node/5112637663)


### Screenshots

![image](https://github.com/user-attachments/assets/ebb1116d-89a0-4757-a985-2f15bfbe9404)

### ToDo

- [x] Add a vector graphic for type 1

Maybe also one for ChaDeMo

