### PR TITLE
Map: add transport layer + dark mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# This file contains API KEYs for osmapp.org and local development
+# If you want to deploy this project publicly, please obtain your own api keys.
+# You may add override values to .env.local file (ignored by git)
+
+# https://indoorequal.com/dashboard/apikeys
+NEXT_PUBLIC_API_KEY_INDOOREQUAL=iek_yRGaKXYLOv8Qz4tJMzQBj326n2Xa
+
+# https://manage.thunderforest.com/dashboard
+NEXT_PUBLIC_API_KEY_THUNDERFOREST=18c0cb31f2fd41d28ac90abe4059e359
+
+# https://cloud.maptiler.com/account/keys/
+NEXT_PUBLIC_API_KEY_MAPTILER=7dlhLl3hiXQ1gsth0kGu
+
+# https://graphhopper.com/dashboard/#/apikeys
+NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /tsconfig.tsbuildinfo
 .next
 .DS_Store
-.env
 .idea
 .vscode
 next-env.d.ts

--- a/src/components/Directions/routing/getGraphhopperResults.ts
+++ b/src/components/Directions/routing/getGraphhopperResults.ts
@@ -3,7 +3,7 @@ import { LonLat } from '../../../services/types';
 import { fetchJson } from '../../../services/fetch';
 import { intl } from '../../../services/intl';
 
-const API_KEY = `f189b841-6529-46c6-8a91-51f17477dcda`;
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY_GRAPHHOPPER;
 
 export const profiles: Record<Profile, string> = {
   car: 'car',

--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -10,6 +10,7 @@ import { t } from '../../services/intl';
 import { isBrowser } from '../helpers';
 import Maki from '../utils/Maki';
 import { useUserThemeContext } from '../../helpers/theme';
+import DirectionsBusIcon from '@mui/icons-material/DirectionsBus';
 
 interface Layers {
   [key: string]: Layer;
@@ -46,7 +47,7 @@ const czBbox: Bbox = [
 
 export const osmappLayers: Layers = {
   basic: {
-    name: t('layers.basic'),
+    name: `${t('layers.basic')} Maptiler`,
     description: 'maptiler.com',
     type: 'basemap',
     Icon: ExploreIcon,
@@ -76,7 +77,6 @@ export const osmappLayers: Layers = {
   outdoor: {
     name: t('layers.outdoor'),
     description: 'Maptiler.com',
-
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
@@ -93,7 +93,7 @@ export const osmappLayers: Layers = {
   sat: {
     name: t('layers.maptilerSat'),
     type: 'basemap',
-    url: 'https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=7dlhLl3hiXQ1gsth0kGu',
+    url: `https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=${process.env.NEXT_PUBLIC_API_KEY_MAPTILER}`,
     Icon: SatelliteIcon,
     attribution: ['maptiler'],
   },
@@ -122,12 +122,20 @@ export const osmappLayers: Layers = {
     name: t('layers.bike'),
     description: 'Thunderforest.com',
     type: 'basemap',
-    url: `https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}${retina}.png?apikey=18c0cb31f2fd41d28ac90abe4059e359`,
+    url: `https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}${retina}.png?apikey=${process.env.NEXT_PUBLIC_API_KEY_THUNDERFOREST}`,
     Icon: DirectionsBikeIcon,
     attribution: [
       '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a>',
       'osm',
     ],
+  },
+  transport: {
+    name: t('layers.transport'),
+    description: 'Thunderforest.com',
+    type: 'basemap',
+    url: `https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}${retina}.png?apikey=${process.env.NEXT_PUBLIC_API_KEY_THUNDERFOREST}`,
+    darkUrl: `https://{s}.tile.thunderforest.com/transport-dark/{z}/{x}/{y}${retina}.png?apikey=${process.env.NEXT_PUBLIC_API_KEY_THUNDERFOREST}`,
+    Icon: DirectionsBusIcon,
   },
   snow: {
     name: t('layers.snow'),

--- a/src/components/Map/BrowserMap.tsx
+++ b/src/components/Map/BrowserMap.tsx
@@ -19,6 +19,7 @@ import { webglSupported } from './helpers';
 import { useOnMapLongPressed } from './behaviour/useOnMapLongPressed';
 import { useAddTopRightControls } from './useAddTopRightControls';
 import { usePersistedScaleControl } from './behaviour/PersistedScaleControl';
+import { useUserThemeContext } from '../../helpers/theme';
 
 const useOnMapLoaded = createMapEventHook<'load', [MapEventHandler<'load'>]>(
   (_, onMapLoaded) => ({
@@ -50,6 +51,7 @@ const BrowserMap = () => {
   const mobileMode = useMobileMode();
   const { setFeature } = useFeatureContext();
   const { mapLoaded, setMapLoaded, mapClickOverrideRef } = useMapStateContext();
+  const { currentTheme } = useUserThemeContext();
 
   const [map, mapRef] = useInitMap();
   useAddTopRightControls(map, mobileMode);
@@ -63,7 +65,7 @@ const BrowserMap = () => {
   useUpdateViewOnMove(map, setViewFromMap, setBbox);
   useToggleTerrainControl(map);
   useUpdateMap(map, viewForMap);
-  useUpdateStyle(map, activeLayers, userLayers, mapLoaded);
+  useUpdateStyle(map, activeLayers, userLayers, mapLoaded, currentTheme);
   usePersistedScaleControl(map);
 
   return <div ref={mapRef} style={{ height: '100%', width: '100%' }} />;

--- a/src/components/Map/consts.ts
+++ b/src/components/Map/consts.ts
@@ -3,7 +3,7 @@ import type {
   SourceSpecification,
 } from '@maplibre/maplibre-gl-style-spec';
 
-const apiKey = '7dlhLl3hiXQ1gsth0kGu';
+const apiKey = process.env.NEXT_PUBLIC_API_KEY_MAPTILER;
 
 export const OSMAPP_SPRITE = [
   {

--- a/src/components/Map/styles/rasterStyle.ts
+++ b/src/components/Map/styles/rasterStyle.ts
@@ -2,6 +2,7 @@ import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { GLYPHS, OSMAPP_SOURCES, OSMAPP_SPRITE } from '../consts';
 import { overpassLayers } from './layers/overpassLayers';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
+import { Theme } from '../../../helpers/theme';
 
 const getSource = (url) => {
   if (url.match('{bingSubdomains}')) {
@@ -53,7 +54,18 @@ const rasterStyle = (id: string, url: string): StyleSpecification => {
   };
 };
 
-export const getRasterStyle = (key: string): StyleSpecification => {
-  const url = osmappLayers[key]?.url ?? key; // if `key` not found, it contains tiles URL
-  return rasterStyle(key, url);
+export const getRasterStyle = (
+  key: string,
+  currentTheme: Theme,
+): StyleSpecification => {
+  const layer = osmappLayers[key];
+  const isDark = currentTheme === 'dark';
+
+  const layerUrl = layer
+    ? isDark
+      ? (layer.darkUrl ?? layer.url)
+      : layer.url
+    : key; // if `key` not found, it contains custom tiles URL
+
+  return rasterStyle(key, layerUrl);
 };

--- a/src/components/utils/MapStateContext.tsx
+++ b/src/components/utils/MapStateContext.tsx
@@ -23,6 +23,7 @@ export interface Layer {
   name?: string;
   description?: string;
   url?: string;
+  darkUrl?: string; // optional url for dark mode
   key?: string;
   Icon?: LayerIcon;
   attribution?: string[]; // missing in spacer TODO refactor ugly

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -208,9 +208,10 @@ export default {
   'layers.mtb': 'MTB',
   'layers.snow': 'Zimní',
   'layers.carto': 'OSM Carto',
-  'layers.maptilerSat': 'Letecká Maptiler ',
+  'layers.maptilerSat': 'Letecká Maptiler',
   'layers.bingSat': 'Letecká Bing',
   'layers.bike': 'Cyklo',
+  'layers.transport': 'Dopravní',
   'layers.climbing': 'Sportovní lezení',
 
   'climbingareas.link': 'Seznam všech lezeckých oblastí',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -266,6 +266,7 @@ export default {
   'layers.maptilerSat': 'Maptiler Satellite (z<14)',
   'layers.bingSat': 'Bing Satellite',
   'layers.bike': 'Bike',
+  'layers.transport': 'Transport',
   'layers.climbing': 'Climbing',
 
   'climbingpanel.create_climbing_route': 'Draw new route in schema',


### PR DESCRIPTION
- add transport layer by [thunderforest.com](https://thunderforest.com)
- switch to dark version, when user theme changes (added support for `darkUrl` for raster layers and overlays)

Also fixes #604