### PR TITLE
osmApi: switch to TEST API via .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,11 @@
 # This file contains API KEYs for osmapp.org and local development
-# If you want to deploy this project publicly, please obtain your own api keys.
-# You may add override values to .env.local file (ignored by git)
+# - If you want to deploy this project publicly, please obtain your own api keys.
+# - You may add override values to `.env.local` file (ignored by git)
+# - Keys prefixed with NEXT_PUBLIC_* are exposed to the client side
+
+# https://www.openstreetmap.org/oauth2/applications
+NEXT_PUBLIC_OSM_CLIENT_ID=vWUdEL3QMBCB2O9q8Vsrl3i2--tcM34rKrxSHR9Vg68
+NEXT_PUBLIC_ENABLE_TEST_API=
 
 # https://indoorequal.com/dashboard/apikeys
 # optional, fill blank to disable

--- a/pages/api/user.ts
+++ b/pages/api/user.ts
@@ -1,9 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { serverFetchOsmUser } from '../../src/server/osmApiAuthServer';
+import { OSM_TOKEN_COOKIE } from '../../src/services/osmApiConsts';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    const user = await serverFetchOsmUser(req.cookies.osmAccessToken);
+    const user = await serverFetchOsmUser(req.cookies[OSM_TOKEN_COOKIE]);
 
     res.status(200).json({ user });
   } catch (err) {

--- a/src/components/utils/OsmAuthContext.tsx
+++ b/src/components/utils/OsmAuthContext.tsx
@@ -5,6 +5,7 @@ import {
   OsmUser,
 } from '../../services/osmApiAuth';
 import { useSnackbar } from './SnackbarContext';
+import { OSM_USER_COOKIE } from '../../services/osmApiConsts';
 
 type OsmAuthType = {
   loggedIn: boolean;
@@ -16,7 +17,7 @@ type OsmAuthType = {
 };
 
 const useOsmUserState = (cookies) => {
-  const initialState = cookies.osmUserForSSR;
+  const initialState = cookies[OSM_USER_COOKIE];
   return useState<OsmUser | undefined>(initialState);
 };
 

--- a/src/services/osmApi.ts
+++ b/src/services/osmApi.ts
@@ -1,5 +1,5 @@
 import { resolveCountryCode } from 'next-codegrid';
-import { FetchError, getShortId, getUrlOsmId, prod } from './helpers';
+import { FetchError, getShortId, getUrlOsmId } from './helpers';
 import { fetchJson } from './fetch';
 import {
   Feature,
@@ -26,15 +26,16 @@ import {
   publishDbgObject,
 } from '../utils';
 import { getOverpassUrl } from './overpassSearch';
+import { API_SERVER, OSM_WEBSITE } from './osmApiConsts';
 
 const getOsmUrl = ({ type, id }: OsmId) =>
-  `https://api.openstreetmap.org/api/0.6/${type}/${id}.json`;
+  `${API_SERVER}/api/0.6/${type}/${id}.json`;
 const getOsmFullUrl = ({ type, id }: OsmId) =>
-  `https://api.openstreetmap.org/api/0.6/${type}/${id}/full.json`;
+  `${API_SERVER}/api/0.6/${type}/${id}/full.json`;
 const getOsmParentUrl = ({ type, id }: OsmId) =>
-  `https://api.openstreetmap.org/api/0.6/${type}/${id}/relations.json`;
+  `${API_SERVER}/api/0.6/${type}/${id}/relations.json`;
 const getOsmHistoryUrl = ({ type, id }: OsmId) =>
-  `https://api.openstreetmap.org/api/0.6/${type}/${id}/history.json`;
+  `${API_SERVER}/api/0.6/${type}/${id}/history.json`;
 const getOsmUrlOrFull = ({ type, id }: OsmId) =>
   type === 'node' ? getOsmUrl({ type, id }) : getOsmFullUrl({ type, id });
 
@@ -395,12 +396,8 @@ export const insertOsmNote = async (
   body.append('lon', `${lon}`);
   body.append('text', text);
 
-  const osmUrl = prod
-    ? 'https://api.openstreetmap.org'
-    : 'https://master.apis.dev.openstreetmap.org';
-
   // {"type":"Feature","geometry":{"type":"Point","coordinates":[14.3244982,50.0927863]},"properties":{"id":26569,"url":"https://master.apis.dev.openstreetmap.org/api/0.6/notes/26569.json","comment_url":"https://master.apis.dev.openstreetmap.org/api/0.6/notes/26569/comment.json","close_url":"https://master.apis.dev.openstreetmap.org/api/0.6/notes/26569/close.json","date_created":"2021-04-17 10:37:44 UTC","status":"open","comments":[{"date":"2021-04-17 10:37:44 UTC","action":"opened","text":"way/39695868! Place was marked permanently closed.From https://osmapp.org/way/39695868","html":"\u003cp\u003eway/39695868! Place was marked permanently closed.From \u003ca href=\"https://osmapp.org/way/39695868\" rel=\"nofollow noopener noreferrer\"\u003ehttps://osmapp.org/way/39695868\u003c/a\u003e\u003c/p\u003e"}]}}
-  const reply = await fetchJson(`${osmUrl}/api/0.6/notes.json`, {
+  const reply = await fetchJson(`${API_SERVER}/api/0.6/notes.json`, {
     nocache: true,
     method: 'POST',
     body,
@@ -410,7 +407,7 @@ export const insertOsmNote = async (
   return {
     type: 'note',
     text,
-    url: `${prod ? 'https://osm.org' : osmUrl}/note/${noteId}`,
+    url: `${OSM_WEBSITE}/note/${noteId}`,
   };
 };
 

--- a/src/services/osmApiConsts.ts
+++ b/src/services/osmApiConsts.ts
@@ -1,0 +1,20 @@
+export const USE_PROD_API = !process.env.NEXT_PUBLIC_ENABLE_TEST_API;
+
+export const TEST_SERVER = 'https://master.apis.dev.openstreetmap.org';
+export const PROD_SERVER = 'https://api.openstreetmap.org';
+export const OSM_WEBSITE = USE_PROD_API
+  ? 'https://www.openstreetmap.org'
+  : TEST_SERVER;
+
+export const API_SERVER = USE_PROD_API ? PROD_SERVER : TEST_SERVER;
+
+export const PROD_CLIENT_ID = process.env.NEXT_PUBLIC_OSM_CLIENT_ID;
+export const TEST_CLIENT_ID = 'a_f_aB7ADY_kdwe4YHpmCSBtNtDZ-BitW8m5I6ijDwI';
+
+export const OSM_USER_COOKIE = USE_PROD_API
+  ? 'osmUserForSSR'
+  : 'osmUserForSSR_TESTAPI';
+
+export const OSM_TOKEN_COOKIE = USE_PROD_API
+  ? 'osmAccessToken'
+  : 'osmAccessToken_TESTAPI';


### PR DESCRIPTION
You can prepare test items in iD editor here:

https://master.apis.dev.openstreetmap.org/edit


To use TEST API add `NEXT_PUBLIC_ENABLE_TEST_API=true` to your `.env.local`.