### PR TITLE
Climbing grades: Support approximation symbol

### DIFF
--- a/src/components/FeaturePanel/Climbing/ConvertedRouteDifficultyBadge.tsx
+++ b/src/components/FeaturePanel/Climbing/ConvertedRouteDifficultyBadge.tsx
@@ -34,6 +34,9 @@ const TooltipGradeItem = ({
     <GradeValue>{difficulty.grade}</GradeValue> according to{' '}
     <strong>{getGradeSystemName(difficulty.gradeSystem)}</strong>{' '}
     {isConverted && <WarningText>(converted)</WarningText>}
+    {difficulty.grade.includes('~') && (
+      <WarningText>(approximated)</WarningText>
+    )}
   </TooltipGradeItemContainer>
 );
 

--- a/src/components/FeaturePanel/Climbing/utils/grades/routeGrade.ts
+++ b/src/components/FeaturePanel/Climbing/utils/grades/routeGrade.ts
@@ -73,16 +73,29 @@ export const getDifficulties = (tags: FeatureTags): RouteDifficulty[] => {
   }));
 };
 
+export const sanitizeApproximationSymbol = (grade) => {
+  return grade.replace('~', '');
+};
+
 export const getDifficultyColor = (routeDifficulty, theme) => {
   const DEFAULT_COLOR = '#555';
   if (!routeDifficulty) {
     return DEFAULT_COLOR;
   }
+
+  const gradeWithoutApproximationCharacters = sanitizeApproximationSymbol(
+    routeDifficulty.grade,
+  );
+
   const { mode } = theme.palette;
   const uiaaGrade =
     routeDifficulty.gradeSystem !== 'uiaa'
-      ? convertGrade(routeDifficulty.gradeSystem, 'uiaa', routeDifficulty.grade)
-      : routeDifficulty.grade;
+      ? convertGrade(
+          routeDifficulty.gradeSystem,
+          'uiaa',
+          gradeWithoutApproximationCharacters,
+        )
+      : gradeWithoutApproximationCharacters;
   return gradeColors[uiaaGrade]?.[mode] || DEFAULT_COLOR;
 };
 
@@ -103,7 +116,7 @@ export const findOrConvertRouteGrade = (
       convertGrade(
         routeDifficulties?.[0]?.gradeSystem,
         selectedRouteSystem,
-        routeDifficulties?.[0]?.grade,
+        sanitizeApproximationSymbol(routeDifficulties?.[0]?.grade),
       ) ?? '?',
     gradeSystem: selectedRouteSystem,
   };


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<img width="522" alt="image" src="https://github.com/user-attachments/assets/8cb418b2-e2de-470a-8bd4-4f30cd193293">
### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)


resolves #778