### PR TITLE
osmApi: implement `nodeLonLat` for existing node

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/AddMemberForm.tsx
@@ -24,7 +24,7 @@ const findItem = (items: EditDataItem[], osmId: OsmId) =>
 
 const getLastNodeLocation = async (osmId: OsmId, items: EditDataItem[]) => {
   if (osmId.id < 0) {
-    return findItem(items, osmId)?.newNodeLonLat;
+    return findItem(items, osmId)?.nodeLonLat;
   }
   const element = await getOsmElement(osmId);
   return [element.lon, element.lat];

--- a/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/EditContent.tsx
@@ -17,6 +17,7 @@ import { useEditDialogFeature } from '../utils';
 import { useEditContext } from '../EditContext';
 import { getShortId } from '../../../../services/helpers';
 import { fetchSchemaTranslations } from '../../../../services/tagging/translations';
+import { TestApiWarning } from '../../helpers/TestApiWarning';
 
 export const EditContent = () => {
   const { items, addFeature, current, setCurrent } = useEditContext();
@@ -60,6 +61,7 @@ export const EditContent = () => {
               <CommentField />
               <ContributionInfoBox />
               <OsmUserLogged />
+              <TestApiWarning />
             </div>
           </Stack>
         </form>

--- a/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
+++ b/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
@@ -67,7 +67,7 @@ export const useGetHandleSave = () => {
         handleLogout();
       } else {
         showToast(
-          `${t('editdialog.save_refused')} ${err.responseText ?? err.message}`,
+          `${t('editdialog.save_refused')} ${err.responseText ?? err.message ?? err}`,
           'error',
         );
         console.error(err); // eslint-disable-line no-console

--- a/src/components/FeaturePanel/FeatureDescription.tsx
+++ b/src/components/FeaturePanel/FeatureDescription.tsx
@@ -6,6 +6,7 @@ import { t, Translation } from '../../services/intl';
 import { useFeatureContext } from '../utils/FeatureContext';
 import { TooltipButton } from '../utils/TooltipButton';
 import { Feature } from '../../services/types';
+import { OSM_WEBSITE } from '../../services/osmApiConsts';
 
 const InfoTooltipWrapper = styled.span`
   position: relative;
@@ -27,10 +28,10 @@ const A = ({ href, children }) =>
   );
 
 const getUrls = ({ type, id, changeset, user }: Feature['osmMeta']) => ({
-  itemUrl: `https://openstreetmap.org/${type}/${id}`,
-  historyUrl: `https://openstreetmap.org/${type}/${id}/history`,
-  changesetUrl: changeset && `https://openstreetmap.org/changeset/${changeset}`, // prettier-ignore
-  userUrl: user && `https://openstreetmap.org/user/${user}`,
+  itemUrl: `${OSM_WEBSITE}/${type}/${id}`,
+  historyUrl: `${OSM_WEBSITE}/${type}/${id}/history`,
+  changesetUrl: changeset && `${OSM_WEBSITE}/changeset/${changeset}`, // prettier-ignore
+  userUrl: user && `${OSM_WEBSITE}/user/${user}`,
 });
 
 const Urls = () => {

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -27,6 +27,7 @@ import { ClimbingStructuredData } from './Climbing/ClimbingStructuredData';
 import { isPublictransportRoute } from '../../utils';
 import { Sockets } from './Sockets/Sockets';
 import { ClimbingTypeBadge } from './Climbing/ClimbingTypeBadge';
+import { TestApiWarning } from './helpers/TestApiWarning';
 
 const Flex = styled.div`
   flex: 1;
@@ -70,6 +71,7 @@ export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
           <ClimbingRestriction />
 
           <OsmError />
+          <TestApiWarning />
         </PanelSidePadding>
 
         <Flex>

--- a/src/components/FeaturePanel/OsmError.tsx
+++ b/src/components/FeaturePanel/OsmError.tsx
@@ -3,22 +3,19 @@ import { Box, Alert } from '@mui/material';
 import { t } from '../../services/intl';
 import { getUrlOsmId } from '../../services/helpers';
 import { useFeatureContext } from '../utils/FeatureContext';
+import { OSM_WEBSITE } from '../../services/osmApiConsts';
 
 export const OsmError = () => {
   const { feature } = useFeatureContext();
   const code = feature.error;
 
   if (feature.deleted) {
+    const historyUrl = `${OSM_WEBSITE}/${getUrlOsmId(feature.osmMeta)}/history`;
     return (
       <Box mb={3}>
         <Alert variant="outlined" severity="warning">
           {t('featurepanel.error_deleted')}{' '}
-          <a
-            href={`https://openstreetmap.org/${getUrlOsmId(
-              feature.osmMeta,
-            )}/history`}
-            target="_blank"
-          >
+          <a href={historyUrl} target="_blank">
             {t('featurepanel.history_button')}
           </a>
         </Alert>

--- a/src/components/FeaturePanel/helpers/TestApiWarning.tsx
+++ b/src/components/FeaturePanel/helpers/TestApiWarning.tsx
@@ -1,0 +1,16 @@
+import { API_SERVER, USE_PROD_API } from '../../../services/osmApiConsts';
+import { Alert, Box } from '@mui/material';
+import Link from 'next/link';
+import React from 'react';
+
+export const TestApiWarning = () =>
+  USE_PROD_API ? null : (
+    <Box mb={2}>
+      <Alert severity="warning">
+        TEST API IN USE: {API_SERVER}
+        <br />
+        Clicking the map will not work.
+        <Link href="/relation/4305224335">Test relation</Link>
+      </Alert>
+    </Box>
+  );

--- a/src/services/osmApiAuth.ts
+++ b/src/services/osmApiAuth.ts
@@ -321,8 +321,8 @@ const getCommentMulti = (
   // TODO find topmost parent in changes and use its name
   // eg. survey • Edited Roviště (5 items) #osmapp #climbing
 
-  if (changes.length === 1 && changes[0].nodeLonLat) {
-    const typeTag = Object.entries(changes[0].tags)[0]?.join('=');
+  if (changes.length === 1 && original.point) {
+    const typeTag = changes[0].tagsEntries[0]?.join('=') ?? 'node with no tags';
     return join(comment, ' • ', `Added ${typeTag} #osmapp`);
   }
 

--- a/src/services/osmApiAuth.ts
+++ b/src/services/osmApiAuth.ts
@@ -283,6 +283,8 @@ const saveChange = async (
   changesetId: string,
   { shortId, version, tags, toBeDeleted, nodeLonLat, members }: EditDataItem,
 ): Promise<OsmId> => {
+  // TODO don't save changes if no change detected
+
   let apiId = getApiId(shortId);
   if (apiId.id < 0) {
     if (apiId.type !== 'node') {
@@ -385,6 +387,8 @@ export const saveChanges = async (
 
   const ids = [...savedNodesIds, ...savedWaysIds, ...savedRelationsIds];
   const redirectId = original.point ? ids[0] : original.osmMeta;
+
+  // TODO invalidate all changed items in browser AND server !
 
   return {
     type: 'edit',

--- a/src/services/osmApiAuth.ts
+++ b/src/services/osmApiAuth.ts
@@ -2,7 +2,14 @@ import Cookies from 'js-cookie';
 import escape from 'lodash/escape';
 import { osmAuth, OSMAuthXHROptions } from 'osm-auth';
 import { zipObject } from 'lodash';
-import { Feature, FeatureTags, OsmId, Position, SuccessInfo } from './types';
+import {
+  Feature,
+  FeatureTags,
+  LonLat,
+  OsmId,
+  Position,
+  SuccessInfo,
+} from './types';
 import {
   buildXmlString,
   getApiId,
@@ -232,11 +239,16 @@ const updateItemXml = async (
   tags: FeatureTags,
   toBeDeleted: boolean,
   members?: Members,
+  nodeLonLat?: LonLat,
 ) => {
   item[apiId.type].$.changeset = changesetId;
   if (!toBeDeleted) {
     item[apiId.type].tag = getXmlTags(tags);
     item[apiId.type].member = getXmlMembers(members);
+    if (nodeLonLat) {
+      item[apiId.type].$.lon = `${nodeLonLat[0]}`;
+      item[apiId.type].$.lat = `${nodeLonLat[1]}`;
+    }
   }
   return buildXmlString(item);
 };
@@ -254,42 +266,6 @@ const checkVersionUnchanged = (
   }
 };
 
-// TODO maybe split to editOsmFeature and undeleteOsmFeature? the flow is kinda unclear
-export const editOsmFeature = async (
-  feature: Feature,
-  comment: string,
-  newTags: FeatureTags,
-  toBeDeleted: boolean,
-): Promise<SuccessInfo> => {
-  const apiId = feature.osmMeta;
-  const freshItem = await getItemOrLastHistoric(apiId);
-  checkVersionUnchanged(freshItem, apiId, feature.osmMeta.version);
-
-  const changesetComment = getChangesetComment(comment, toBeDeleted, feature);
-  const changesetXml = getChangesetXml({ changesetComment, feature });
-  const changesetId = await putChangeset(changesetXml);
-
-  const newItem = await updateItemXml(
-    freshItem,
-    apiId,
-    changesetId,
-    newTags,
-    toBeDeleted,
-  );
-
-  await putOrDeleteItem(toBeDeleted, apiId, newItem);
-  await putChangesetClose(changesetId);
-
-  clearFeatureCache(feature.osmMeta);
-
-  return {
-    type: 'edit',
-    text: changesetComment,
-    url: `${OSM_WEBSITE}/changeset/${changesetId}`,
-    redirect: `${getOsmappLink(feature)}`,
-  };
-};
-
 const getNewNodeXml = async (
   changesetId: string,
   [lon, lat]: Position,
@@ -305,14 +281,14 @@ const getNewNodeXml = async (
 
 const saveChange = async (
   changesetId: string,
-  { shortId, version, tags, toBeDeleted, newNodeLonLat, members }: EditDataItem,
+  { shortId, version, tags, toBeDeleted, nodeLonLat, members }: EditDataItem,
 ): Promise<OsmId> => {
   let apiId = getApiId(shortId);
   if (apiId.id < 0) {
     if (apiId.type !== 'node') {
       throw new Error('We can only add new nodes so far.');
     }
-    const content = await getNewNodeXml(changesetId, newNodeLonLat, tags);
+    const content = await getNewNodeXml(changesetId, nodeLonLat, tags);
     const newNodeId = await createItem(content);
     return { type: 'node', id: parseInt(newNodeId, 10) };
   }
@@ -320,6 +296,7 @@ const saveChange = async (
   const freshItem = await getItem(apiId);
   checkVersionUnchanged(freshItem, apiId, version);
 
+  // TODO document undelete feature - the flow is kinda unclear
   const newItem = await updateItemXml(
     freshItem,
     apiId,
@@ -327,6 +304,7 @@ const saveChange = async (
     tags,
     toBeDeleted,
     members,
+    nodeLonLat,
   );
   await putOrDeleteItem(toBeDeleted, apiId, newItem);
   return apiId;
@@ -343,7 +321,7 @@ const getCommentMulti = (
   // TODO find topmost parent in changes and use its name
   // eg. survey • Edited Roviště (5 items) #osmapp #climbing
 
-  if (changes.length === 1 && changes[0].newNodeLonLat) {
+  if (changes.length === 1 && changes[0].nodeLonLat) {
     const typeTag = Object.entries(changes[0].tags)[0]?.join('=');
     return join(comment, ' • ', `Added ${typeTag} #osmapp`);
   }


### PR DESCRIPTION
- rename `newNodeLonLat` to `nodeLonLat`
- fill this value for any node added to editItems (new or existing)
- add xml for existing item


Also:
- add TestApi Warning
- change Website urls to currently used instance