### PR TITLE
Climbing: Persist splitPaneSize in UserSettingsContext

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingView.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingView.tsx
@@ -262,8 +262,6 @@ export const ClimbingView = ({ photo }: { photo?: string }) => {
     imageSize,
     routeSelectedIndex,
     getMachine,
-    splitPaneSize,
-    setSplitPaneSize,
     isEditMode,
     viewportSize,
     editorPosition,
@@ -286,7 +284,8 @@ export const ClimbingView = ({ photo }: { photo?: string }) => {
   const [backgroundImageUrl, setBackgroundImageUrl] = useState(null);
   const machine = getMachine();
   const cragViewLayout = useGetCragViewLayout();
-  const { userSettings } = useUserSettingsContext();
+  const { userSettings, setUserSetting } = useUserSettingsContext();
+  const splitPaneSize = userSettings['climbing.splitPaneSize'];
 
   useEffect(() => {
     if (isEditMode && machine.currentStateName === 'routeSelected') {
@@ -307,7 +306,7 @@ export const ClimbingView = ({ photo }: { photo?: string }) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onSplitPaneSizeReset = () => {
-    setSplitPaneSize(null);
+    setUserSetting('climbing.splitPaneSize', null);
   };
 
   React.useEffect(() => {
@@ -324,7 +323,7 @@ export const ClimbingView = ({ photo }: { photo?: string }) => {
     setIsSplitViewDragging(true);
   };
   const onDragFinished = (splitHeight: number) => {
-    setSplitPaneSize(splitHeight);
+    setUserSetting('climbing.splitPaneSize', splitHeight);
     setIsSplitViewDragging(false);
   };
   const [windowDimensions, setWindowDimensions] = useState(

--- a/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
@@ -16,6 +16,7 @@ import dynamic from 'next/dynamic';
 import { EditButton } from '../EditButton';
 import { EditDialog } from '../EditDialog/EditDialog';
 import { useGetCragViewLayout } from './utils/useCragViewLayout';
+import { useUserSettingsContext } from '../../utils/UserSettingsContext';
 
 const CragMapDynamic = dynamic(() => import('./CragMap'), {
   ssr: false,
@@ -38,8 +39,10 @@ const ContentBelowRouteList = styled.div<{
 `;
 
 export const ClimbingViewContent = ({ isMapVisible }) => {
-  const { splitPaneSize, showDebugMenu, routes } = useClimbingContext();
+  const { showDebugMenu, routes } = useClimbingContext();
   const cragViewLayout = useGetCragViewLayout();
+  const { userSettings } = useUserSettingsContext();
+  const splitPaneSize = userSettings['climbing.splitPaneSize'];
 
   const getRoutesCsv = () => {
     const getPathString = (path) =>

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -60,8 +60,6 @@ type ClimbingContextType = {
   setEditorPosition: (position: PositionPx) => void;
   setImageSize: (ImageSize) => void;
   setImageContainerSize: (ImageSize) => void;
-  splitPaneSize: number | null;
-  setSplitPaneSize: (size: number | null) => void;
   photoPaths: Array<string>;
   setPhotoPaths: (path: Array<string>) => void;
   photoPath: string;
@@ -158,7 +156,6 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
   });
   const [loadedPhotos, setLoadedPhotos] = useState<LoadedPhotos>({});
   const [routes, setRoutes] = useState<Array<ClimbingRoute>>(initialRoutes);
-  const [splitPaneSize, setSplitPaneSize] = useState<number | null>(null);
   const [isPointMoving, setIsPointMoving] = useState<boolean>(false);
   const [isPanningDisabled, setIsPanningDisabled] = useState<boolean>(false);
   const [isPointClicked, setIsPointClicked] = useState<boolean>(false);
@@ -353,8 +350,6 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
     scrollOffset,
     setScrollOffset,
     findCloserPoint,
-    splitPaneSize,
-    setSplitPaneSize,
     mousePosition,
     setMousePosition,
     pointElement,

--- a/src/components/utils/UserSettingsContext.tsx
+++ b/src/components/utils/UserSettingsContext.tsx
@@ -6,6 +6,7 @@ import {
 } from '../FeaturePanel/Climbing/utils/grades/gradeData';
 import { TickStyle } from '../FeaturePanel/Climbing/types';
 import { isMobileDevice } from '../helpers';
+import { SPLIT_PANE_DEFAULT_SIZE } from '../FeaturePanel/Climbing/config';
 
 type CragViewLayout = 'vertical' | 'horizontal' | 'auto';
 
@@ -19,6 +20,7 @@ type UserSettingsType = {
   'climbing.switchPhotosByScrolling': boolean;
   'climbing.visibleGradeSystems': Record<string, boolean>;
   'climbing.cragViewLayout': CragViewLayout;
+  'climbing.splitPaneSize': null | number;
 };
 
 type UserSettingsContextType = {
@@ -41,6 +43,8 @@ const initialUserSettings: UserSettingsType = {
     {},
   ),
   'climbing.cragViewLayout': 'auto',
+
+  'climbing.splitPaneSize': null,
 };
 
 export const UserSettingsContext =


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
