### PR TITLE
climbingTiles: add missing routes

### DIFF
--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -40,7 +40,7 @@ const prepareGeojson = (
 
 const fetchFromOverpass = async () => {
   // takes about 42 secs, 25MB
-  const query = `[out:json][timeout:80];(nwr["climbing"];nwr["sport"="climbing"];);>>;out qt;`;
+  const query = `[out:json][timeout:80];(nwr["climbing"];nwr["sport"="climbing"];);(._;>>;);out qt;`;
   const data = await fetchJson<OsmResponse>(
     'https://overpass-api.de/api/interpreter',
     {


### PR DESCRIPTION
With `._` we have on preview:

```
Starting...
Overpass elements: 201367
Records: 41737
SQL Query length: 14531069 chars
Done.
Duration: 84808 ms
```

<img width="396" alt="image" src="https://github.com/user-attachments/assets/0faf97f2-365d-4acf-9066-bef427dc23ae" />
