### PR TITLE
SearchBox: add spinner for `?qd=query`

### DIFF
--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -11,6 +11,7 @@ import { AutocompleteProps } from '@mui/material/Autocomplete/Autocomplete';
 import { Option } from './types';
 import { renderInputFactory } from './renderInputFactory';
 import { useHandleDirectQuery } from './useHandleDirectQuery';
+import { Setter } from '../../types';
 
 const AutocompleteConfigured = (
   props: AutocompleteProps<Option, false, true, true>,
@@ -29,19 +30,19 @@ const AutocompleteConfigured = (
 
 type AutocompleteInputProps = {
   autocompleteRef: React.MutableRefObject<undefined>;
-  setOverpassLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoading: Setter<boolean>;
 };
 
 export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   autocompleteRef,
-  setOverpassLoading,
+  setIsLoading,
 }) => {
   const { inputValue, setInputValue } = useInputValueState();
   const options = useGetOptions(inputValue);
   const onHighlight = useGetOnHighlight();
-  const onSelected = useGetOnSelected(setOverpassLoading);
+  const onSelected = useGetOnSelected(setIsLoading);
 
-  useHandleDirectQuery(onSelected, setInputValue);
+  useHandleDirectQuery(onSelected, setInputValue, setIsLoading);
 
   return (
     <AutocompleteConfigured

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -58,7 +58,7 @@ const SearchIconButton = styled(IconButton)`
   }
 `;
 
-const OverpassCircularProgress = styled(CircularProgress)`
+const LoadingSpinner = styled(CircularProgress)`
   padding: 10px;
 `;
 
@@ -77,7 +77,7 @@ const useOnClosePanel = () => {
 const SearchBoxInner = ({ withoutPanel }) => {
   const isMobileMode = useMobileMode();
   const { featureShown } = useFeatureContext();
-  const [overpassLoading, setOverpassLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const autocompleteRef = useRef();
   const onClosePanel = useOnClosePanel();
 
@@ -94,10 +94,10 @@ const SearchBoxInner = ({ withoutPanel }) => {
 
         <AutocompleteInput
           autocompleteRef={autocompleteRef}
-          setOverpassLoading={setOverpassLoading}
+          setIsLoading={setIsLoading}
         />
 
-        {overpassLoading && <OverpassCircularProgress />}
+        {isLoading && <LoadingSpinner />}
         {!isMobileMode && featureShown && (
           <ClosePanelButton onClick={onClosePanel} />
         )}

--- a/src/components/SearchBox/useHandleDirectQuery.tsx
+++ b/src/components/SearchBox/useHandleDirectQuery.tsx
@@ -37,5 +37,5 @@ export const useHandleDirectQuery = (
         onSelected(null, foundOption);
       }
     })();
-  }, [bbox, onSelected, query, setInputValue, stars, view]);
+  }, [bbox, onSelected, query, setInputValue, setIsLoading, stars, view]);
 };

--- a/src/components/SearchBox/useHandleDirectQuery.tsx
+++ b/src/components/SearchBox/useHandleDirectQuery.tsx
@@ -9,6 +9,7 @@ import { useStarsContext } from '../utils/StarsContext';
 export const useHandleDirectQuery = (
   onSelected: (_: null, option: Option) => void,
   setInputValue: Setter<string>,
+  setIsLoading: Setter<boolean>,
 ) => {
   const { stars } = useStarsContext();
   const { bbox, view } = useMapStateContext();
@@ -28,8 +29,10 @@ export const useHandleDirectQuery = (
 
       lastQuery.current = query;
       setInputValue(query);
+      setIsLoading(true);
 
       const foundOption = await getFirstOption(query, stars, view);
+      setIsLoading(false);
       if (foundOption) {
         onSelected(null, foundOption);
       }


### PR DESCRIPTION
Circular spinner while geocoder may be loading - the same spinner which runs for overpass when onSelected is called.