### PR TITLE
Icons: Use marker icon instead of information for generic POIs

### DIFF
--- a/src/services/__tests__/fetchCrags.test.ts
+++ b/src/services/__tests__/fetchCrags.test.ts
@@ -106,7 +106,7 @@ const geojson = [
     id: 2221,
     osmMeta: { id: 222, type: 'way' },
     properties: {
-      class: 'information',
+      class: 'marker',
       osmappType: 'way',
       osmappHasImages: false,
       osmappLabel: '',
@@ -203,7 +203,7 @@ test('conversion with centers instead of geometries', () => {
         type: 'GeometryCollection',
       },
       properties: {
-        class: 'information',
+        class: 'marker',
         osmappType: 'relation',
         osmappHasImages: false,
         osmappLabel: '',
@@ -218,7 +218,7 @@ test('conversion with centers instead of geometries', () => {
       center: [14, 51],
       geometry: { coordinates: [14, 51], type: 'Point' },
       properties: {
-        class: 'information',
+        class: 'marker',
         osmappType: 'relation',
         osmappHasImages: false,
         osmappLabel: '',

--- a/src/services/__tests__/overpassAroundToSkeletons.test.ts
+++ b/src/services/__tests__/overpassAroundToSkeletons.test.ts
@@ -105,7 +105,7 @@ const skeletons = [
       type: 'node',
     },
     properties: {
-      class: 'information',
+      class: 'marker',
     },
     tags: {},
     type: 'Feature',
@@ -121,7 +121,7 @@ const skeletons = [
       type: 'node',
     },
     properties: {
-      class: 'information',
+      class: 'marker',
       subclass: 'crossing',
     },
     tags: {

--- a/src/services/__tests__/overpassSearch.test.ts
+++ b/src/services/__tests__/overpassSearch.test.ts
@@ -109,7 +109,7 @@ const geojson = [
       type: 'node',
     },
     properties: {
-      class: 'information',
+      class: 'marker',
       crossing: 'marked',
       highway: 'crossing',
       osmappType: 'node',
@@ -137,7 +137,7 @@ const geojson = [
       type: 'way',
     },
     properties: {
-      class: 'information',
+      class: 'marker',
       highway: 'track',
       osmappType: 'way',
       subclass: 'track',

--- a/src/services/getPoiClass.ts
+++ b/src/services/getPoiClass.ts
@@ -322,5 +322,5 @@ export const getPoiClass = (tags: FeatureTags): PoiClass => {
     };
   }
 
-  return { class: 'information', subclass }; // default icon
+  return { class: 'marker', subclass }; // default icon
 };


### PR DESCRIPTION
Closed: #966

### Description

User marker icon

### Example links

Search for hydrants

### Screenshots

![marker icon](https://github.com/user-attachments/assets/d48f46c7-0ef0-4141-8e7e-5ab436883739)

### Checklist

- [x] dark mode / light mode
- [x] mobile / desktop
- [x] server-side-rendering (SSR)
- [x] all texts are localized (in vocabulary.ts)
