### PR TITLE
FeaturePanel: fix ShareDialog when no center

### DIFF
--- a/src/components/FeaturePanel/QuickActions/ShareDialog/useGetItems.ts
+++ b/src/components/FeaturePanel/QuickActions/ShareDialog/useGetItems.ts
@@ -8,13 +8,19 @@ import { imageAttributions, items } from './items';
 const MAPLIBREGL_ZOOM_DIFFERENCE = 1;
 
 export const useGetItems = () => {
+  const { view, activeLayers } = useMapStateContext();
   const { feature } = useFeatureContext();
   const { center, roundedCenter = undefined } = feature;
   const position = roundedCenter ?? center;
 
-  const { view, activeLayers } = useMapStateContext();
-  const [lon, lat] = position;
+  if (!position) {
+    return {
+      imageAttributions: [],
+      items: [],
+    };
+  }
 
+  const [lon, lat] = position;
   const [ourZoom] = view;
   const zoom = parseFloat(ourZoom) + MAPLIBREGL_ZOOM_DIFFERENCE;
   const zoomInt = Math.round(zoom);


### PR DESCRIPTION
Relation can have no `center`, when Overpass is broken, or it is new item that was not yet imported to overpass. Via #970

Then it will look like this:

![image](https://github.com/user-attachments/assets/61505177-5f4d-4114-b86a-dcf46c8cc7a5)
