### PR TITLE
osmApi: convertToRelation - deletes existing node

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -110,6 +110,7 @@ export const AddMemberForm = ({
       newLonLat,
       setCurrent,
       setMembers,
+      view,
     ],
   );
 

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -67,7 +67,7 @@ export const AddMemberForm = ({
   const defaultTags = getDefaultTags();
 
   const { addFeature, items, setCurrent, current } = useEditContext();
-  const { members, setMembers, tags, setShortId } = useCurrentItem();
+  const { members, setMembers, tags, convertToRelation } = useCurrentItem();
   const [showInput, setShowInput] = React.useState(false);
   const [label, setLabel] = React.useState('');
   const isClimbingCrag = tags.climbing === 'crag';
@@ -133,9 +133,8 @@ export const AddMemberForm = ({
     return; // TODO so far, we need a node (with coordinates) for adding a new node
   }
 
-  const convertToRelation = () => {
-    const newShortId = `r${getNewId()}`;
-    setShortId(newShortId); // TODO duplicate item instead and add `redirect=relation/123` tag
+  const handleConvertToRelation = async () => {
+    const newShortId = await convertToRelation();
     setCurrent(newShortId);
   };
 
@@ -162,7 +161,7 @@ export const AddMemberForm = ({
           icon={null}
           action={
             <Button
-              onClick={convertToRelation}
+              onClick={handleConvertToRelation}
               color="inherit"
               variant="text"
               size="small"

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ItemHeading.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ItemHeading.tsx
@@ -2,9 +2,14 @@ import { useCurrentItem } from './CurrentContext';
 import { Stack, Typography } from '@mui/material';
 import { getOsmTypeFromShortId, NwrIcon } from '../../../NwrIcon';
 import React from 'react';
+import styled from '@emotion/styled';
+
+const StyledTypography = styled(Typography)<{ $deleted: boolean }>`
+  ${({ $deleted }) => $deleted && 'text-decoration: line-through;'}
+`;
 
 export const ItemHeading = () => {
-  const { shortId, tags, presetLabel } = useCurrentItem();
+  const { shortId, tags, presetLabel, toBeDeleted } = useCurrentItem();
 
   return (
     <Stack
@@ -14,7 +19,9 @@ export const ItemHeading = () => {
       alignItems="center"
       mb={2}
     >
-      <Typography variant="h6">{tags.name || presetLabel || ' '}</Typography>
+      <StyledTypography variant="h6" $deleted={toBeDeleted}>
+        {tags.name || presetLabel || ' '}
+      </StyledTypography>
       <Stack direction="row" alignItems="center" gap={0.5}>
         <Typography variant="caption" color="secondary">
           {shortId}

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -79,9 +79,9 @@ export const MembersEditor = () => {
       >
         <Stack direction="row" spacing={2} alignItems="center">
           <SectionName />
-          {membersLength && (
+          {membersLength ? (
             <Chip size="small" label={membersLength} variant="outlined" />
-          )}
+          ) : null}
         </Stack>
       </AccordionSummary>
       <AccordionDetails>

--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
@@ -12,6 +12,10 @@ import React from 'react';
 import { PoiIcon } from '../../../utils/icons/PoiIcon';
 import { EditDataItem } from '../useEditItems';
 
+const StyledTypography = styled(Typography)<{ $deleted: boolean }>`
+  ${({ $deleted }) => $deleted && 'text-decoration: line-through;'}
+`;
+
 const StyledTabs = styled(Tabs)`
   border-color: ${({ theme }) => theme.palette.divider};
   && .MuiTab-root {
@@ -42,34 +46,30 @@ const StyledTabs = styled(Tabs)`
 type TabLabelProps = {
   item: EditDataItem;
 };
-
-const TabLabel = ({ item }: TabLabelProps) => {
-  const { shortId, tags, presetLabel } = item;
-
-  return (
-    <Stack direction="column" alignItems="flex-start" width="100%">
-      <Stack
-        direction="row"
-        gap={1}
-        alignItems="center"
-        justifyContent="space-between"
-        width="100%"
-      >
-        <Typography variant="button" whiteSpace="nowrap">
-          {tags.name ?? shortId}
-        </Typography>
-      </Stack>
-      <Typography
-        variant="caption"
-        textTransform="lowercase"
+const TabLabel = ({
+  item: { shortId, tags, presetLabel, toBeDeleted },
+}: TabLabelProps) => (
+  <Stack direction="column" alignItems="flex-start" width="100%">
+    <Stack
+      direction="row"
+      gap={1}
+      alignItems="center"
+      justifyContent="space-between"
+      width="100%"
+    >
+      <StyledTypography
+        variant="button"
         whiteSpace="nowrap"
+        $deleted={toBeDeleted}
       >
-        <PoiIcon tags={tags} />
-        {presetLabel}
-      </Typography>
+        {tags.name ?? shortId}
+      </StyledTypography>
     </Stack>
-  );
-};
+    <Typography variant="caption" textTransform="lowercase" whiteSpace="nowrap">
+      {presetLabel}
+    </Typography>
+  </Stack>
+);
 
 export const ItemsTabs = () => {
   const { items, current, setCurrent } = useEditContext();

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -11,6 +11,9 @@ import { useMemo, useState } from 'react';
 import { publishDbgObject } from '../../../utils';
 import { findPreset } from '../../../services/tagging/presets';
 import { getPresetTranslation } from '../../../services/tagging/translations';
+import { getNewId } from '../../../services/getCoordsFeature';
+import { fetchParentFeatures } from '../../../services/osm/fetchParentFeatures';
+import { fetchWays } from '../../../services/osm/fetchWays';
 
 export type TagsEntries = [string, string][];
 
@@ -41,6 +44,7 @@ export type EditDataItem = DataItem & {
   setShortId: SetShortId;
   setNodeLonLat: (lonLat: LonLat) => void;
   toggleToBeDeleted: () => void;
+  convertToRelation: ConvertToRelation;
 };
 
 const buildDataItem = (feature: Feature): DataItem => {
@@ -56,7 +60,7 @@ const buildDataItem = (feature: Feature): DataItem => {
       feature.memberFeatures?.map((memberFeature) => ({
         shortId: getShortId(memberFeature.osmMeta),
         role: memberFeature.osmMeta.role,
-        label: getLabel(memberFeature), // TODO what if user updates the tags ?
+        label: getLabel(memberFeature),
       })) ??
       feature.members?.map((member) => ({
         shortId: getShortId({ type: member.type, id: member.ref }),
@@ -124,6 +128,59 @@ const setDataItemFactory =
       }
       return newData;
     });
+  };
+
+type ConvertToRelation = () => Promise<string>;
+const convertToRelationFactory =
+  (setData: Setter<DataItem[]>, shortId: string): ConvertToRelation =>
+  async () => {
+    const [parentFeatures, waysFeatures] = await Promise.all([
+      fetchParentFeatures(getApiId(shortId)),
+      fetchWays(getApiId(shortId)),
+    ]);
+
+    if (waysFeatures.length > 0) {
+      throw new Error(`Can't convert node ${shortId} which is part of a way`);
+    }
+
+    const newShortId = `r${getNewId()}`;
+    setData((prevData) => {
+      // TODO - don't delete natural=peak - leave it as node
+      const newData = prevData.map((item) =>
+        item.shortId === shortId ? { ...item, toBeDeleted: true } : item,
+      );
+      const currentItem = prevData.find((item) => item.shortId === shortId);
+
+      const newRelation: DataItem = {
+        shortId: newShortId,
+        version: undefined,
+        tagsEntries: currentItem.tagsEntries,
+        toBeDeleted: false,
+        members: [],
+        nodeLonLat: undefined,
+      };
+
+      // update member id in all parent relations
+      const parentItems = parentFeatures.map((feature) => {
+        const dataItem = buildDataItem(feature);
+        return {
+          ...dataItem,
+          members: dataItem.members.map((member) =>
+            member.shortId === shortId
+              ? {
+                  ...member,
+                  shortId: newShortId,
+                  label: getName(currentItem) ?? newShortId,
+                }
+              : member,
+          ),
+        };
+      });
+
+      return [...newData, ...parentItems, newRelation];
+    });
+
+    return newShortId;
   };
 
 type SetTagsEntries = (updateFn: (prev: TagsEntries) => TagsEntries) => void;
@@ -206,6 +263,7 @@ export const useEditItems = (originalFeature: Feature) => {
           setNodeLonLat: setNodeLonLatFactory(setDataItem),
           presetKey,
           presetLabel: getPresetTranslation(presetKey),
+          convertToRelation: convertToRelationFactory(setData, shortId),
         };
         // TODO maybe keep reference to original EditDataItem if DataItem didnt change? #performance
       }),


### PR DESCRIPTION
In this process we want to change the "deleted node id" in all parent relations to the new relation id instead.

Also:
- before showing the EditDialog - we refresh the item (to ensure we have memberFeatures)
- when adding node and we have no previous in relation, we use the MapView

Followup:
- when using the mapview - we need to show a warning (or prompt the user to confirm it)
- when deleting a node, we want to forbid any edits, as OsmApi probably needs exactly the last version.