### PR TITLE
Gallery: Support different URL variants on wikimedia commons

### DIFF
--- a/src/services/images/getCommonsImageUrl.ts
+++ b/src/services/images/getCommonsImageUrl.ts
@@ -11,7 +11,9 @@ export const getCommonsImageUrl = (
     console.warn('Invalid Commons photo name without "File:":', photoName);
     return null;
   }
-  const fileName = photoName.replace(/^File:/, '').replace(/ /g, '_');
+  const fileName = decodeURI(photoName)
+    .replace(/^.*File:/, '')
+    .replace(/ /g, '_');
   const hash = md5(fileName);
   const part1 = hash[0];
   const part2 = hash.substring(0, 2);


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots
support for following:
- `File:Seidelbruch - Bruchwächter - Südwest.jpg` (worked before)
- `https://commons.wikimedia.org/wiki/File:Seidelbruch_-_Bruchw%C3%A4chter_-_S%C3%BCdwest.jpg` (new)
- `File:Seidelbruch_-_Bruchw%C3%A4chter_-_S%C3%BCdwest.jpg` (new)



<img width="1218" alt="image" src="https://github.com/user-attachments/assets/85da5f09-3f04-4a5d-b969-e4449165fea5" />


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
