### PR TITLE
general: add Cache-control headers

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -164,7 +164,7 @@ MyApp.getInitialProps = async ({
     }
   }
 
-  ctx.res.setHeader(
+  ctx.res?.setHeader(
     'Cache-Control',
     'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -164,6 +164,11 @@ MyApp.getInitialProps = async ({
     }
   }
 
+  ctx.res.setHeader(
+    'Cache-Control',
+    'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
+  );
+
   const initialMapView = await getInitialMapView(ctx);
 
   return {

--- a/pages/api/climbing-tiles/stats.ts
+++ b/pages/api/climbing-tiles/stats.ts
@@ -7,6 +7,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const json = await getClimbingStats();
 
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    );
+
     res.status(200).setHeader('Content-Type', 'application/json').send(json);
   } catch (err) {
     console.error(err); // eslint-disable-line no-console

--- a/pages/api/climbing-tiles/tile.ts
+++ b/pages/api/climbing-tiles/tile.ts
@@ -14,6 +14,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     const geojson = await getClimbingTile(tileNumber);
 
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
+    );
+
     res.status(200).setHeader('Content-Type', 'application/json').send(geojson);
   } catch (err) {
     console.error(err); // eslint-disable-line no-console

--- a/pages/api/og-image.tsx
+++ b/pages/api/og-image.tsx
@@ -108,6 +108,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       }ms, fetchImage+renderSvg: ${t4 - t3}ms, svg2png: ${t5 - t4}ms`,
     );
 
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
+    );
+
     sendImageResponse(res, feature, png, PNG_TYPE);
     return;
   } catch (err) {


### PR DESCRIPTION
CDN will cache all SSR requests for 1 hour. Unfortunately this means, that user can click inside OsmAPP, then hit ctrl+R and receive older data. But 1 hour is not that painful.

Lets see if this dramatically lowers the number of SSR execution. We still have around 10k per day, which is better but lets see.

It would be cool to see which URLs are being served, and if this is caused by accessing one URL many times in one day, but this costs another 20€/monthly on vercel, which is too much for our small project. :)


// update: every feature unfortunately sends a set-cookie which prevents the caching. Hmm?