### PR TITLE
climbingTiles: add stats

### DIFF
--- a/pages/api/climbing-tiles/stats.ts
+++ b/pages/api/climbing-tiles/stats.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { addCorsHeaders } from '../../../src/server/climbing-tiles/utils';
+import { getClimbingStats } from '../../../src/server/climbing-tiles/getClimbingStats';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  addCorsHeaders(req, res);
+  try {
+    const json = await getClimbingStats();
+
+    res.status(200).setHeader('Content-Type', 'application/json').send(json);
+  } catch (err) {
+    console.error(err); // eslint-disable-line no-console
+    res.status(err.code ?? 400).send(String(err));
+  }
+};

--- a/pages/api/climbing-tiles/tile.ts
+++ b/pages/api/climbing-tiles/tile.ts
@@ -1,23 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getClimbingTile } from '../../../src/server/climbing-tiles/getClimbingTile';
+import { addCorsHeaders } from '../../../src/server/climbing-tiles/utils';
 import { Tile } from '../../../src/types';
-
-const addCorsHeaders = (req: NextApiRequest, res: NextApiResponse) => {
-  const origin = req.headers.origin;
-  if (origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  }
-};
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   addCorsHeaders(req, res);
   try {
-    if (!process.env.XATA_PASSWORD) {
-      throw new Error('XATA_PASSWORD must be set');
-    }
-
     const tileNumber: Tile = {
       z: Number(req.query.z),
       x: Number(req.query.x),

--- a/src/components/LayerSwitcher/Overlays.tsx
+++ b/src/components/LayerSwitcher/Overlays.tsx
@@ -9,11 +9,11 @@ import {
 import { LayerIcon, Spacer, StyledList } from './helpers';
 import { Layer, useMapStateContext } from '../utils/MapStateContext';
 import { dotToOptionalBr } from '../helpers';
-import { intl, t } from '../../services/intl';
+import { intl, t, Translation } from '../../services/intl';
 import { TooltipButton } from '../utils/TooltipButton';
 import { useQuery } from 'react-query';
 import { fetchJson } from '../../services/fetch';
-import { ClimbingStatsResponse } from '../../types';
+import type { ClimbingStatsResponse } from '../../types';
 import { nl2br } from '../utils/nl2br';
 
 const getLocalTime = (lastRefresh: string) =>
@@ -30,18 +30,20 @@ const ClimbingSecondary = () => {
   }
 
   if (error) {
-    return <>Error: {`${error}`}</>;
+    console.error('Error fetching climbing stats', error); // eslint-disable-line no-console
+    return null;
   }
 
   const { lastRefresh, osmDataTimestamp, devStats } = data;
-  const osmTime = getLocalTime(osmDataTimestamp);
   const tooltip = (
     <>
-      Refreshed: 1× / night
-      <br />
-      Last refresh: {getLocalTime(lastRefresh)}
-      <br />
-      OSM timestamp: {osmTime}
+      <Translation
+        id="climbing_tiles.stats"
+        values={{
+          lastRefresh: getLocalTime(lastRefresh),
+          osmTime: getLocalTime(osmDataTimestamp),
+        }}
+      />
       <br />
       <br />
       Dev stats:{' '}
@@ -56,7 +58,7 @@ const ClimbingSecondary = () => {
 
   return (
     <>
-      {osmTime.replace(/:\d+( [APM]+)?$/, '$1')}
+      {getLocalTime(osmDataTimestamp).replace(/:\d+( [APM]+)?$/, '$1')}
       <TooltipButton fontSize={14} tooltip={tooltip} />
     </>
   );

--- a/src/components/LayerSwitcher/Overlays.tsx
+++ b/src/components/LayerSwitcher/Overlays.tsx
@@ -9,7 +9,7 @@ import {
 import { LayerIcon, Spacer, StyledList } from './helpers';
 import { Layer, useMapStateContext } from '../utils/MapStateContext';
 import { dotToOptionalBr } from '../helpers';
-import { t } from '../../services/intl';
+import { intl, t } from '../../services/intl';
 import { TooltipButton } from '../utils/TooltipButton';
 import { useQuery } from 'react-query';
 import { fetchJson } from '../../services/fetch';
@@ -17,7 +17,7 @@ import { ClimbingStatsResponse } from '../../types';
 import { nl2br } from '../utils/nl2br';
 
 const getLocalTime = (lastRefresh: string) =>
-  lastRefresh ? new Date(lastRefresh).toLocaleString() : null;
+  lastRefresh ? new Date(lastRefresh).toLocaleString(intl.lang) : null;
 
 const fetchClimbingStats = () =>
   fetchJson<ClimbingStatsResponse>('/api/climbing-tiles/stats');
@@ -30,29 +30,33 @@ const ClimbingSecondary = () => {
   }
 
   if (error) {
-    return <>{`${error}`}</>;
+    return <>Error: {`${error}`}</>;
   }
 
   const { lastRefresh, osmDataTimestamp, devStats } = data;
-
+  const osmTime = getLocalTime(osmDataTimestamp);
   const tooltip = (
     <>
       Refreshed: 1× / night
       <br />
       Last refresh: {getLocalTime(lastRefresh)}
       <br />
-      OSM timestamp: {getLocalTime(osmDataTimestamp)}
-      {/*<br /><a href="">Refresh now</a>*/}
+      OSM timestamp: {osmTime}
       <br />
       <br />
-      Dev stats: {nl2br(JSON.stringify(devStats, null, 2))}
+      Dev stats:{' '}
+      {nl2br(
+        Object.entries(devStats)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join('\n'),
+      )}
       <br />
     </>
   );
 
   return (
     <>
-      2025-02-10 15:23
+      {osmTime.replace(/:\d+( [APM]+)?$/, '$1')}
       <TooltipButton fontSize={14} tooltip={tooltip} />
     </>
   );

--- a/src/components/utils/TooltipButton.tsx
+++ b/src/components/utils/TooltipButton.tsx
@@ -5,12 +5,6 @@ import { SvgIconOwnProps } from '@mui/material/SvgIcon/SvgIcon';
 import { isMobileDevice, useBoolState } from '../helpers';
 import styled from '@emotion/styled';
 
-type Props = {
-  tooltip: React.ReactNode;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  color?: SvgIconOwnProps['color'];
-};
-
 const useClickAwayListener = (
   tooltipRef: React.MutableRefObject<HTMLDivElement>,
   hide: () => void,
@@ -35,11 +29,18 @@ const useClickAwayListener = (
   }, [hide, isMobile, tooltipRef]);
 };
 
-const StyledIconButton = styled(IconButton)`
-  font-size: inherit;
+const StyledIconButton = styled(IconButton)<{ fontSize?: number }>`
+  font-size: ${({ fontSize }) => (fontSize ? `${fontSize}px` : 'inherit')};
 `;
 
-export const TooltipButton = ({ tooltip, onClick, color }: Props) => {
+type Props = {
+  tooltip: React.ReactNode;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  color?: SvgIconOwnProps['color'];
+  fontSize?: number;
+};
+
+export const TooltipButton = ({ tooltip, onClick, color, fontSize }: Props) => {
   const isMobile = isMobileDevice();
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [mobileTooltipShown, show, hide] = useBoolState(false);
@@ -55,8 +56,8 @@ export const TooltipButton = ({ tooltip, onClick, color }: Props) => {
   useClickAwayListener(tooltipRef, hide, isMobile);
 
   const content = (
-    <StyledIconButton onClick={handleClick}>
-      <InfoOutlinedIcon fontSize="small" color={color} />
+    <StyledIconButton onClick={handleClick} fontSize={fontSize}>
+      <InfoOutlinedIcon fontSize="inherit" color={color} />
     </StyledIconButton>
   );
 

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -293,4 +293,6 @@ export default {
   'osmtype.relation.description': 'Skupina dalších prvků – cest, uzlů a případně dalších relací.',
 
   weather: 'Počasí',
+
+  'climbing_tiles.stats': `Obnovuje se: 1× / noc<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__`,
 };

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -384,4 +384,6 @@ export default {
   'osmtype.relation.description': 'Group of other elements – ways, nodes, and even other relations.',
 
   weather: 'Weather',
+
+  'climbing_tiles.stats': `Refreshed: 1× / night<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__`,
 };

--- a/src/server/climbing-tiles/db.sql
+++ b/src/server/climbing-tiles/db.sql
@@ -1,6 +1,9 @@
-create table if not exists public.climbing_features
+-- copy DDL to clipboard on "public" schema + Reformat in WebStorm
+
+create table climbing_features
 (
-  id        SERIAL           primary key,
+  id        serial
+    primary key,
   type      text             not null,
   lon       double precision not null,
   lat       double precision not null,
@@ -11,24 +14,38 @@ create table if not exists public.climbing_features
   geojson   json             not null
 );
 
-create table if not exists public.climbing_tiles_stats
-(
-  id                 SERIAL                                 primary key,
-  timestamp          timestamp with time zone default now() not null,
-  osm_data_timestamp timestamp with time zone               not null,
-  build_log          text,
-  build_duration     bigint                                 not null,
-  max_size           bigint                                 not null,
-  max_size_zxy       text                                   not null,
-  max_time           bigint                                 not null,
-  max_time_zxy       text                                   not null,
-  prev_tiles_stats   text
-);
+alter table climbing_features
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 
-create table if not exists public.climbing_tiles_cache
+create table climbing_tiles_cache
 (
-  zxy           text not null       primary key,
+  zxy           text not null
+    primary key,
   tile_geojson  text not null,
   duration      integer,
   feature_count integer
 );
+
+alter table climbing_tiles_cache
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
+
+create table climbing_tiles_stats
+(
+  id                     serial
+    primary key,
+  timestamp              timestamp with time zone default now() not null,
+  osm_data_timestamp     timestamp with time zone               not null,
+  build_log              text,
+  build_duration         bigint                                 not null,
+  max_size               bigint                                 not null,
+  max_size_zxy           text                                   not null,
+  max_time               bigint                                 not null,
+  max_time_zxy           text                                   not null,
+  groups_count           integer,
+  groups_with_name_count integer,
+  routes_count           integer
+);
+
+alter table climbing_tiles_stats
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
+

--- a/src/server/climbing-tiles/db.sql
+++ b/src/server/climbing-tiles/db.sql
@@ -29,21 +29,22 @@ create table climbing_tiles_cache
 alter table climbing_tiles_cache
   owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 
+drop table climbing_tiles_stats;
 create table climbing_tiles_stats
 (
   id                     serial
     primary key,
-  timestamp              timestamp with time zone default now() not null,
-  osm_data_timestamp     timestamp with time zone               not null,
-  build_log              text,
-  build_duration         bigint                                 not null,
-  max_size               bigint                                 not null,
-  max_size_zxy           text                                   not null,
-  max_time               bigint                                 not null,
-  max_time_zxy           text                                   not null,
-  groups_count           integer,
-  groups_with_name_count integer,
-  routes_count           integer
+  timestamp              text    null,
+  osm_data_timestamp     text    null,
+  build_log              text    null,
+  build_duration         bigint  null,
+  max_size               bigint  null,
+  max_size_zxy           text    null,
+  max_time               bigint  null,
+  max_time_zxy           text    null,
+  groups_count           integer null,
+  groups_with_name_count integer null,
+  routes_count           integer null
 );
 
 alter table climbing_tiles_stats

--- a/src/server/climbing-tiles/db.sql
+++ b/src/server/climbing-tiles/db.sql
@@ -29,22 +29,21 @@ create table climbing_tiles_cache
 alter table climbing_tiles_cache
   owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 
-drop table climbing_tiles_stats;
 create table climbing_tiles_stats
 (
   id                     serial
     primary key,
-  timestamp              text    null,
-  osm_data_timestamp     text    null,
-  build_log              text    null,
-  build_duration         bigint  null,
-  max_size               bigint  null,
-  max_size_zxy           text    null,
-  max_time               bigint  null,
-  max_time_zxy           text    null,
-  groups_count           integer null,
-  groups_with_name_count integer null,
-  routes_count           integer null
+  timestamp              text,
+  osm_data_timestamp     text,
+  build_log              text,
+  build_duration         bigint,
+  max_size               bigint,
+  max_size_zxy           text,
+  max_time               bigint,
+  max_time_zxy           text,
+  groups_count           integer,
+  groups_with_name_count integer,
+  routes_count           integer
 );
 
 alter table climbing_tiles_stats

--- a/src/server/climbing-tiles/db.ts
+++ b/src/server/climbing-tiles/db.ts
@@ -1,10 +1,25 @@
 import { Client } from 'pg';
 
+export type ClimbingFeaturesRecords = {
+  type: string;
+  osmType: string;
+  osmId: number;
+  name: string;
+  count: number;
+  lon: number;
+  lat: number;
+  geojson: string;
+}[];
+
 if (!global.db) {
   global.db = { pool: false };
 }
 
 export async function getClient(): Promise<Client> {
+  if (!process.env.XATA_PASSWORD) {
+    throw new Error('XATA_PASSWORD must be set');
+  }
+
   if (!global.db.pool) {
     const client = new Client({
       user: 'tvgiad',
@@ -26,4 +41,5 @@ export async function getClient(): Promise<Client> {
 
 export async function closeClient(client: Client): Promise<void> {
   await client.end();
+  global.db.pool = false;
 }

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -1,6 +1,6 @@
 import { getClient } from './db';
 
-const query = `SELECT * FROM climbing_tiles_stats LIMIT 1`;
+const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
 
 export const getClimbingStats = async () => {
   const client = await getClient();

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -1,6 +1,23 @@
 import { getClient } from './db';
+import { ClimbingStatsResponse } from '../../types';
 
-export const getClimbingStats = async () => {
+export const getClimbingStats = async (): Promise<ClimbingStatsResponse> => {
+  // return {
+  //   "lastRefresh": "2025-02-10T15:23:37.283Z",
+  //   "osmDataTimestamp": "2024-11-26T08:17:27Z",
+  //   "devStats": {
+  //     "id": 37,
+  //     "build_duration": "12942",
+  //     "max_size": null,
+  //     "max_size_zxy": null,
+  //     "max_time": null,
+  //     "max_time_zxy": null
+  //   },
+  //   "groupsCount": 6518,
+  //   "groupsWithNameCount": 6422,
+  //   "routesCount": 14777
+  // };
+
   const client = await getClient();
   const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
   const result = await client.query(query);
@@ -15,15 +32,16 @@ export const getClimbingStats = async () => {
     groups_count,
     groups_with_name_count,
     routes_count,
+    build_log, // only in db
     ...devStats
   } = result.rows[0];
 
-  return JSON.stringify({
+  return {
     lastRefresh: timestamp,
     osmDataTimestamp: osm_data_timestamp,
-    devStats: JSON.stringify(devStats),
+    devStats,
     groupsCount: groups_count,
     groupsWithNameCount: groups_with_name_count,
     routesCount: routes_count,
-  });
+  };
 };

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -1,23 +1,29 @@
 import { getClient } from './db';
 
-const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
-
 export const getClimbingStats = async () => {
   const client = await getClient();
+  const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
   const result = await client.query(query);
 
   if (result.rowCount === 0) {
     throw new Error('No row found in climbing_tiles_stats');
   }
 
-  const row = result.rows[0];
+  const {
+    timestamp,
+    osm_data_timestamp,
+    groups_count,
+    groups_with_name_count,
+    routes_count,
+    ...devStats
+  } = result.rows[0];
 
   return JSON.stringify({
-    lastRefresh: row.timestamp,
-    osmTimestamp: row.osm_data_timestamp,
-    devStats: JSON.stringify(row, null, 2),
-    groupsCount: row.groups_count,
-    groupsWithNameCount: row.groups_with_name_count,
-    routesCount: row.routes_count,
+    lastRefresh: timestamp,
+    osmDataTimestamp: osm_data_timestamp,
+    devStats: JSON.stringify(devStats),
+    groupsCount: groups_count,
+    groupsWithNameCount: groups_with_name_count,
+    routesCount: routes_count,
   });
 };

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -1,0 +1,23 @@
+import { getClient } from './db';
+
+const query = `SELECT * FROM climbing_tiles_stats LIMIT 1`;
+
+export const getClimbingStats = async () => {
+  const client = await getClient();
+  const result = await client.query(query);
+
+  if (result.rowCount === 0) {
+    throw new Error('No row found in climbing_tiles_stats');
+  }
+
+  const row = result.rows[0];
+
+  return JSON.stringify({
+    lastRefresh: row.timestamp,
+    osmTimestamp: row.osm_data_timestamp,
+    devStats: JSON.stringify(row, null, 2),
+    groupsCount: row.groups_count,
+    groupsWithNameCount: row.groups_with_name_count,
+    routesCount: row.routes_count,
+  });
+};

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -2,22 +2,6 @@ import { getClient } from './db';
 import { ClimbingStatsResponse } from '../../types';
 
 export const getClimbingStats = async (): Promise<ClimbingStatsResponse> => {
-  // return {
-  //   "lastRefresh": "2025-02-10T15:23:37.283Z",
-  //   "osmDataTimestamp": "2024-11-26T08:17:27Z",
-  //   "devStats": {
-  //     "id": 37,
-  //     "build_duration": "12942",
-  //     "max_size": null,
-  //     "max_size_zxy": null,
-  //     "max_time": null,
-  //     "max_time_zxy": null
-  //   },
-  //   "groupsCount": 6518,
-  //   "groupsWithNameCount": 6422,
-  //   "routesCount": 14777
-  // };
-
   const client = await getClient();
   const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
   const result = await client.query(query);

--- a/src/server/climbing-tiles/getClimbingTile.ts
+++ b/src/server/climbing-tiles/getClimbingTile.ts
@@ -53,13 +53,12 @@ export const getClimbingTile = async ({ z, x, y }: Tile) => {
   const duration = Math.round(performance.now() - start);
   logCacheMiss(duration, geojson.features.length);
 
-  // intentionally not awaited to make quicker return of data
-  client.query(
+  await client.query(
     `INSERT INTO climbing_tiles_cache VALUES ($1, $2, $3, $4) ON CONFLICT (zxy) DO NOTHING`,
     [cacheKey, geojson, duration, geojson.features.length],
   );
 
-  closeClient(client);
+  await closeClient(client);
 
   return JSON.stringify(geojson);
 };

--- a/src/server/climbing-tiles/getClimbingTile.ts
+++ b/src/server/climbing-tiles/getClimbingTile.ts
@@ -1,4 +1,4 @@
-import { getClient } from './db';
+import { closeClient, getClient } from './db';
 import { tileToBBOX } from './tileToBBOX';
 import { Tile } from '../../types';
 import { optimizeGeojsonToGrid } from './optimizeGeojsonToGrid';
@@ -58,6 +58,8 @@ export const getClimbingTile = async ({ z, x, y }: Tile) => {
     `INSERT INTO climbing_tiles_cache VALUES ($1, $2, $3, $4) ON CONFLICT (zxy) DO NOTHING`,
     [cacheKey, geojson, duration, geojson.features.length],
   );
+
+  closeClient(client);
 
   return JSON.stringify(geojson);
 };

--- a/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
+++ b/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
@@ -37,6 +37,7 @@ type OsmRelation = {
 type OsmItem = OsmNode | OsmWay | OsmRelation;
 export type OsmResponse = {
   elements: OsmItem[];
+  osm3s: { timestamp_osm_base: string }; // overpass only
 };
 
 export type GeojsonFeature<T extends FeatureGeometry = FeatureGeometry> = {

--- a/src/server/climbing-tiles/utils.ts
+++ b/src/server/climbing-tiles/utils.ts
@@ -50,8 +50,7 @@ export const updateStats = async (
   records: ClimbingFeaturesRecords,
 ) => {
   const statsRow = {
-    id: 1,
-    timestamp: new Date().toISOString(),
+    timestamp: new Date(),
     osm_data_timestamp: data.osm3s.timestamp_osm_base,
     build_log: buildLog,
     build_duration: buildDuration,
@@ -62,12 +61,14 @@ export const updateStats = async (
       .length,
   };
 
-  const client = await getClient();
-  await client.query(
-    format(
-      'TRUNCATE climbing_tiles_stats;INSERT INTO climbing_tiles_stats(%I) VALUES %L',
-      Object.keys(statsRow),
-      Object.values(statsRow),
-    ),
+  const query = format(
+    'INSERT INTO climbing_tiles_stats(%I) VALUES (%L)',
+    Object.keys(statsRow),
+    Object.values(statsRow),
   );
+
+  console.log(query);
+
+  const client = await getClient();
+  await client.query(query);
 };

--- a/src/server/climbing-tiles/utils.ts
+++ b/src/server/climbing-tiles/utils.ts
@@ -46,29 +46,27 @@ export const updateStats = async (
   data: OsmResponse,
   buildLog: string,
   buildDuration: number,
-  tileStats: TileStats,
+  deletedTilesStats: TileStats,
   records: ClimbingFeaturesRecords,
 ) => {
   const statsRow = {
-    timestamp: new Date(),
+    timestamp: new Date().toISOString(),
     osm_data_timestamp: data.osm3s.timestamp_osm_base,
     build_log: buildLog,
     build_duration: buildDuration,
-    ...tileStats,
+    ...deletedTilesStats,
     routes_count: records.filter((r) => r.type === 'route').length,
     groups_count: records.filter((r) => r.type === 'group').length,
     groups_with_name_count: records.filter((r) => r.type === 'group' && r.name)
       .length,
   };
 
-  const query = format(
-    'INSERT INTO climbing_tiles_stats(%I) VALUES (%L)',
-    Object.keys(statsRow),
-    Object.values(statsRow),
-  );
-
-  console.log(query);
-
   const client = await getClient();
-  await client.query(query);
+  await client.query(
+    format(
+      'INSERT INTO climbing_tiles_stats(%I) VALUES (%L)',
+      Object.keys(statsRow),
+      Object.values(statsRow),
+    ),
+  );
 };

--- a/src/server/climbing-tiles/utils.ts
+++ b/src/server/climbing-tiles/utils.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Client } from 'pg';
+import { OsmResponse } from './overpass/overpassToGeojsons';
+import { ClimbingFeaturesRecords, getClient } from './db';
+import format from 'pg-format';
+
+export const addCorsHeaders = (req: NextApiRequest, res: NextApiResponse) => {
+  const origin = req.headers.origin;
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+};
+
+type TileStats =
+  | {}
+  | {
+      max_time_zxy: string;
+      max_size_zxy: string;
+      max_time: string;
+      max_size: string;
+    };
+
+export const queryTileStats = async (client: Client): Promise<TileStats> => {
+  const time = await client.query(
+    'SELECT zxy, duration FROM climbing_tiles_cache ORDER BY duration DESC LIMIT 1',
+  );
+  const size = await client.query(
+    'SELECT zxy, LENGTH(tile_geojson) AS size FROM climbing_tiles_cache ORDER BY size DESC LIMIT 1',
+  );
+
+  if (!time.rowCount || !size.rowCount) {
+    return {};
+  }
+
+  return {
+    max_time: time.rows[0].duration,
+    max_time_zxy: time.rows[0].zxy,
+    max_size: size.rows[0].size,
+    max_size_zxy: size.rows[0].zxy,
+  };
+};
+
+export const updateStats = async (
+  data: OsmResponse,
+  buildLog: string,
+  buildDuration: number,
+  tileStats: TileStats,
+  records: ClimbingFeaturesRecords,
+) => {
+  const statsRow = {
+    id: 1,
+    timestamp: new Date().toISOString(),
+    osm_data_timestamp: data.osm3s.timestamp_osm_base,
+    build_log: buildLog,
+    build_duration: buildDuration,
+    ...tileStats,
+    routes_count: records.filter((r) => r.type === 'route').length,
+    groups_count: records.filter((r) => r.type === 'group').length,
+    groups_with_name_count: records.filter((r) => r.type === 'group' && r.name)
+      .length,
+  };
+
+  const client = await getClient();
+  await client.query(
+    format(
+      'TRUNCATE climbing_tiles_stats;INSERT INTO climbing_tiles_stats(%I) VALUES %L',
+      Object.keys(statsRow),
+      Object.values(statsRow),
+    ),
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,12 @@
 export type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
 
 export type Tile = { z: number; x: number; y: number };
+
+export type ClimbingStatsResponse = {
+  lastRefresh: string;
+  osmDataTimestamp: string;
+  devStats: Record<string, string>;
+  groupsCount: number;
+  groupsWithNameCount: number;
+  routesCount: number;
+};


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

Add API endpoint `api/climbing-tiles/stats`, which shows statistics about last ClimbingTiles refresh and some useful numbers:

eg.
```
{
  "lastRefresh": "2025-02-11T06:29:30.892Z",
  "osmDataTimestamp": "2025-02-11T06:26:33Z",
  "devStats": {
    "id": 1,
    "build_duration": "91728",
    "max_size": "284394",
    "max_size_zxy": "6/34/21",
    "max_time": "1219",
    "max_time_zxy": "6/34/21"
  },
  "groupsCount": 15970,
  "groupsWithNameCount": 14878,
  "routesCount": 19421
}
```

### Screenshots

In LayerSwitcher we show the timestamp of the data:

<img width="319" alt="image" src="https://github.com/user-attachments/assets/3666c16f-48cc-4b10-ab90-dc79b15a65d2" />


<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [x] dark mode / light mode
- [x] mobile / desktop
- NA server-side-rendering (SSR)
- [x] all texts are localized (in vocabulary.ts)
