### PR TITLE
general: log server load events to tweak vercel bill

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,3 @@ NEXT_PUBLIC_API_KEY_MAPTILER=7dlhLl3hiXQ1gsth0kGu
 
 # https://graphhopper.com/dashboard/#/apikeys
 NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda
-
-# https://us.umami.is/websites - this key is for development only, prod code in vercel
-UMAMI_WEBSITE_ID=5e4d4917-9031-42f1-a26a-e71d7ab8e3fe

--- a/.env
+++ b/.env
@@ -13,3 +13,6 @@ NEXT_PUBLIC_API_KEY_MAPTILER=7dlhLl3hiXQ1gsth0kGu
 
 # https://graphhopper.com/dashboard/#/apikeys
 NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda
+
+# https://us.umami.is/websites - this key is for development only, prod code in vercel
+UMAMI_WEBSITE_ID=5e4d4917-9031-42f1-a26a-e71d7ab8e3fe

--- a/.env
+++ b/.env
@@ -14,5 +14,6 @@ NEXT_PUBLIC_API_KEY_MAPTILER=7dlhLl3hiXQ1gsth0kGu
 # https://graphhopper.com/dashboard/#/apikeys
 NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda
 
+# Umami anylytics is used to track server load only. We don't want to track clicks in browser.
 # https://us.umami.is/websites - this key is for development only, prod code in vercel
 UMAMI_WEBSITE_ID=5e4d4917-9031-42f1-a26a-e71d7ab8e3fe

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,8 +9,8 @@ import Document, {
 } from 'next/document';
 import type { DocumentContext } from 'next/dist/shared/lib/utils';
 import {
-  DocumentHeadTags,
   documentGetInitialProps,
+  DocumentHeadTags,
   DocumentHeadTagsProps,
 } from '@mui/material-nextjs/v13-pagesRouter';
 import { getServerIntl } from '../src/services/intlServer';
@@ -20,6 +20,7 @@ import { PROJECT_ID, setProjectForSSR } from '../src/services/project';
 import { FaviconsOpenClimbing } from '../src/helpers/FaviconsOpenClimbing';
 import { LANGUAGES } from '../src/config.mjs';
 import styled from '@emotion/styled';
+import { logRequest } from '../src/server/logRequest';
 
 const Body = styled.body`
   @media (prefers-color-scheme: light) {
@@ -103,6 +104,8 @@ MyDocument.getInitialProps = async (
   setProjectForSSR(ctx);
 
   const initialProps = await documentGetInitialProps(ctx);
+
+  logRequest(ctx, serverIntl);
 
   return {
     ...initialProps,

--- a/src/components/App/helpers.ts
+++ b/src/components/App/helpers.ts
@@ -12,8 +12,6 @@ import { NextPageContext } from 'next';
 
 const DEFAULT_VIEW: View = ['4', '50', '14'];
 
-const isLocalhostOrNgnix = (ip: string) => ['127.0.0.1', '::1'].includes(ip);
-
 type IpApiResponse = {
   status: string;
   lat: number;
@@ -39,14 +37,20 @@ const getViewFromIp = async (ip: string): Promise<View> => {
   }
 };
 
-export const getViewFromRequest = async (
-  req: NextPageContext['req'],
-): Promise<View> => {
+const isLocalhostOrNgnix = (ip: string) => ['127.0.0.1', '::1'].includes(ip);
+
+export const getIp = (req: NextPageContext['req']) => {
   const remoteIp = req.socket.remoteAddress;
   const fwdIp = ((req.headers['x-forwarded-for'] as string) || '') // ngnix: proxy_set_header X-Forwarded-For $remote_addr;
     .split(',')[0]
     .trim();
-  const ip = isLocalhostOrNgnix(remoteIp) ? fwdIp : remoteIp;
+  return isLocalhostOrNgnix(remoteIp) ? fwdIp : remoteIp;
+};
+
+export const getViewFromRequest = async (
+  req: NextPageContext['req'],
+): Promise<View> => {
+  const ip = getIp(req);
   const view = ip ? await getViewFromIp(ip) : null;
   return view ?? DEFAULT_VIEW;
 };

--- a/src/server/logRequest.tsx
+++ b/src/server/logRequest.tsx
@@ -1,0 +1,47 @@
+import type { DocumentContext } from 'next/dist/shared/lib/utils';
+import { Intl } from '../services/intl';
+import { fetchJson } from '../services/fetch';
+import { getIp } from '../components/App/helpers';
+
+// On some days we have 100k of page loads of Vercel Serveless Function.
+// Because of that, we had to switch to paid Pro plan from the Hobby.
+//
+// We need to debug where this traffic comes from to be able to optimize it.
+
+// This function works server-side only to omit any tracking cookies.
+
+export const logRequest = (ctx: DocumentContext, intl: Intl) => {
+  const { host, referrer } = ctx.req.headers;
+  const data = {
+    type: 'event',
+    payload: {
+      website: process.env.UMAMI_WEBSITE_ID,
+      url: ctx.asPath,
+      hostname: host,
+      language: intl.lang,
+      referrer,
+      screen: '1280x800',
+    },
+  };
+  const headers = {
+    'X-Client-IP': getIp(ctx.req),
+    'User-Agent': ctx.req.headers['user-agent'],
+  };
+
+  console.log('umami data', JSON.stringify({ data, headers }, null, 2));
+
+  // Promise omitted intentionally
+  fetchJson('https://cloud.umami.is/api/send', {
+    nocache: true,
+    method: 'POST',
+    headers,
+    body: JSON.stringify(data),
+  }).then(
+    (response) => {
+      console.log('umami response', response);
+    },
+    (error) => {
+      console.error('umami error', error);
+    },
+  );
+};

--- a/src/server/logRequest.tsx
+++ b/src/server/logRequest.tsx
@@ -1,7 +1,7 @@
 import type { DocumentContext } from 'next/dist/shared/lib/utils';
 import { Intl } from '../services/intl';
-import { fetchJson } from '../services/fetch';
 import { getIp } from '../components/App/helpers';
+import { fetchText } from '../services/fetch';
 
 // On some days we have 100k of page loads of Vercel Serveless Function.
 // Because of that, we had to switch to paid Pro plan from the Hobby.
@@ -17,31 +17,23 @@ export const logRequest = (ctx: DocumentContext, intl: Intl) => {
     payload: {
       website: process.env.UMAMI_WEBSITE_ID,
       url: ctx.asPath,
-      hostname: host,
+      hostname: host.split(':')[0],
       language: intl.lang,
       referrer,
-      screen: '1280x800',
     },
   };
   const headers = {
+    'Content-Type': 'application/json',
     'X-Client-IP': getIp(ctx.req),
     'User-Agent': ctx.req.headers['user-agent'],
   };
 
-  console.log('umami data', JSON.stringify({ data, headers }, null, 2));
-
-  // Promise omitted intentionally
-  fetchJson('https://cloud.umami.is/api/send', {
-    nocache: true,
+  // Promise omitted intentionally, so the app can continue without waiting
+  fetchText('https://cloud.umami.is/api/send', {
     method: 'POST',
     headers,
     body: JSON.stringify(data),
-  }).then(
-    (response) => {
-      console.log('umami response', response);
-    },
-    (error) => {
-      console.error('umami error', error);
-    },
-  );
+  }).catch((error) => {
+    console.error('logRequest error', error); // eslint-disable-line no-console
+  });
 };

--- a/src/server/logRequest.tsx
+++ b/src/server/logRequest.tsx
@@ -13,35 +13,36 @@ import { getIp } from '../components/App/helpers';
 export const logRequest = (ctx: DocumentContext, intl: Intl) => {
   const { host, referrer } = ctx.req.headers;
   const data = {
-    type: 'event',
-    payload: {
-      website: process.env.UMAMI_WEBSITE_ID,
+    event: {
       url: ctx.asPath,
       hostname: host,
       language: intl.lang,
       referrer,
-      screen: '1280x800',
+      ip: getIp(ctx.req),
+      browser: ctx.req.headers['user-agent'],
     },
+    sourcetype: 'manual',
+    host,
+    index: 'main',
   };
-  const headers = {
-    'X-Client-IP': getIp(ctx.req),
-    'User-Agent': ctx.req.headers['user-agent'],
-  };
-
-  console.log('umami data', JSON.stringify({ data, headers }, null, 2));
 
   // Promise omitted intentionally
-  fetchJson('https://cloud.umami.is/api/send', {
-    nocache: true,
-    method: 'POST',
-    headers,
-    body: JSON.stringify(data),
-  }).then(
+  fetchJson(
+    'https://prd-p-a8gkn.splunkcloud.com:8088/services/collector/event',
+    {
+      nocache: true,
+      method: 'POST',
+      headers: {
+        authorization: 'Splunk 21a3e9e9-9f65-4eee-a18d-02e86aa6374a',
+      },
+      body: JSON.stringify(data),
+    },
+  ).then(
     (response) => {
-      console.log('umami response', response);
+      console.log('logRequest response', response);
     },
     (error) => {
-      console.error('umami error', error);
+      console.error('logRequest error', error);
     },
   );
 };

--- a/src/server/logRequest.tsx
+++ b/src/server/logRequest.tsx
@@ -13,36 +13,35 @@ import { getIp } from '../components/App/helpers';
 export const logRequest = (ctx: DocumentContext, intl: Intl) => {
   const { host, referrer } = ctx.req.headers;
   const data = {
-    event: {
+    type: 'event',
+    payload: {
+      website: process.env.UMAMI_WEBSITE_ID,
       url: ctx.asPath,
       hostname: host,
       language: intl.lang,
       referrer,
-      ip: getIp(ctx.req),
-      browser: ctx.req.headers['user-agent'],
+      screen: '1280x800',
     },
-    sourcetype: 'manual',
-    host,
-    index: 'main',
+  };
+  const headers = {
+    'X-Client-IP': getIp(ctx.req),
+    'User-Agent': ctx.req.headers['user-agent'],
   };
 
+  console.log('umami data', JSON.stringify({ data, headers }, null, 2));
+
   // Promise omitted intentionally
-  fetchJson(
-    'https://prd-p-a8gkn.splunkcloud.com:8088/services/collector/event',
-    {
-      nocache: true,
-      method: 'POST',
-      headers: {
-        authorization: 'Splunk 21a3e9e9-9f65-4eee-a18d-02e86aa6374a',
-      },
-      body: JSON.stringify(data),
-    },
-  ).then(
+  fetchJson('https://cloud.umami.is/api/send', {
+    nocache: true,
+    method: 'POST',
+    headers,
+    body: JSON.stringify(data),
+  }).then(
     (response) => {
-      console.log('logRequest response', response);
+      console.log('umami response', response);
     },
     (error) => {
-      console.error('logRequest error', error);
+      console.error('umami error', error);
     },
   );
 };

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -58,9 +58,7 @@ export const fetchText = async (url: string, opts: FetchOpts = {}) => {
       throw e;
     }
 
-    const cause = e instanceof Error ? ` / cause: ${e.cause}` : '';
-    const message = `${e.message}${cause} at ${url}`;
-    throw new FetchError(message, e.code || 'network', e.data); // TODO how to tell network error from code exception?
+    throw new FetchError(`${e.message} at ${url}`, e.code || 'network', e.data); // TODO how to tell network error from code exception?
   }
 };
 

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -58,7 +58,9 @@ export const fetchText = async (url: string, opts: FetchOpts = {}) => {
       throw e;
     }
 
-    throw new FetchError(`${e.message} at ${url}`, e.code || 'network', e.data); // TODO how to tell network error from code exception?
+    const cause = e?.cause ? ` / cause: ${e.cause}` : '';
+    const message = `${e.message}${cause} at ${url}`;
+    throw new FetchError(message, e.code || 'network', e.data); // TODO how to tell network error from code exception?
   }
 };
 

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -58,7 +58,9 @@ export const fetchText = async (url: string, opts: FetchOpts = {}) => {
       throw e;
     }
 
-    throw new FetchError(`${e.message} at ${url}`, e.code || 'network', e.data); // TODO how to tell network error from code exception?
+    const cause = e instanceof Error ? ` / cause: ${e.cause}` : '';
+    const message = `${e.message}${cause} at ${url}`;
+    throw new FetchError(message, e.code || 'network', e.data); // TODO how to tell network error from code exception?
   }
 };
 

--- a/src/services/intl.tsx
+++ b/src/services/intl.tsx
@@ -8,7 +8,7 @@ import { publishDbgObject } from '../utils';
 
 type Values = { [variable: string]: string | number };
 
-interface Intl {
+export interface Intl {
   lang: string;
   messages: MessagesType | {};
 }

--- a/src/services/intlServer.tsx
+++ b/src/services/intlServer.tsx
@@ -1,6 +1,7 @@
 import acceptLanguageParser from 'accept-language-parser';
 import nextCookies from 'next-cookies';
 import { LANGUAGES } from '../config.mjs';
+import { Intl } from './intl';
 
 // the files are not imported in main bundle
 const getMessages = async (lang) =>
@@ -33,7 +34,7 @@ const resolveCurrentLang = (ctx) => {
   return getLangFromAcceptHeader(ctx) ?? DEFAULT_LANG;
 };
 
-export const getServerIntl = async (ctx) => {
+export const getServerIntl = async (ctx): Promise<Intl> => {
   const lang = resolveCurrentLang(ctx);
   const vocabulary = await getMessages('vocabulary');
   const messages = lang === DEFAULT_LANG ? {} : await getMessages(lang);


### PR DESCRIPTION
On some days we have 100k of page loads of Vercel Serveless Function. Currently we had to switch to payed Pro plan from the Hobby.

We need to debug where this traffic comes from to be able to optimize it.