### PR TITLE
general: turn off sentry - really

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -4,9 +4,12 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const enabled = process.env.NODE_ENV === 'production';
 Sentry.init({
-  enabled: process.env.NODE_ENV === 'production',
-  dsn: 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591',
+  enabled,
+  dsn: enabled
+    ? 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591'
+    : undefined,
   release: process.env.sentryRelease,
 
   // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,9 +5,13 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const enabled = process.env.NODE_ENV === 'production';
+
 Sentry.init({
-  enabled: process.env.NODE_ENV === 'production',
-  dsn: 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591',
+  enabled,
+  dsn: enabled
+    ? 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591'
+    : undefined,
   release: process.env.sentryRelease,
 
   // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,9 +4,12 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const enabled = process.env.NODE_ENV === 'production';
 Sentry.init({
-  enabled: process.env.NODE_ENV === 'production',
-  dsn: 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591',
+  enabled,
+  dsn: enabled
+    ? 'https://79cd9dbaeb0f4d0f868e2d4574f8b7e2@o332956.ingest.us.sentry.io/1858591'
+    : undefined,
   release: process.env.sentryRelease,
 
   // Adjust this value in production, or use tracesSampler for greater control


### PR DESCRIPTION
Sentry still sends some requests on localhost even though `enabled: false` 😅.. lets take the DSN from it, so it really can't send anything.

