### PR TITLE
feat: Search via URL - Add q and qd parameters

### DIFF
--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -110,6 +110,8 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
                 push: () => Promise.resolve(true),
               },
             })(null as never, firstOption);
+            // Ensure search box stays closed after qd search
+            setIsOpen(false);
           }
         }
       }, 500);
@@ -177,7 +179,10 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         undefined,
         { shallow: true },
       );
-      setIsOpen(true);
+      // Only open search box if not using qd parameter
+      if (!router.query.qd) {
+        setIsOpen(true);
+      }
     } else {
       const { q, qd, ...restQuery } = router.query;
       void router.push(

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Autocomplete, InputBase } from '@mui/material';
 import { useFeatureContext } from '../utils/FeatureContext';
 import { renderOptionFactory } from './renderOptionFactory';
@@ -84,6 +84,52 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const { isImperial } = userSettings;
   const inputRef = useRef<HTMLInputElement>(null);
   const lastInputValue = useRef(inputValue);
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Handle qd parameter on mount
+  useEffect(() => {
+    const qd = router.query.qd;
+    if (typeof qd === 'string') {
+      // Set input value and wait for options
+      setInputValue(qd);
+      const timer = setTimeout(() => {
+        if (options.length > 0) {
+          const firstOption = options[0];
+          if (
+            firstOption.type === 'preset' ||
+            firstOption.type === 'overpass'
+          ) {
+            // First perform the search
+            onSelectedFactory({
+              setFeature,
+              setPreview,
+              bbox,
+              showToast,
+              setOverpassLoading,
+              router: {
+                ...router,
+                push: () => Promise.resolve(true), // Mock router.push to do nothing
+              },
+            })(null as never, firstOption);
+
+            // Then update the URL after a delay to ensure the search is complete
+            setTimeout(() => {
+              const { qd: _, ...restQuery } = router.query;
+              router.push(
+                {
+                  pathname: router.pathname,
+                  query: restQuery, // Don't add q parameter to keep search box closed
+                },
+                undefined,
+                { shallow: true },
+              );
+            }, 1000);
+          }
+        }
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+  }, [router.query.qd, options.length]);
 
   // Only set initial query value on mount
   useEffect(() => {
@@ -95,6 +141,11 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   // Update URL while typing (debounced)
   const debouncedInputValue = useDebounce(inputValue, 300);
   useEffect(() => {
+    // Skip URL update if we're handling qd parameter
+    if (router.query.qd) {
+      return;
+    }
+
     if (debouncedInputValue === lastInputValue.current) {
       return;
     }
@@ -109,6 +160,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         undefined,
         { shallow: true },
       );
+      setIsOpen(true); // Keep search box open when typing
     } else {
       // Remove q parameter when input is empty
       const { q, ...restQuery } = router.query;
@@ -120,12 +172,14 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
         undefined,
         { shallow: true },
       );
+      setIsOpen(false); // Close search box when input is empty
     }
   }, [debouncedInputValue, router]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
     setInputValue(newValue);
+    setIsOpen(!!newValue); // Open dialog when there's input
   };
 
   return (
@@ -151,7 +205,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       autoHighlight
       clearOnEscape
       freeSolo
-      open={!!inputValue}
+      open={isOpen}
       renderInput={(params) => (
         <SearchBoxInput
           params={params}

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -64,11 +64,13 @@ const SearchBoxInput = ({
 type AutocompleteInputProps = {
   autocompleteRef: React.MutableRefObject<undefined>;
   setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  initialQuery?: string;
 };
 
 export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   autocompleteRef,
   setOverpassLoading,
+  initialQuery,
 }) => {
   const { setFeature, setPreview } = useFeatureContext();
   const { bbox } = useMapStateContext();
@@ -80,6 +82,13 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const router = useRouter();
   const { userSettings } = useUserSettingsContext();
   const { isImperial } = userSettings;
+
+  // Only set initial query value on mount
+  useEffect(() => {
+    if (initialQuery && inputValue === '') {
+      setInputValue(initialQuery);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Autocomplete
@@ -106,6 +115,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       clearOnEscape
       // disableCloseOnSelect
       freeSolo
+      open={!!inputValue} // Show results when there's input
       // disableOpenOnFocus
       renderInput={(params) => (
         <SearchBoxInput

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -91,7 +91,6 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   useEffect(() => {
     const qd = router.query.qd;
     if (typeof qd === 'string' && bbox) {
-      // Set input value and wait for options
       setInputValue(qd);
       const timer = setTimeout(() => {
         if (options.length > 0) {
@@ -100,7 +99,6 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
             firstOption.type === 'preset' ||
             firstOption.type === 'overpass'
           ) {
-            // Perform the search without updating the URL
             onSelectedFactory({
               setFeature,
               setPreview,
@@ -109,7 +107,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
               setOverpassLoading,
               router: {
                 ...router,
-                push: () => Promise.resolve(true), // Mock router.push to prevent URL updates
+                push: () => Promise.resolve(true),
               },
             })(null as never, firstOption);
           }
@@ -117,7 +115,17 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       }, 500);
       return () => clearTimeout(timer);
     }
-  }, [router.query.qd, options.length, bbox]);
+  }, [
+    router.query.qd,
+    bbox,
+    options,
+    router,
+    setFeature,
+    setInputValue,
+    setOverpassLoading,
+    setPreview,
+    showToast,
+  ]);
 
   // Only set initial query value on mount
   useEffect(() => {
@@ -160,7 +168,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
     lastInputValue.current = debouncedInputValue;
 
     if (debouncedInputValue) {
-      router.push(
+      void router.push(
         {
           pathname: router.pathname,
           query: { ...router.query, q: debouncedInputValue },
@@ -171,9 +179,8 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       );
       setIsOpen(true);
     } else {
-      // Remove q parameter when input is empty
-      const { q, qd, ...restQuery } = router.query; // Also remove qd if it exists
-      router.push(
+      const { q, qd, ...restQuery } = router.query;
+      void router.push(
         {
           pathname: router.pathname,
           query: restQuery,
@@ -184,7 +191,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       );
       setIsOpen(false);
     }
-  }, [debouncedInputValue, router]);
+  }, [debouncedInputValue, router, inputValue]);
 
   return (
     <Autocomplete

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -86,6 +86,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const lastInputValue = useRef(inputValue);
   const [isOpen, setIsOpen] = useState(false);
+  const { feature } = useFeatureContext();
 
   // Handle qd parameter on mount
   useEffect(() => {
@@ -176,6 +177,13 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       { shallow: true },
     );
   }, [debouncedInputValue, router, inputValue]);
+
+  // Keep search box closed when feature is shown
+  useEffect(() => {
+    if (feature) {
+      setIsOpen(false);
+    }
+  }, [feature]);
 
   return (
     <Autocomplete

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -92,38 +92,44 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
     const qd = router.query.qd;
     if (typeof qd === 'string' && bbox) {
       setInputValue(qd);
-      const timer = setTimeout(() => {
-        if (options.length > 0) {
-          const firstOption = options[0];
-          if (
-            firstOption.type === 'preset' ||
-            firstOption.type === 'overpass'
-          ) {
-            onSelectedFactory({
-              setFeature,
-              setPreview,
-              bbox,
-              showToast,
-              setOverpassLoading,
-              router: {
-                ...router,
-                push: () => Promise.resolve(true),
-              },
-            })(null as never, firstOption);
-            setIsOpen(false);
-          }
-        }
-      }, 500);
-      return () => clearTimeout(timer);
+      // Trigger search immediately
+      const firstOption = options[0];
+      if (
+        firstOption &&
+        (firstOption.type === 'preset' || firstOption.type === 'overpass')
+      ) {
+        onSelectedFactory({
+          setFeature,
+          setPreview,
+          bbox,
+          showToast,
+          setOverpassLoading,
+          router: {
+            ...router,
+            push: () => Promise.resolve(true),
+          },
+        })(null as never, firstOption);
+        setIsOpen(false);
+      }
     }
-  }, [router.query.qd, bbox, options]);
+  }, [
+    router.query.qd,
+    bbox,
+    options,
+    router,
+    setFeature,
+    setPreview,
+    showToast,
+    setOverpassLoading,
+    setInputValue,
+  ]);
 
   // Only set initial query value on mount
   useEffect(() => {
     if (initialQuery && inputValue === '') {
       setInputValue(initialQuery);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialQuery, inputValue, setInputValue]);
 
   // Handle input changes
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -89,7 +89,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   // Handle qd parameter on mount
   useEffect(() => {
     const qd = router.query.qd;
-    if (typeof qd === 'string') {
+    if (typeof qd === 'string' && bbox) {
       // Set input value and wait for options
       setInputValue(qd);
       const timer = setTimeout(() => {
@@ -129,7 +129,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       }, 500);
       return () => clearTimeout(timer);
     }
-  }, [router.query.qd, options.length]);
+  }, [router.query.qd, options.length, bbox]);
 
   // Only set initial query value on mount
   useEffect(() => {

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -217,6 +217,7 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       clearOnEscape
       freeSolo
       open={isOpen}
+      onClose={() => setIsOpen(false)}
       renderInput={(params) => (
         <SearchBoxInput
           params={params}

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -80,6 +80,8 @@ const SearchBoxInner = ({ withoutPanel }) => {
   const [overpassLoading, setOverpassLoading] = useState(false);
   const autocompleteRef = useRef();
   const onClosePanel = useOnClosePanel();
+  const router = useRouter();
+  const searchQuery = router.query.q as string;
 
   return (
     <TopPanel>
@@ -95,6 +97,7 @@ const SearchBoxInner = ({ withoutPanel }) => {
         <AutocompleteInput
           autocompleteRef={autocompleteRef}
           setOverpassLoading={setOverpassLoading}
+          initialQuery={searchQuery}
         />
 
         {overpassLoading && <OverpassCircularProgress />}

--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -42,7 +42,6 @@ const overpassOptionSelected = (
       const content = t('searchbox.overpass_success', { count });
       showToast(content);
 
-      // Wait for the map to be ready
       const map = getGlobalMap();
       const setDataWhenReady = () => {
         const source = getOverpassSource();
@@ -51,11 +50,9 @@ const overpassOptionSelected = (
         }
       };
 
-      // If the map is loaded, set the data immediately
       if (map?.loaded()) {
         setDataWhenReady();
       } else {
-        // Otherwise, wait for the load event
         map?.once('load', setDataWhenReady);
       }
 
@@ -66,7 +63,6 @@ const overpassOptionSelected = (
     .catch((e) => {
       const message = `${e}`.substring(0, 100);
       const content = t('searchbox.overpass_error', { message });
-      console.error(e);
       showToast(content, 'error');
     })
     .finally(() => {

--- a/src/components/SearchBox/onSelectedFactory.ts
+++ b/src/components/SearchBox/onSelectedFactory.ts
@@ -112,6 +112,12 @@ export const onSelectedFactory =
         break;
       case 'geocoder':
         geocoderOptionSelected(option, setFeature);
+        // Update URL with search query
+        const searchQuery = option.geocoder.properties?.name || '';
+        router.push({
+          pathname: router.pathname,
+          query: { ...router.query, q: searchQuery },
+        });
         break;
       case 'osm':
         osmOptionSelected(option, router);

--- a/src/components/SearchBox/useGetOptions.tsx
+++ b/src/components/SearchBox/useGetOptions.tsx
@@ -29,6 +29,15 @@ export const useGetOptions = (inputValue: string) => {
         return;
       }
 
+      // Check for overpass options first if input matches a tag pattern
+      if (inputValue.includes('=')) {
+        const overpassOptions = getOverpassOptions(inputValue);
+        if (overpassOptions.length) {
+          setOptions(overpassOptions);
+          return;
+        }
+      }
+
       const coordOptions = getCoordsOption(inputValue);
       if (coordOptions.length) {
         setOptions(coordOptions);
@@ -54,11 +63,11 @@ export const useGetOptions = (inputValue: string) => {
       fetchGeocoderOptions({
         inputValue,
         view,
-        setOptions, // TODO refactor to await options instead of setOptions
+        setOptions,
         before: beforeWithStars,
         after,
       });
     })();
-  }, [inputValue, stars]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [inputValue, stars, view]);
   return options;
 };

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import debounce from 'lodash/debounce';
 
 export const useScreensize = () => {
   const [screenSize, setScreenSize] = useState({
@@ -71,4 +72,25 @@ export const useLog = (...params: any[]) => {
     console.log(...params);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [...params]);
+};
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const debouncedRef = useRef<ReturnType<typeof debounce>>();
+
+  useEffect(() => {
+    if (!debouncedRef.current) {
+      debouncedRef.current = debounce((newValue: T) => {
+        setDebouncedValue(newValue);
+      }, delay);
+    }
+
+    debouncedRef.current(value);
+
+    return () => {
+      debouncedRef.current?.cancel();
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
 };


### PR DESCRIPTION
### Description

See #119 

* Introduced ?q= parameter which prefills the search and opens the search dropdown
* Introduce ?qd= parameter (qd for query directly) which searches for the first result.
* URL is updated (debounced) when typing a search query

**Disclaimer: I did this with cursor AI - feel free to discard completely.**

Mainly doing the MR to have some PoC Vercel app for further testing.

### Example links

* https://osmapp-git-fork-openplaceguide-119-searchbang-ai-osm-app-team.vercel.app/?q=Addis+Ababa
* https://osmapp-git-fork-openplaceguide-119-searchbang-ai-osm-app-team.vercel.app/?qd=amenity%3Drestaurant#11.70/8.9907/38.8546
* https://osmapp-git-fork-openplaceguide-119-searchbang-ai-osm-app-team.vercel.app/?qd=restaurants#11.70/8.9907/38.8546

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)





