### PR TITLE
EditDialog: add LocationEditor node-in-way check

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import {
   Accordion,
@@ -7,15 +7,64 @@ import {
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { t } from '../../../../../../services/intl';
+import { t, Translation } from '../../../../../../services/intl';
+import { useCurrentItem } from '../CurrentContext';
+import { getApiId } from '../../../../../../services/helpers';
+import { fetchWays } from '../../../../../../services/osm/fetchWays';
+import { OsmId } from '../../../../../../services/types';
 
 const EditFeatureMapDynamic = dynamic(() => import('./EditFeatureMap'), {
   ssr: false,
   loading: () => <div style={{ height: 500 }} />,
 });
 
+const WayWarning = () => {
+  const { shortId } = useCurrentItem();
+  const osmId = getApiId(shortId);
+  const link = `https://www.openstreetmap.org/edit?${osmId.type}=${osmId.id}`;
+
+  return (
+    <Translation
+      id="editdialog.location_editor_to_be_added"
+      values={{ link }}
+    />
+  );
+};
+
+const useNodeWithoutWayCheck = (osmId: OsmId) => {
+  const [isNodeWithoutWay, setIsNodeWithoutWay] = useState(false);
+
+  useEffect(() => {
+    if (osmId.type === 'node') {
+      // this is already cached from ParentsEditor
+      fetchWays(osmId).then((waysOfNodes) =>
+        setIsNodeWithoutWay(waysOfNodes.length === 0),
+      );
+    }
+  }, [osmId]);
+
+  return isNodeWithoutWay;
+};
+
 export const LocationEditor = () => {
   const [expanded, setExpanded] = useState(false);
+  const { shortId } = useCurrentItem();
+  const osmId = getApiId(shortId);
+  const isNodeWithoutWay = useNodeWithoutWayCheck(osmId);
+
+  if (osmId.type === 'relation') {
+    return null;
+  }
+
+  let content = null;
+  if (expanded) {
+    if (osmId.type === 'node') {
+      content = isNodeWithoutWay ? <EditFeatureMapDynamic /> : <WayWarning />;
+    }
+    if (osmId.type === 'way') {
+      content = <WayWarning />;
+    }
+  }
 
   return (
     <Accordion
@@ -28,9 +77,7 @@ export const LocationEditor = () => {
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Typography variant="button">{t('editdialog.location')}</Typography>
       </AccordionSummary>
-      <AccordionDetails>
-        {expanded && <EditFeatureMapDynamic />}
-      </AccordionDetails>
+      <AccordionDetails>{content}</AccordionDetails>
     </Accordion>
   );
 };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -16,7 +16,7 @@ import { getApiId, getShortId } from '../../../../../services/helpers';
 import { FeatureRow } from '../FeatureRow';
 import { t } from '../../../../../services/intl';
 import { useGetHandleClick } from '../helpers';
-import { fetchNodesWaysFeatures } from '../../../../../services/osm/fetchNodesWaysFeatures';
+import { fetchWays } from '../../../../../services/osm/fetchWays';
 import { useEditContext } from '../../EditContext';
 import {
   isClimbingRoute,
@@ -51,7 +51,7 @@ export const ParentsEditor = () => {
       }
       const [parentFeatures, waysFeatures] = await Promise.all([
         fetchParentFeatures(getApiId(current)),
-        fetchNodesWaysFeatures(getApiId(current)),
+        fetchWays(getApiId(current)),
       ]);
       setParents([...parentFeatures, ...waysFeatures]);
     })();

--- a/src/services/osm/fetchWays.ts
+++ b/src/services/osm/fetchWays.ts
@@ -1,16 +1,16 @@
 import { OsmId } from '../types';
 import { fetchJson } from '../fetch';
-import { getOsmNodesWaysUrl, isNodeOsmId, NodeOsmId } from './urls';
+import { getOsmWaysUrl, isNodeOsmId, NodeOsmId } from './urls';
 import { addSchemaToFeature } from '../tagging/idTaggingScheme';
 import { osmToFeature } from './osmToFeature';
 import { OsmResponse } from './types';
 
-const getOsmNodesWaysPromise = async (apiId: NodeOsmId) =>
-  fetchJson<OsmResponse<'way'>>(getOsmNodesWaysUrl(apiId));
+const getOsmWaysPromise = async (apiId: NodeOsmId) =>
+  fetchJson<OsmResponse<'way'>>(getOsmWaysUrl(apiId));
 
-export const fetchNodesWaysFeatures = async (apiId: OsmId) => {
+export const fetchWays = async (apiId: OsmId) => {
   if (isNodeOsmId(apiId)) {
-    const { elements } = await getOsmNodesWaysPromise(apiId);
+    const { elements } = await getOsmWaysPromise(apiId);
     return elements.map((element) => addSchemaToFeature(osmToFeature(element)));
   }
 

--- a/src/services/osm/urls.ts
+++ b/src/services/osm/urls.ts
@@ -14,7 +14,7 @@ export const getOsmFullUrl = ({ type, id }: OsmId) =>
 export const getOsmParentUrl = ({ type, id }: OsmId) =>
   `${API_SERVER}/api/0.6/${type}/${id}/relations.json`;
 
-export const getOsmNodesWaysUrl = ({ id }: NodeOsmId) =>
+export const getOsmWaysUrl = ({ id }: NodeOsmId) =>
   `${API_SERVER}/api/0.6/node/${id}/ways.json`;
 
 export const getOsmHistoryUrl = ({ type, id }: OsmId) =>


### PR DESCRIPTION
When node is inside a way, we show warning instead of the Map:

<img width="683" alt="image" src="https://github.com/user-attachments/assets/acb61d86-2db6-4101-8f29-70cac526b689" />
