### PR TITLE
general: experiment - disable sentry tunnelRoute

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,7 @@ export default withSentryConfig(nextConfig, {
   silent: !process.env.CI,
   widenClientFileUpload: true, // Upload a larger set of source maps for prettier stack traces (increases build time)
   reactComponentAnnotation: { enabled: true }, // Automatically annotate React components to show their full name in breadcrumbs and session replay
-  tunnelRoute: '/monitoring',
+  // tunnelRoute: '/monitoring',
   hideSourceMaps: false,
   disableLogger: true, // Automatically tree-shake Sentry logger statements to reduce bundle size
   automaticVercelMonitors: true, // https://vercel.com/docs/cron-jobs

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -14,19 +14,16 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
-  replaysOnErrorSampleRate: 1.0,
 
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
+  // replaysOnErrorSampleRate: 1.0,
+  // replaysSessionSampleRate: 0.1,
 
-  // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [
     Sentry.captureConsoleIntegration(),
-    Sentry.replayIntegration({
-      // Additional Replay configuration goes in here, for example:
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
+    // Sentry.replayIntegration({
+    //   // Additional Replay configuration goes in here, for example:
+    //   maskAllText: false,
+    //   blockAllMedia: false,
+    // }),
   ],
 });


### PR DESCRIPTION
We were hitting 80 GB-Hrs out of 100 in our hobby plan recently.

I would like to test if sentry tunnelRoute helps this or not. Also i didn't find replays particulary useful, maybe we can make do without them.

Lets evaluate it in a month or so.



----

We have heavy usage from old URLs of our logos: 🤔 
![image](https://github.com/user-attachments/assets/b71d429d-158e-449f-8f2a-1a3b1b49a1d4)
