### PR TITLE
SearchBox: Add a `!=` operator to the query wizard

### DIFF
--- a/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
+++ b/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
@@ -14,6 +14,10 @@ describe('userInput -> query works', () => {
     expect(generateQuery(getAST('   diet:vegan=no '))).toBe(
       'nwr["diet:vegan"="no"]',
     );
+    expect(generateQuery(getAST('tourism!=hotel'))).toBe(
+      'nwr["tourism"!="hotel"]',
+    );
+    expect(generateQuery(getAST('cuisine!=*'))).toBe('nwr["cousine"!~".*"]');
   });
 
   it('should work for more complex queries', () => {
@@ -32,6 +36,10 @@ describe('userInput -> query works', () => {
         getAST('amenity=restaurant or amenity = cafe or historic=*'),
       ),
     ).toBe('nwr["amenity"="restaurant"];nwr["amenity"="cafe"];nwr["historic"]');
+
+    expect(generateQuery(getAST('tourism=* and tourism!=hotel'))).toBe(
+      'nwr["tourism"]["tourisms"!="hotel"]',
+    );
   });
 
   it('should work with groups', () => {
@@ -70,6 +78,7 @@ describe('userInput -> query works', () => {
 test('userInput (ast) -> label works', () => {
   expect(queryWizardLabel(getAST('amenity=*'))).toBe('amenity=*');
   expect(queryWizardLabel(getAST('amenity=bench'))).toBe('amenity=bench');
+  expect(queryWizardLabel(getAST('amenity!=bench'))).toBe('amenity!=bench');
   expect(queryWizardLabel(getAST('amenity=bench or speed_limit=30'))).toBe(
     'amenity=bench or 1 other',
   );

--- a/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
+++ b/src/components/SearchBox/queryWizard/__tests__/queryWizard.test.ts
@@ -17,7 +17,7 @@ describe('userInput -> query works', () => {
     expect(generateQuery(getAST('tourism!=hotel'))).toBe(
       'nwr["tourism"!="hotel"]',
     );
-    expect(generateQuery(getAST('cuisine!=*'))).toBe('nwr["cousine"!~".*"]');
+    expect(generateQuery(getAST('cuisine!=*'))).toBe('nwr["cuisine"!~".*"]');
   });
 
   it('should work for more complex queries', () => {
@@ -38,7 +38,7 @@ describe('userInput -> query works', () => {
     ).toBe('nwr["amenity"="restaurant"];nwr["amenity"="cafe"];nwr["historic"]');
 
     expect(generateQuery(getAST('tourism=* and tourism!=hotel'))).toBe(
-      'nwr["tourism"]["tourisms"!="hotel"]',
+      'nwr["tourism"]["tourism"!="hotel"]',
     );
   });
 

--- a/src/components/SearchBox/queryWizard/ast.ts
+++ b/src/components/SearchBox/queryWizard/ast.ts
@@ -8,7 +8,7 @@ export type ASTNodeComparison = {
   type: 'comparison';
   key: string;
   value: SpecialValue | string;
-  operator: '=';
+  operator: '=' | '!=';
 };
 
 export type ASTNodeGroup = { type: 'group'; expression: ASTNode };

--- a/src/components/SearchBox/queryWizard/generateQuery.ts
+++ b/src/components/SearchBox/queryWizard/generateQuery.ts
@@ -1,4 +1,5 @@
 import { ASTNode, ASTNodeComparison, ASTNodeExpression } from './ast';
+import { isSpecialComparisonValue } from './isAst';
 
 const processNode = (node: ASTNode): string[][] => {
   switch (node.type) {
@@ -12,11 +13,14 @@ const processNode = (node: ASTNode): string[][] => {
 };
 
 const generateComparison = ({ key, value, operator }: ASTNodeComparison) => {
-  // Using switch to simplify adding more operators in the future
   switch (operator) {
     case '=':
       // Only { type=anything } isn't a string
       return typeof value === 'string' ? `["${key}"="${value}"]` : `["${key}"]`;
+    case '!=':
+      return typeof value === 'string'
+        ? `["${key}"!="${value}"]`
+        : `["${key}"!~".*"]`;
   }
 };
 

--- a/src/components/SearchBox/queryWizard/isAst.ts
+++ b/src/components/SearchBox/queryWizard/isAst.ts
@@ -22,7 +22,7 @@ const isComparisonAstNode = (obj: any): obj is ASTNodeComparison => {
       type === 'comparison' &&
       typeof key === 'string' &&
       (typeof value === 'string' || isSpecialComparisonValue(value)) &&
-      operator === '='
+      (operator === '=' || operator === '!=')
     );
   } catch {
     return false;

--- a/src/components/SearchBox/queryWizard/queryWizard.ts
+++ b/src/components/SearchBox/queryWizard/queryWizard.ts
@@ -10,12 +10,13 @@ export const getAST = (inputValue: string) => {
 export const queryWizardLabel = (ast: ASTNode): string => {
   switch (ast.type) {
     case 'comparison':
+      const { operator } = ast;
       if (!isSpecialComparisonValue(ast.value)) {
-        return `${ast.key}=${ast.value}`;
+        return `${ast.key}${operator}${ast.value}`;
       }
 
       if (ast.value.type === 'anything') {
-        return `${ast.key}=*`;
+        return `${ast.key}${operator}*`;
       }
       break;
     case 'expression':

--- a/src/components/SearchBox/queryWizard/tokens.ts
+++ b/src/components/SearchBox/queryWizard/tokens.ts
@@ -2,11 +2,11 @@ export type Operator = 'and' | 'or';
 export type Token =
   | { type: 'string'; value: string }
   | { type: 'logical'; value: Operator }
-  | { type: 'operator'; value: '=' }
+  | { type: 'operator'; value: '=' | '!=' }
   | { type: 'bracket'; value: 'opening' | 'closing' }
   | { type: 'anything' };
 
-const tokenRegex = /\s+and\s+|\s+or\s+|\*|=|\(|\)|[\w:]+|"[^"]*"/g;
+const tokenRegex = /\s+and\s+|\s+or\s+|\*|!=|=|\(|\)|[\w:]+|"[^"]*"/g;
 
 const validateMatches = (matches: RegExpExecArray[], inputValue: string) => {
   const [lastMatchedIndex, onlyWhitespaceGaps] = matches.reduce<
@@ -46,6 +46,8 @@ export function tokenize(inputValue: string) {
       case 'or':
         return { type: 'logical', value };
       case '=':
+        return { type: 'operator', value };
+      case '!=':
         return { type: 'operator', value };
       case '*':
         return { type: 'anything' };


### PR DESCRIPTION
### Description

As described in #849 this adds a `!=` operator to the query wizard.