### PR TITLE
EditDialog: optimize performace of TagsEditor

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/KeyInput.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/KeyInput.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { InputAdornment, TextField } from '@mui/material';
 import WarningIcon from '@mui/icons-material/Warning';
 import { useFeatureEditData } from '../SingleFeatureEditContext';
+import { FastInput } from './helpers';
 
 const useUpdatedState = (currentKey: string) => {
   const [tmpKey, setTmpKey] = useState(currentKey);
@@ -53,25 +54,23 @@ export const KeyInput = ({ index }: { index: number }) => {
   const isError = useIsError(index);
 
   return (
-    <TextField
+    <FastInput
       value={tmpKey}
       onChange={({ target }) => setTmpKey(target.value)}
       onBlur={handleBlur}
       autoFocus={focusTag === tmpKey}
-      fullWidth
-      variant="outlined"
-      size="small"
+      autoCapitalize="none"
+      maxLength={255}
       error={isError}
-      slotProps={{
-        htmlInput: { autoCapitalize: 'none', maxLength: 255 },
-        input: {
-          endAdornment: isError ? (
-            <InputAdornment position="end">
-              <WarningIcon color="error" />
-            </InputAdornment>
-          ) : undefined,
-        },
-      }}
+      // slotProps={{
+      //   input: {
+      //     endAdornment: isError ? (
+      //       <InputAdornment position="end">
+      //         <WarningIcon color="error" />
+      //       </InputAdornment>
+      //     ) : undefined,
+      //   },
+      // }}
     />
   );
 };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/ValueInput.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/ValueInput.tsx
@@ -1,9 +1,10 @@
 import React, { ChangeEvent, FocusEvent, useRef, useState } from 'react';
 import { useEditDialogContext } from '../../../../helpers/EditDialogContext';
-import { IconButton, Stack, TextField } from '@mui/material';
+import { IconButton, Stack } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { getInputTypeForKey } from '../../helpers';
 import { useFeatureEditData } from '../SingleFeatureEditContext';
+import { FastInput } from './helpers';
 
 const useHidableDeleteButton = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -68,16 +69,12 @@ export const ValueInput = ({ index }: Props) => {
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
-      <TextField
+      <FastInput
         type={getInputTypeForKey(currentKey)}
         value={currentValue}
         onChange={handleChange}
-        fullWidth
-        variant="outlined"
-        size="small"
-        slotProps={{
-          htmlInput: { autoCapitalize: 'none', maxLength: 255 },
-        }}
+        autoCapitalize="none"
+        maxLength={255}
         autoFocus={focusTag === currentKey}
         onFocus={deleteButton.onInputFocus}
         onBlur={deleteButton.onInputBlur}

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/helpers.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/helpers.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+const WarningSvg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='#ff0000' width="20"><path d='M1 21h22L12 2zm12-3h-2v-2h2zm0-4h-2v-4h2z'/></svg>`;
+const WarningSvgDataUrl = `url("data:image/svg+xml,${encodeURIComponent(WarningSvg)}")`;
+
+/**
+ * This is replacement for MUI's TextField,
+ * it was rendering 4 seconds for 200 tags.
+ * (eg  node/1601837931)
+ */
+export const FastInput = styled.input<{ error?: boolean }>`
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  height: 32px;
+  padding: 0 8px;
+  font-size: 13px;
+
+  color: ${({ theme }) => theme.palette.text.primary};
+  background-color: ${({ theme }) => theme.palette.background.paper};
+
+  border: 1px solid ${({ theme }) => theme.palette.action.disabled};
+  ${({ theme, error }) => error && `border-color: ${theme.palette.error.main};`}
+  border-radius: 4px;
+
+  ${({ error }) =>
+    error &&
+    `background: ${WarningSvgDataUrl} no-repeat right 8px center; padding-right: 35px;`}
+
+  &:hover {
+    border-color: ${({ theme }) => theme.palette.secondary.main};
+  }
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.palette.primary.main};
+    border-width: 2px;
+  }
+
+  transition: border-color 0.2s;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+`;


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

This is replacement for MUI's TextField,
it was rendering 4 seconds for 200 tags.

### Example links

http://127.0.0.1:3000/node/1601837931

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [x] dark mode / light mode
- [x] mobile / desktop
- [x] server-side-rendering (SSR)
- [x] all texts are localized (in vocabulary.ts)
