### PR TITLE
images: remove street-view images for relations

### DIFF
--- a/src/services/__tests__/osmApi.fixture.ts
+++ b/src/services/__tests__/osmApi.fixture.ts
@@ -140,9 +140,5 @@ export const RELATION_FEATURE = {
     amenity: 'university',
     type: 'multipolygon',
   },
-  imageDefs: [
-    { type: 'center', service: 'panoramax', center: [15, 51] },
-    { type: 'center', service: 'kartaview', center: [15, 51] },
-    { type: 'center', service: 'mapillary', center: [15, 51] },
-  ],
+  imageDefs: [],
 };

--- a/src/services/getCoordsFeature.ts
+++ b/src/services/getCoordsFeature.ts
@@ -20,7 +20,7 @@ export const getCoordsFeature = ([lon, lat]: LonLatRounded): Feature => {
     },
     tags: {},
     properties: { class: 'marker', subclass: 'point' },
-    imageDefs: getImagesFromCenter({}, center),
+    imageDefs: getImagesFromCenter({}, 'node', center),
   };
 };
 

--- a/src/services/images/__tests__/getImageDefs.test.ts
+++ b/src/services/images/__tests__/getImageDefs.test.ts
@@ -72,7 +72,7 @@ test('conversion', () => {
     },
   ];
 
-  expect(getImageDefs(tags, center)).toEqual(imageDefs);
+  expect(getImageDefs(tags, 'node', center)).toEqual(imageDefs);
 });
 
 test('correctly sorted', () => {
@@ -87,7 +87,7 @@ test('correctly sorted', () => {
     'ignored-non-image-tag': 'x',
   };
 
-  expect(getImageDefs(tags, center).map((def: any) => def.k)).toEqual([
+  expect(getImageDefs(tags, 'node', center).map((def: any) => def.k)).toEqual([
     'wikimedia_commons',
     'image',
     'image2',
@@ -97,4 +97,10 @@ test('correctly sorted', () => {
     'wikimedia_commons:3',
     undefined, // mapillary
   ]);
+});
+
+test('no center for relation', () => {
+  const tags = {};
+  expect(getImageDefs(tags, 'node', center)).toHaveLength(3);
+  expect(getImageDefs(tags, 'relation', center)).toEqual([]);
 });

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -6,6 +6,7 @@ import {
   ImageDefFromTag,
   isTag,
   LonLat,
+  OsmType,
   PathType,
 } from '../types';
 import { getCommonsImageUrl } from './getCommonsImageUrl';
@@ -130,9 +131,10 @@ const getImagesFromTags = (tags: FeatureTags) => {
 
 export const getImagesFromCenter = (
   tags: FeatureTags,
+  osmType: OsmType,
   center?: LonLat,
 ): ImageDef[] => {
-  if (!center) {
+  if (!center || osmType === 'relation') {
     return [];
   }
   return [
@@ -146,9 +148,13 @@ export const getImagesFromCenter = (
   ];
 };
 
-export const getImageDefs = (tags: FeatureTags, center?: LonLat) => [
+export const getImageDefs = (
+  tags: FeatureTags,
+  osmType: OsmType,
+  center?: LonLat,
+) => [
   ...getImagesFromTags(tags),
-  ...getImagesFromCenter(tags, center),
+  ...getImagesFromCenter(tags, osmType, center),
 ];
 
 export const mergeMemberImageDefs = (feature: Feature) => {

--- a/src/services/osm/osmApi.ts
+++ b/src/services/osm/osmApi.ts
@@ -114,7 +114,11 @@ const fetchFeatureWithCenter = async (apiId: OsmId) => {
   const feature = osmToFeature(element);
   if (!feature.center && center) {
     feature.center = center;
-    feature.imageDefs = getImageDefs(feature.tags, center);
+    feature.imageDefs = getImageDefs(
+      feature.tags,
+      feature.osmMeta.type,
+      center,
+    );
   }
 
   if (feature.center) {

--- a/src/services/osm/osmToFeature.ts
+++ b/src/services/osm/osmToFeature.ts
@@ -20,7 +20,7 @@ export const osmToFeature = (element): Feature => {
     osmMeta,
     tags,
     members,
-    imageDefs: getImageDefs(tags, center),
+    imageDefs: getImageDefs(tags, osmMeta.type, center),
     properties: { ...getPoiClass(tags) },
     deleted: osmappDeletedMarker,
   };


### PR DESCRIPTION
It doesn't make sense to show street-level imagery for relations, because their `center` point is just computed as centroid of all its members - so it can be very far from any actual stuff in the relation.

This is open for discussion – if anyone finds any actual usecase, I am open to revert this PR :-)