### PR TITLE
Style multi edit dialog

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/ContributionInfoBox.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ContributionInfoBox.tsx
@@ -7,13 +7,13 @@ export const ContributionInfoBox = () => {
   const { loggedIn } = useOsmAuthContext();
   return loggedIn ? (
     <Box mt={4} mb={4}>
-      <Typography variant="body1" color="textSecondary" paragraph>
+      <Typography variant="body1" color="textSecondary">
         <Translation id="editdialog.info_edit" />
       </Typography>
     </Box>
   ) : (
     <Box mt={4} mb={4}>
-      <Typography variant="body1" color="textSecondary" paragraph>
+      <Typography variant="body1" color="textSecondary">
         <Translation id="editdialog.info_note" />
       </Typography>
     </Box>

--- a/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
@@ -1,4 +1,11 @@
-import { DialogContent } from '@mui/material';
+import {
+  DialogContent,
+  Stack,
+  Tab,
+  Tabs,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import React from 'react';
 import { EditDialogActions } from './EditDialogActions';
 import { CommentField } from './CommentField';
@@ -9,52 +16,55 @@ import { FeatureEditSection } from './FeatureEditSection/FeatureEditSection';
 import { useEditDialogFeature } from '../utils';
 import { useEditContext } from '../EditContext';
 import { getShortId } from '../../../../services/helpers';
-import { fetchSchemaTranslations } from '../../../../services/tagging/translations';
 
 export const EditContent = () => {
   const { feature } = useEditDialogFeature();
-  const { items, addFeature } = useEditContext();
+  const { items } = useEditContext();
   const [current, setCurrent] = React.useState(getShortId(feature.osmMeta));
+  const theme = useTheme();
+
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
     <>
       <DialogContent dividers>
         <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
           <OsmUserLoggedOut />
-          {items.map(({ shortId }, idx) => (
-            <button key={idx} onClick={() => setCurrent(shortId)}>
-              {shortId}
-            </button>
-          ))}
-          <br />
-          <button
-            onClick={async () => {
-              await fetchSchemaTranslations();
-              const osmApiTestItems = await import(
-                '../../../../services/osmApiTestItems'
-              );
-              addFeature(osmApiTestItems.TEST_CRAG);
-            }}
-          >
-            Add test crag
-          </button>
-          <button
-            onClick={async () => {
-              await fetchSchemaTranslations();
-              const osmApiTestItems = await import(
-                '../../../../services/osmApiTestItems'
-              );
-              addFeature(osmApiTestItems.TEST_NODE);
-            }}
-          >
-            Add test node
-          </button>
-          <br />
-          <br />
-          <FeatureEditSection shortId={current} />
-          <ContributionInfoBox />
-          <CommentField />
-          <OsmUserLogged />
+
+          <Stack direction={isSmallScreen ? 'column' : 'row'} gap={2}>
+            {items.length > 1 && (
+              <Tabs
+                orientation={isSmallScreen ? 'horizontal' : 'vertical'}
+                variant={isSmallScreen ? 'scrollable' : 'standard'}
+                value={current}
+                onChange={(
+                  _event: React.SyntheticEvent,
+                  newShortId: string,
+                ) => {
+                  setCurrent(newShortId);
+                }}
+                sx={{
+                  borderRight: isSmallScreen ? 0 : 1,
+                  borderBottom: isSmallScreen ? 1 : 0,
+                  borderColor: 'divider',
+                  '&& .MuiTab-root': {
+                    alignItems: isSmallScreen ? undefined : 'baseline',
+                    textAlign: isSmallScreen ? undefined : 'left',
+                  },
+                }}
+              >
+                {items.map(({ shortId, tags }, idx) => (
+                  <Tab key={idx} label={tags.name ?? shortId} value={shortId} />
+                ))}
+              </Tabs>
+            )}
+            <div>
+              <FeatureEditSection shortId={current} />
+              <ContributionInfoBox />
+              <CommentField />
+              <OsmUserLogged />
+            </div>
+          </Stack>
         </form>
       </DialogContent>
       <EditDialogActions />

--- a/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
@@ -7,19 +7,50 @@ import { ContributionInfoBox } from './ContributionInfoBox';
 import { OsmUserLoggedOut } from './OsmUserLoggedOut';
 import { FeatureEditSection } from './FeatureEditSection/FeatureEditSection';
 import { useEditDialogFeature } from '../utils';
+import { useEditContext } from '../EditContext';
 import { getShortId } from '../../../../services/helpers';
+import { fetchSchemaTranslations } from '../../../../services/tagging/translations';
 
 export const EditContent = () => {
   const { feature } = useEditDialogFeature();
-
-  const current = getShortId(feature.osmMeta);
+  const { items, addFeature } = useEditContext();
+  const [current, setCurrent] = React.useState(getShortId(feature.osmMeta));
 
   return (
     <>
       <DialogContent dividers>
         <form autoComplete="off" onSubmit={(e) => e.preventDefault()}>
           <OsmUserLoggedOut />
-
+          {items.map(({ shortId }, idx) => (
+            <button key={idx} onClick={() => setCurrent(shortId)}>
+              {shortId}
+            </button>
+          ))}
+          <br />
+          <button
+            onClick={async () => {
+              await fetchSchemaTranslations();
+              const osmApiTestItems = await import(
+                '../../../../services/osmApiTestItems'
+              );
+              addFeature(osmApiTestItems.TEST_CRAG);
+            }}
+          >
+            Add test crag
+          </button>
+          <button
+            onClick={async () => {
+              await fetchSchemaTranslations();
+              const osmApiTestItems = await import(
+                '../../../../services/osmApiTestItems'
+              );
+              addFeature(osmApiTestItems.TEST_NODE);
+            }}
+          >
+            Add test node
+          </button>
+          <br />
+          <br />
           <FeatureEditSection shortId={current} />
           <ContributionInfoBox />
           <CommentField />

--- a/src/components/FeaturePanel/EditDialog/EditDialog.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditDialog.tsx
@@ -29,11 +29,17 @@ const EditDialogInner = () => {
 
   return (
     <StyledDialog
-      maxWidth="md"
+      PaperProps={{
+        sx: {
+          height: '100%',
+        },
+      }}
+      maxWidth="xl"
       fullScreen={fullScreen}
       open={opened}
       onClose={onClose}
       aria-labelledby="edit-dialog-title"
+      sx={{ height: '100%' }}
     >
       <EditDialogTitle />
       {successInfo ? <SuccessContent /> : <EditContent />}

--- a/src/components/FeaturePanel/EditDialog/EditDialogTitle.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditDialogTitle.tsx
@@ -6,13 +6,21 @@ import { t } from '../../../services/intl';
 import { getLabel } from '../../../helpers/featureLabel';
 import CommentIcon from '@mui/icons-material/Comment';
 import EditIcon from '@mui/icons-material/Edit';
+import { useEditContext } from './EditContext';
 
 const useGetDialogTitle = (isAddPlace, isUndelete, feature) => {
   const { loggedIn } = useOsmAuthContext();
+  const { items } = useEditContext();
   if (isAddPlace) return t('editdialog.add_heading');
   if (isUndelete) return t('editdialog.undelete_heading');
-  if (!loggedIn)
+  if (!loggedIn) {
+    if (items.length > 1)
+      return `${t('editdialog.suggest_heading')} ${items.length} ${t('editdialog.items')}`;
     return `${t('editdialog.suggest_heading')} ${getLabel(feature)}`;
+  }
+
+  if (items.length > 1)
+    return `${t('editdialog.edit_heading')} ${items.length} ${t('editdialog.items')}`;
   return `${t('editdialog.edit_heading')} ${getLabel(feature)}`;
 };
 

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -187,6 +187,7 @@ export default {
   'editdialog.add_heading': 'Add to OpenStreetMap',
   'editdialog.undelete_heading': 'Add again to OpenStreetMap',
   'editdialog.edit_heading': 'Edit:',
+  'editdialog.items': 'items',
   'editdialog.suggest_heading': 'Suggest an edit:',
   'editdialog.feature_type_select': 'Choose type',
   'editdialog.options_heading': 'Options',


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

1 entity
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/a048e02f-ab11-4f43-a297-9439c6eff98f">

2 entities
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/c412f5ee-b977-46c9-9ac8-016d4d950acc">

3 entities + mobile resolution
<img width="583" alt="image" src="https://github.com/user-attachments/assets/7b357c7f-960d-4be2-8026-3cb60660ff06">

cc @zbycz 


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
