### PR TITLE
EditDialog: Show climbing presets as default in openclimbing

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSearchBox.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSearchBox.tsx
@@ -37,23 +37,23 @@ const StyledListSubheader = styled(ListSubheader)`
   }
 `;
 
-const emptyOptions = [
-  'amenity/cafe',
-  'amenity/restaurant',
-  'amenity/fast_food',
-  'amenity/bar',
-  'shop',
-  'leisure/park',
-  'amenity/place_of_worship',
-  ...(PROJECT_ID === 'openclimbing'
+const emptyOptions =
+  PROJECT_ID === 'openclimbing'
     ? [
         'climbing/route_bottom',
         'climbing/route',
         'climbing/crag',
         // 'climbing/area',
       ]
-    : []),
-];
+    : [
+        'amenity/cafe',
+        'amenity/restaurant',
+        'amenity/fast_food',
+        'amenity/bar',
+        'shop',
+        'leisure/park',
+        'amenity/place_of_worship',
+      ];
 
 const Placeholder = styled.span`
   color: ${({ theme }) => theme.palette.text.secondary};


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<img width="939" alt="image" src="https://github.com/user-attachments/assets/f0d70880-c2ae-45ed-ab9c-82c8648fa5b8" />


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
