### PR TITLE
SearchBox: fix `null`s in overpass history

### DIFF
--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -28,7 +28,7 @@ const overpassOptionSelected = (
   const astOrQuery =
     option.type === 'preset'
       ? option.preset?.presetForSearch.tags
-      : (option.overpass.ast ?? option.overpass.query);
+      : (option.overpass.ast ?? option.overpass.query); // TODO there should be two types for "query" and "ast"
 
   const timeout = setTimeout(() => {
     setOverpassLoading(true);
@@ -41,7 +41,7 @@ const overpassOptionSelected = (
       showToast(content);
       getOverpassSource()?.setData(geojson);
 
-      if (option.type === 'overpass') {
+      if (option.type === 'overpass' && !option.overpass.ast) {
         addOverpassQueryHistory(option.overpass.query);
       }
     })

--- a/src/components/SearchBox/options/overpass.tsx
+++ b/src/components/SearchBox/options/overpass.tsx
@@ -10,7 +10,9 @@ const OVERPASS_HISTORY_KEY = 'overpassQueryHistory';
 
 // TODO use usePersistedState with global context triggering changes
 const getOverpassQueryHistory = (): string[] =>
-  JSON.parse(window.localStorage.getItem(OVERPASS_HISTORY_KEY) ?? '[]');
+  JSON.parse(window.localStorage.getItem(OVERPASS_HISTORY_KEY) ?? '[]').filter(
+    Boolean,
+  );
 
 export const addOverpassQueryHistory = (query: string) => {
   window.localStorage.setItem(

--- a/src/components/SearchBox/types.ts
+++ b/src/components/SearchBox/types.ts
@@ -39,7 +39,7 @@ export type GeocoderOption = GenericOption<
 export type OverpassOption = GenericOption<
   'overpass',
   {
-    query?: string;
+    query?: string; // TODO there should be two types for "query" and "ast"
     ast?: ASTNode;
     inputValue: string;
     label: string;


### PR DESCRIPTION
Every AST search was adding nulls which looked like this:

<img width="525" alt="image" src="https://github.com/user-attachments/assets/c544727e-b9f4-4b67-8295-b22d1e79e5db">

