### PR TITLE
ClimbingView: Add boulder badge to crag and route detail

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingTypeBadge.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingTypeBadge.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Feature } from '../../../services/types';
+import styled from '@emotion/styled';
+import { Chip } from '@mui/material';
+
+const StyledChip = styled(Chip)`
+  font-size: 10px;
+  font-weight: 600;
+  height: 14px;
+  padding: 0;
+  > span {
+    padding: 4px;
+  }
+`;
+
+type Props = {
+  feature: Feature;
+};
+
+export const ClimbingTypeBadge = ({ feature }: Props) => {
+  if (feature.tags?.['climbing:boulder'] === 'yes')
+    return (
+      <StyledChip
+        label="boulder"
+        size="small"
+        color="primary"
+        variant="filled"
+      />
+    );
+  return null;
+};

--- a/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
@@ -26,6 +26,7 @@ import { useEditDialogContext } from '../../helpers/EditDialogContext';
 import EditIcon from '@mui/icons-material/Edit';
 import CloseIcon from '@mui/icons-material/Close';
 import { useMobileMode } from '../../../helpers';
+import { ClimbingTypeBadge } from '../ClimbingTypeBadge';
 
 const Container = styled.div`
   width: 100%;
@@ -47,9 +48,9 @@ const RouteName = styled.div<{ opacity: number }>`
   flex: 1;
   opacity: ${({ opacity }) => opacity};
   display: flex;
-  gap: 4px;
-  justify-content: space-between;
+  gap: 8px;
   position: relative;
+  align-items: center;
   user-select: text;
 `;
 
@@ -176,7 +177,6 @@ export const ClimbingRouteTableRow = forwardRef<
       href: routeDetailUrl,
       locale: intl.lang,
     };
-
     return (
       <Container ref={ref}>
         <Row
@@ -198,6 +198,8 @@ export const ClimbingRouteTableRow = forwardRef<
           <Stack justifyContent="stretch" flex={1}>
             <RouteName opacity={photoPathsCount === 0 ? 0.5 : 1}>
               {feature.tags?.name}
+              <ClimbingTypeBadge feature={feature} />
+
               {!isMobileMode && isSelected && (
                 <SelectedButton>
                   <Tooltip title="Deselect route">

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -21,11 +21,12 @@ import { EditDialog } from './EditDialog/EditDialog';
 import { RouteDistributionInPanel } from './Climbing/RouteDistribution';
 import { FeaturePanelFooter } from './FeaturePanelFooter';
 import { ClimbingRouteGrade } from './ClimbingRouteGrade';
-import { Box } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { ClimbingGuideInfo } from './Climbing/ClimbingGuideInfo';
 import { ClimbingStructuredData } from './Climbing/ClimbingStructuredData';
 import { isPublictransportRoute } from '../../utils';
 import { Sockets } from './Sockets/Sockets';
+import { ClimbingTypeBadge } from './Climbing/ClimbingTypeBadge';
 
 const Flex = styled.div`
   flex: 1;
@@ -60,7 +61,10 @@ export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
       <PanelContent>
         <PanelSidePadding>
           <FeatureHeading ref={headingRef} />
-          <ClimbingRouteGrade />
+          <Stack spacing={1} alignItems="flex-start">
+            <ClimbingRouteGrade />
+            <ClimbingTypeBadge feature={feature} />
+          </Stack>
           <ClimbingGuideInfo />
           <ParentLink />
           <ClimbingRestriction />


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

<img width="464" alt="image" src="https://github.com/user-attachments/assets/a7496e7d-4c63-42b7-829b-ecc23875560a">


### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
