### PR TITLE
PublicTransport: Fix a bug with default categories

### DIFF
--- a/src/components/FeaturePanel/PublicTransport/routes/useShowOnMap.ts
+++ b/src/components/FeaturePanel/PublicTransport/routes/useShowOnMap.ts
@@ -27,6 +27,10 @@ const getPublictransportSource = () => {
     id: `${SOURCE_NAME}-lines`,
     type: 'line',
     source: SOURCE_NAME,
+    layout: {
+      'line-join': 'round',
+      'line-cap': 'round',
+    },
     paint: {
       'line-color': ['get', COLOR_ATTRIBUTE],
       'line-width': 4,


### PR DESCRIPTION
### Description

If a train station has only categories that are not shown by default the map didn't include a single route. Even worse when the train station has only one category of type (for example only "unknown" or only "high speed" as it is the case in "Limburg Süd") it isn't even possible to turn the categories on. Now at least one category is shown all of the time

### Example links

[Limburg Süd](https://osmapp.org/node/4530820013)
