### PR TITLE
SearchBox: implement ?qd=query for search from browser

### DIFF
--- a/src/components/Directions/DirectionsAutocomplete.tsx
+++ b/src/components/Directions/DirectionsAutocomplete.tsx
@@ -160,7 +160,11 @@ const useOptions = (inputValue: string) => {
           return;
         }
 
-        const geocoderOptions = await fetchGeocoderOptions(inputValue, view);
+        const geocoderOptions = await fetchGeocoderOptions(
+          inputValue,
+          view,
+          GEOCODER_ABORTABLE_QUEUE,
+        );
         if (geocoderOptions) {
           setOptions(geocoderOptions);
         }

--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -10,6 +10,7 @@ import { OptionsPaper, OptionsPopper } from './optionsPopper';
 import { AutocompleteProps } from '@mui/material/Autocomplete/Autocomplete';
 import { Option } from './types';
 import { renderInputFactory } from './renderInputFactory';
+import { useHandleDirectQuery } from './useHandleDirectQuery';
 
 const AutocompleteConfigured = (
   props: AutocompleteProps<Option, false, true, true>,
@@ -39,6 +40,8 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   const options = useGetOptions(inputValue);
   const onHighlight = useGetOnHighlight();
   const onSelected = useGetOnSelected(setOverpassLoading);
+
+  useHandleDirectQuery(onSelected, setInputValue);
 
   return (
     <AutocompleteConfigured

--- a/src/components/SearchBox/options/geocoder.tsx
+++ b/src/components/SearchBox/options/geocoder.tsx
@@ -73,11 +73,12 @@ export const debounceGeocoderOrReject = (delay: number): Promise<void> => {
 export const fetchGeocoderOptions = async (
   inputValue: string,
   view: View,
+  abortQueue?: string,
 ): Promise<Option[] | undefined> => {
   try {
     const searchResponse = await fetchJson<PhotonResponse>(
       getApiUrl(inputValue, view),
-      { abortableQueueName: GEOCODER_ABORTABLE_QUEUE },
+      { abortableQueueName: abortQueue },
     );
 
     // This blocks rendering of old result, when user already changed input

--- a/src/components/SearchBox/options/overpass.tsx
+++ b/src/components/SearchBox/options/overpass.tsx
@@ -8,7 +8,10 @@ import { getAST, queryWizardLabel } from '../queryWizard/queryWizard';
 import { Bbox } from '../../utils/MapStateContext';
 import { ShowToast } from '../../utils/SnackbarContext';
 import { performOverpassSearch } from '../../../services/overpass/overpassSearch';
-import { getOverpassSource } from '../../../services/mapStorage';
+import {
+  getOverpassSource,
+  mapIdlePromise,
+} from '../../../services/mapStorage';
 
 const OVERPASS_HISTORY_KEY = 'overpassQueryHistory';
 
@@ -103,7 +106,10 @@ export const overpassOptionSelected = (
       const count = geojson.features.length;
       const content = t('searchbox.overpass_success', { count });
       showToast(content);
-      getOverpassSource()?.setData(geojson);
+
+      mapIdlePromise.then(() => {
+        getOverpassSource()?.setData(geojson);
+      });
 
       if (option.type === 'overpass' && !option.overpass.ast) {
         addOverpassQueryHistory(option.overpass.query);

--- a/src/components/SearchBox/useGetOnSelected.ts
+++ b/src/components/SearchBox/useGetOnSelected.ts
@@ -8,31 +8,35 @@ import { geocoderOptionSelected, useInputValueState } from './options/geocoder';
 import { starOptionSelected } from './options/stars';
 import { useFeatureContext } from '../utils/FeatureContext';
 import { Setter } from '../../types';
+import { useCallback } from 'react';
 
 export const useGetOnSelected = (setOverpassLoading: Setter<boolean>) => {
   const { setFeature, setPreview } = useFeatureContext();
   const { bbox } = useMapStateContext();
   const { showToast } = useSnackbar();
 
-  return (_: never, option: Option) => {
-    setPreview(null); // it could be stuck from onHighlight
+  return useCallback(
+    (_: null, option: Option) => {
+      setPreview(null); // it could be stuck from onHighlight
 
-    switch (option.type) {
-      case 'star':
-        starOptionSelected(option);
-        break;
-      case 'overpass':
-      case 'preset':
-        overpassOptionSelected(option, setOverpassLoading, bbox, showToast);
-        break;
-      case 'geocoder':
-        geocoderOptionSelected(option, setFeature);
-        break;
-      case 'osm':
-        osmOptionSelected(option);
-        break;
-      case 'coords':
-        coordsOptionsSelected(option, setFeature);
-    }
-  };
+      switch (option.type) {
+        case 'star':
+          starOptionSelected(option);
+          break;
+        case 'overpass':
+        case 'preset':
+          overpassOptionSelected(option, setOverpassLoading, bbox, showToast);
+          break;
+        case 'geocoder':
+          geocoderOptionSelected(option, setFeature);
+          break;
+        case 'osm':
+          osmOptionSelected(option);
+          break;
+        case 'coords':
+          coordsOptionsSelected(option, setFeature);
+      }
+    },
+    [bbox, setFeature, setOverpassLoading, setPreview, showToast],
+  );
 };

--- a/src/components/SearchBox/useGetOptions.tsx
+++ b/src/components/SearchBox/useGetOptions.tsx
@@ -44,6 +44,27 @@ const getSearchOptions = async (stars: Star[], inputValue: string) => {
   return { restPresets, before };
 };
 
+export const getFirstOption = async (
+  query: string,
+  stars: Star[],
+  view: View,
+) => {
+  const options = getMatchedOptions(query, stars);
+  if (options && options.length > 0) {
+    return options[0];
+  }
+
+  const { before, restPresets } = await getSearchOptions(stars, query);
+  if (before && before.length > 0) {
+    return before[0];
+  }
+
+  const geocoderOptions = await fetchGeocoderOptions(query, view);
+  if (geocoderOptions && geocoderOptions.length > 0) {
+    return geocoderOptions[0];
+  }
+};
+
 export const useGetOptions = (inputValue: string) => {
   const { view } = useMapStateContext();
   const { stars } = useStarsContext();
@@ -67,7 +88,11 @@ export const useGetOptions = (inputValue: string) => {
         setOptions([...before, { type: 'loader' }]);
 
         await debounceGeocoderOrReject(400);
-        const geocoderOptions = await fetchGeocoderOptions(inputValue, view);
+        const geocoderOptions = await fetchGeocoderOptions(
+          inputValue,
+          view,
+          GEOCODER_ABORTABLE_QUEUE,
+        );
         if (geocoderOptions) {
           setOptions([...before, ...geocoderOptions, ...restPresets]);
         }

--- a/src/components/SearchBox/useHandleDirectQuery.tsx
+++ b/src/components/SearchBox/useHandleDirectQuery.tsx
@@ -1,0 +1,38 @@
+import { Option } from './types';
+import { useRouter } from 'next/router';
+import { Setter } from '../../types';
+import { useMapStateContext } from '../utils/MapStateContext';
+import { useEffect, useRef } from 'react';
+import { getFirstOption } from './useGetOptions';
+import { useStarsContext } from '../utils/StarsContext';
+
+export const useHandleDirectQuery = (
+  onSelected: (_: null, option: Option) => void,
+  setInputValue: Setter<string>,
+) => {
+  const { stars } = useStarsContext();
+  const { bbox, view } = useMapStateContext();
+  const lastQuery = useRef<string | undefined>();
+  const router = useRouter();
+  const query = router.query.qd;
+
+  useEffect(() => {
+    (async () => {
+      if (typeof query !== 'string' || !bbox) {
+        return;
+      }
+
+      if (lastQuery.current === query) {
+        return;
+      }
+
+      lastQuery.current = query;
+      setInputValue(query);
+
+      const foundOption = await getFirstOption(query, stars, view);
+      if (foundOption) {
+        onSelected(null, foundOption);
+      }
+    })();
+  }, [bbox, onSelected, query, setInputValue, stars, view]);
+};


### PR DESCRIPTION
Based on PR #988 by @amenk.

You can supply eg a query `?qd=London` and osmapp will open as if user typed this query and selected first result.

Sometimes it can be confusing, because Preset category is first matching result. But you can easily click the SearchBox and select the second result.

Note: photon geocoder is experiencing long loading times, maybe becuase the company got acquired recently.

TODO add opensearch.xml
TODO show spinner while loading the result