### PR TITLE
osmApi: change to .osc diff upload

### DIFF
--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -21,7 +21,7 @@ export type Members = Array<{
 }>;
 
 // internal type stored in the state
-type DataItem = {
+export type DataItem = {
   shortId: string;
   version: number | undefined; // undefined for new item
   tagsEntries: TagsEntries;

--- a/src/components/FeaturePanel/helpers/TestApiWarning.tsx
+++ b/src/components/FeaturePanel/helpers/TestApiWarning.tsx
@@ -10,7 +10,9 @@ export const TestApiWarning = () =>
         TEST API IN USE: {API_SERVER}
         <br />
         Clicking the map will not work.
-        <Link href="/relation/4305224335">Test relation</Link>
+        <Link href="/relation/4305224335">Test relation</Link>/
+        <Link href="/way/4307240838">way</Link>/
+        <Link href="/node/4352746388">node</Link>
       </Alert>
     </Box>
   );

--- a/src/services/osm/auth/__tests__/getDiffXml.test.ts
+++ b/src/services/osm/auth/__tests__/getDiffXml.test.ts
@@ -1,0 +1,176 @@
+import { DataItem } from '../../../../components/FeaturePanel/EditDialog/useEditItems';
+import { getDiffXml } from '../getDIffXml';
+
+const nodeNew: DataItem = {
+  shortId: 'n-1',
+  version: undefined,
+  tagsEntries: [['newNode', 'yes']],
+  members: undefined,
+  nodes: undefined,
+  nodeLonLat: [14, 50],
+  toBeDeleted: false,
+};
+
+const nodeChange: DataItem = {
+  shortId: 'n2222',
+  version: 2,
+  tagsEntries: [['addedTags', 'yes']],
+  members: undefined,
+  nodes: undefined,
+  nodeLonLat: [14, 50],
+  toBeDeleted: false,
+};
+
+const nodeToDelete: DataItem = {
+  shortId: 'n9999',
+  version: 9,
+  tagsEntries: [],
+  members: undefined,
+  nodes: undefined,
+
+  nodeLonLat: [14, 50],
+  toBeDeleted: true,
+};
+
+const nodesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<osmChange generator="OsmAPP" version="0.6">
+  <create>
+    <node id="-1" lon="14" lat="50" version="0" changeset="123">
+      <tag k="newNode" v="yes"/>
+    </node>
+  </create>
+  <modify>
+    <node id="2222" lon="14" lat="50" version="2" changeset="123">
+      <tag k="addedTags" v="yes"/>
+    </node>
+  </modify>
+  <delete if-unused="true">
+    <node id="9999" lon="14" lat="50" version="9" changeset="123"/>
+  </delete>
+</osmChange>`;
+
+test('should convert nodes', () => {
+  expect(getDiffXml('123', [nodeNew, nodeChange, nodeToDelete])).toEqual(
+    nodesXml,
+  );
+});
+
+const wayNew: DataItem = {
+  shortId: 'w-1',
+  version: undefined,
+  tagsEntries: [['newWay', 'yes']],
+  members: undefined,
+  nodes: [4001, 4002, 4003],
+  nodeLonLat: undefined,
+  toBeDeleted: false,
+};
+
+const wayChange: DataItem = {
+  shortId: 'w2222',
+  version: 2,
+  tagsEntries: [['addedTags', 'yes']],
+  members: undefined,
+  nodes: [4001, 4002, 4003],
+  nodeLonLat: undefined,
+  toBeDeleted: false,
+};
+
+const wayToDelete: DataItem = {
+  shortId: 'w9999',
+  version: 9,
+  tagsEntries: [],
+  members: undefined,
+  nodes: [4001, 4002, 4003],
+  nodeLonLat: undefined,
+  toBeDeleted: true,
+};
+
+const waysXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<osmChange generator="OsmAPP" version="0.6">
+  <create>
+    <way id="-1" version="0" changeset="123">
+      <tag k="newWay" v="yes"/>
+      <nd ref="4001"/>
+      <nd ref="4002"/>
+      <nd ref="4003"/>
+    </way>
+  </create>
+  <modify>
+    <way id="2222" version="2" changeset="123">
+      <tag k="addedTags" v="yes"/>
+      <nd ref="4001"/>
+      <nd ref="4002"/>
+      <nd ref="4003"/>
+    </way>
+  </modify>
+  <delete if-unused="true">
+    <way id="9999" version="9" changeset="123">
+      <nd ref="4001"/>
+      <nd ref="4002"/>
+      <nd ref="4003"/>
+    </way>
+  </delete>
+</osmChange>`;
+
+test('should convert ways', () => {
+  expect(getDiffXml('123', [wayNew, wayChange, wayToDelete])).toEqual(waysXml);
+});
+
+const relationNew: DataItem = {
+  shortId: 'r-1',
+  version: undefined,
+  tagsEntries: [['new', 'yes']],
+  members: [
+    { shortId: 'n-1', role: 'role', label: 'x' },
+    { shortId: 'w-2', role: 'role', label: 'y' },
+  ],
+  nodes: undefined,
+  nodeLonLat: undefined,
+  toBeDeleted: false,
+};
+
+const relationChange: DataItem = {
+  shortId: 'r22',
+  version: 2,
+  tagsEntries: [['changed', 'yes']],
+  members: [{ shortId: 'n-1', role: 'role', label: 'x' }],
+  nodes: undefined,
+  nodeLonLat: undefined,
+  toBeDeleted: false,
+};
+
+const relationToDelete: DataItem = {
+  shortId: 'r99',
+  version: 9,
+  tagsEntries: [],
+  members: [],
+  nodes: undefined,
+  nodeLonLat: undefined,
+  toBeDeleted: true,
+};
+
+const relationsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<osmChange generator="OsmAPP" version="0.6">
+  <create>
+    <relation id="-1" version="0" changeset="123">
+      <tag k="new" v="yes"/>
+      <member type="node" ref="-1" role="role"/>
+      <member type="way" ref="-2" role="role"/>
+    </relation>
+  </create>
+  <modify>
+    <relation id="22" version="2" changeset="123">
+      <tag k="changed" v="yes"/>
+      <member type="node" ref="-1" role="role"/>
+    </relation>
+  </modify>
+  <delete if-unused="true">
+    <relation id="99" version="9" changeset="123"/>
+  </delete>
+</osmChange>`;
+
+test('should convert relations', () => {
+  expect(
+    getDiffXml('123', [relationNew, relationChange, relationToDelete]),
+  ).toEqual(relationsXml);
+});

--- a/src/services/osm/auth/__tests__/getFirstId.test.ts
+++ b/src/services/osm/auth/__tests__/getFirstId.test.ts
@@ -1,0 +1,50 @@
+import { EditDataItem } from '../../../../components/FeaturePanel/EditDialog/useEditItems';
+import { parseToXmljs } from '../xmlHelpers';
+import { DiffResultXmljs } from '../xmlTypes';
+import { getFirstId } from '../../getFirstId';
+
+const diffResponse = `<?xml version="1.0" encoding="UTF-8"?>
+      <diffResult version="0.6" generator="openstreetmap-cgimap 2.0.1.2504041438 (3164272 faffy.openstreetmap.org)">
+        <node old_id="-6" new_id="4359364811" new_version="1"/>
+        <way old_id="-21" new_id="3333331" new_version="1"/>
+        <way old_id="-22" new_id="3333332" new_version="1"/>
+      </diffResult>
+    `;
+
+describe('getFirstId', () => {
+  it('should return mapped ID for new node', async () => {
+    const changes: EditDataItem[] = [{ shortId: 'n-6' } as EditDataItem];
+
+    const xml = await parseToXmljs<DiffResultXmljs>(diffResponse);
+    const osmId = getFirstId(xml, changes);
+
+    expect(osmId).toEqual({
+      type: 'node',
+      id: 4359364811,
+    });
+  });
+
+  it('should return mapped ID for new way', async () => {
+    const changes: EditDataItem[] = [{ shortId: 'w-22' } as EditDataItem];
+
+    const xml = await parseToXmljs<DiffResultXmljs>(diffResponse);
+    const osmId = getFirstId(xml, changes);
+
+    expect(osmId).toEqual({
+      type: 'way',
+      id: 3333332,
+    });
+  });
+
+  it('should return the ID when first ID is positive', async () => {
+    const changes: EditDataItem[] = [{ shortId: 'r23456' } as EditDataItem];
+
+    const xml = await parseToXmljs<DiffResultXmljs>(diffResponse);
+    const osmId = getFirstId(xml, changes);
+
+    expect(osmId).toEqual({
+      type: 'relation',
+      id: 23456,
+    });
+  });
+});

--- a/src/services/osm/auth/api.ts
+++ b/src/services/osm/auth/api.ts
@@ -2,6 +2,7 @@ import { OsmId } from '../../types';
 import { authFetch } from './authFetch';
 import { getUrlOsmId } from '../../helpers';
 import { parseToXmljs } from './xmlHelpers';
+import { DiffResultXmljs } from './xmlTypes';
 import { stringifyDomXml } from './stringifyDomXml';
 
 export const putChangeset = (content: string) =>
@@ -63,6 +64,16 @@ export const createRelationItem = (content: string) =>
     headers: { 'Content-Type': 'text/xml; charset=utf-8' },
     content,
   });
+
+export const uploadDiff = async (changesetId: string, content: string) => {
+  const result = await authFetch<Node>({
+    method: 'POST',
+    path: `/api/0.6/changeset/${changesetId}/upload`,
+    headers: { 'Content-Type': 'text/xml; charset=utf-8' },
+    content,
+  });
+  return await parseToXmljs<DiffResultXmljs>(stringifyDomXml(result));
+};
 
 export const putOrDeleteItem = async (
   toBeDeleted: boolean,

--- a/src/services/osm/auth/getDIffXml.ts
+++ b/src/services/osm/auth/getDIffXml.ts
@@ -1,0 +1,98 @@
+import { DataItem } from '../../../components/FeaturePanel/EditDialog/useEditItems';
+import { getApiId } from '../../helpers';
+import {
+  DiffDocXmljs,
+  NodeItemXml,
+  RelationItemXml,
+  WayItemXml,
+} from './xmlTypes';
+import { xmljsBuildOsmChange } from './xmlHelpers';
+
+const isNode = ({ shortId }: DataItem) => shortId.startsWith('n');
+const isWay = ({ shortId }: DataItem) => shortId.startsWith('w');
+const isRelation = ({ shortId }: DataItem) => shortId.startsWith('r');
+
+const TAG = ([k, v]: [string, string]) => k && v;
+
+const nodeItemToXml = (change: DataItem, changeset: string): NodeItemXml => {
+  const { shortId, version = 0, tagsEntries, nodeLonLat } = change;
+  const { id } = getApiId(shortId);
+  const [lon, lat] = nodeLonLat;
+
+  return {
+    $: { id, lon, lat, version, changeset },
+    tag: tagsEntries.filter(TAG).map(([k, v]) => ({ $: { k, v } })),
+  };
+};
+
+const wayItemToXml = (change: DataItem, changeset: string): WayItemXml => {
+  const { shortId, version = 0, tagsEntries, nodes } = change;
+  const { id } = getApiId(shortId);
+
+  if (!nodes) {
+    throw new Error(`No nodes found for item: way/${id}`);
+  }
+
+  return {
+    $: { id, version, changeset },
+    tag: tagsEntries.filter(TAG).map(([k, v]) => ({ $: { k, v } })),
+    nd: nodes.map((ref) => ({ $: { ref } })),
+  };
+};
+
+const relationItemToXml = (
+  change: DataItem,
+  changeset: string,
+): RelationItemXml => {
+  const { shortId, version = 0, tagsEntries, members } = change;
+  const { id } = getApiId(shortId);
+
+  return {
+    $: { id, version, changeset },
+    tag: tagsEntries.filter(TAG).map(([k, v]) => ({ $: { k, v } })),
+    member: members.map(({ shortId, role }) => {
+      const { type, id } = getApiId(shortId);
+      return { $: { type, ref: id, role } };
+    }),
+  };
+};
+
+const isNew = ({ shortId }: DataItem) => shortId.includes('-');
+const isDeleted = ({ toBeDeleted }: DataItem) => toBeDeleted;
+const condition = {
+  create: isNew,
+  delete: isDeleted,
+  modify: (item: DataItem) => !isNew(item) && !isDeleted(item),
+};
+
+const getXmlByAction = (
+  changes: DataItem[],
+  action: 'create' | 'modify' | 'delete',
+  changesetId: string,
+) => {
+  const items = changes.filter(condition[action]);
+  return {
+    node: items.filter(isNode).map((node) => nodeItemToXml(node, changesetId)),
+    way: items.filter(isWay).map((way) => wayItemToXml(way, changesetId)),
+    relation: items
+      .filter(isRelation)
+      .map((relation) => relationItemToXml(relation, changesetId)),
+  };
+};
+
+export const getDiffXml = (
+  changesetId: string,
+  changes: DataItem[],
+): string => {
+  const xml: DiffDocXmljs = {
+    $: { generator: 'OsmAPP', version: '0.6' },
+    create: getXmlByAction(changes, 'create', changesetId),
+    modify: getXmlByAction(changes, 'modify', changesetId),
+    delete: {
+      $: { 'if-unused': 'true' },
+      ...getXmlByAction(changes, 'delete', changesetId),
+    },
+  };
+
+  return xmljsBuildOsmChange(xml);
+};

--- a/src/services/osm/auth/xmlHelpers.ts
+++ b/src/services/osm/auth/xmlHelpers.ts
@@ -1,5 +1,10 @@
 import * as xml2js from 'isomorphic-xml2js';
-import { DiffResultXmljs, MultiDocXmljs, SingleDocXmljs } from './xmlTypes';
+import {
+  DiffDocXmljs,
+  DiffResultXmljs,
+  MultiDocXmljs,
+  SingleDocXmljs,
+} from './xmlTypes';
 
 // eventhough it is called "xml2js" we call it "xmljs" for brevity
 // don't confuse with Browser DOM XML (stringifyDomXml)
@@ -26,10 +31,16 @@ export const parseToXmljs = <
   });
 };
 
-const buildXml = (xml: SingleDocXmljs | MultiDocXmljs, rootName: string) => {
+const buildXml = (
+  xml: SingleDocXmljs | MultiDocXmljs | DiffDocXmljs,
+  rootName: string,
+) => {
   const builder = new xml2js.Builder({ rootName });
   return builder.buildObject(xml);
 };
 
 export const xmljsBuildOsm = (xml: SingleDocXmljs | MultiDocXmljs) =>
   buildXml(xml, 'osm');
+
+export const xmljsBuildOsmChange = (xml: DiffDocXmljs) =>
+  buildXml(xml, 'osmChange');

--- a/src/services/osm/auth/xmlTypes.ts
+++ b/src/services/osm/auth/xmlTypes.ts
@@ -1,3 +1,44 @@
+export type NodeItemXml = {
+  $: {
+    id: number;
+    lon: number;
+    lat: number;
+    version?: number;
+    changeset: string;
+  };
+  tag: { $: { k: string; v: string } }[];
+};
+export type WayItemXml = {
+  $: { id: number; version: number; changeset: string };
+  tag: { $: { k: string; v: string } }[];
+  nd: { $: { ref: number } }[];
+};
+export type RelationItemXml = {
+  $: { id: number; version: number; changeset: string };
+  tag: { $: { k: string; v: string } }[];
+  member: { $: { type: string; ref: number; role: string } }[];
+};
+
+export type DiffDocXmljs = {
+  $: { version: '0.6'; generator: 'OsmAPP' };
+  create: {
+    node: NodeItemXml[];
+    way: WayItemXml[];
+    relation: RelationItemXml[];
+  };
+  modify: {
+    node: NodeItemXml[];
+    way: WayItemXml[];
+    relation: RelationItemXml[];
+  };
+  delete: {
+    $: { 'if-unused': 'true' };
+    node: NodeItemXml[];
+    way: WayItemXml[];
+    relation: RelationItemXml[];
+  };
+};
+
 type OsmItemXmljs = {
   tag: { $: { k: string; v: string } }[];
   member?: { $: { type: string; ref: string; role: string } }[];

--- a/src/services/osm/getFirstId.ts
+++ b/src/services/osm/getFirstId.ts
@@ -1,0 +1,22 @@
+import { DiffResultXmljs } from './auth/xmlTypes';
+import { EditDataItem } from '../../components/FeaturePanel/EditDialog/useEditItems';
+import { getApiId } from '../helpers';
+
+export const getFirstId = (
+  result: DiffResultXmljs,
+  changes: EditDataItem[],
+) => {
+  const firstId = getApiId(changes[0].shortId);
+
+  if (firstId.id < 0) {
+    const idMapping = result[firstId.type].find(
+      ({ $ }) => `${firstId.id}` === $.old_id,
+    );
+    return {
+      type: firstId.type,
+      id: parseInt(idMapping.$.new_id, 10),
+    };
+  }
+
+  return firstId;
+};

--- a/src/services/osm/osmApiAuth.ts
+++ b/src/services/osm/osmApiAuth.ts
@@ -1,18 +1,7 @@
+// TODO move this file to ./auth folder
 import escape from 'lodash/escape';
-import {
-  Feature,
-  FeatureTags,
-  LonLat,
-  OsmId,
-  Position,
-  SuccessInfo,
-} from '../types';
-import {
-  getApiId,
-  getFullOsmappLink,
-  getShortId,
-  getUrlOsmId,
-} from '../helpers';
+import { Feature, FeatureTags, LonLat, OsmId, SuccessInfo } from '../types';
+import { getApiId, getFullOsmappLink, getUrlOsmId } from '../helpers';
 import { join } from '../../utils';
 import { clearFetchCache } from '../fetchCache';
 import { getLabel } from '../../helpers/featureLabel';
@@ -21,10 +10,11 @@ import {
   Members,
 } from '../../components/FeaturePanel/EditDialog/useEditItems';
 import { OSM_WEBSITE } from './consts';
+import { getDiffXml } from './auth/getDIffXml';
 import { SingleDocXmljs } from './auth/xmlTypes';
-import { parseToXmljs, xmljsBuildOsm } from './auth/xmlHelpers';
+import { xmljsBuildOsm } from './auth/xmlHelpers';
 import * as api from './auth/api';
-import zipObject from 'lodash/zipObject';
+import { getFirstId } from './getFirstId';
 
 export const getChangesetXml = ({ changesetComment, feature }) => {
   const tags = [
@@ -90,83 +80,6 @@ export const updateItemXml = (
   return xmljsBuildOsm(item);
 };
 
-const checkVersionUnchanged = (
-  freshItem: SingleDocXmljs,
-  apiId: OsmId,
-  ourVersion: number,
-) => {
-  const freshVersion = parseInt(freshItem[apiId.type][0].$.version, 10);
-  if (ourVersion !== freshVersion) {
-    throw new Error(
-      `The ${getShortId(apiId)} has been updated, please reload.`,
-    );
-  }
-};
-
-const getNewNodeXml = async (
-  changesetId: string,
-  [lon, lat]: Position,
-  newTags: FeatureTags,
-) => {
-  const xml = await parseToXmljs('<osm><node lon="x"/></osm>');
-  xml.node[0].$.changeset = changesetId;
-  xml.node[0].$.lon = `${lon}`;
-  xml.node[0].$.lat = `${lat}`;
-  xml.node[0].tag = getXmlTags(newTags);
-  return xmljsBuildOsm(xml);
-};
-
-const getNewRelationXml = async (
-  changesetId: string,
-  newTags: FeatureTags,
-  members: Members,
-) => {
-  const xml = await parseToXmljs('<osm><relation visible="true" /></osm>');
-  xml.relation[0].$.changeset = changesetId;
-  xml.relation[0].tag = getXmlTags(newTags);
-  xml.relation[0].member = getXmlMembers(members);
-  return xmljsBuildOsm(xml);
-};
-
-const saveChange = async (
-  changesetId: string,
-  { shortId, version, tags, toBeDeleted, nodeLonLat, members }: EditDataItem,
-): Promise<OsmId> => {
-  // TODO don't save changes if no change detected
-  let apiId = getApiId(shortId);
-  if (apiId.id < 0) {
-    if (apiId.type === 'way') {
-      throw new Error('We can only add new nodes and relations so far.');
-    }
-    if (apiId.type === 'node') {
-      const content = await getNewNodeXml(changesetId, nodeLonLat, tags);
-      const newNodeId = await api.createNodeItem(content);
-      return { type: 'node', id: parseInt(newNodeId, 10) };
-    }
-    if (apiId.type === 'relation') {
-      const content = await getNewRelationXml(changesetId, tags, members);
-      const newRelationId = await api.createRelationItem(content);
-      return { type: 'relation', id: parseInt(newRelationId, 10) };
-    }
-  }
-
-  const freshItem = await api.getItem(apiId);
-  checkVersionUnchanged(freshItem, apiId, version);
-
-  // TODO document undelete feature - the flow is kinda unclear
-  const newItem = updateItemXml(
-    freshItem,
-    apiId,
-    changesetId,
-    tags,
-    toBeDeleted,
-    members,
-    nodeLonLat,
-  );
-  await api.putOrDeleteItem(toBeDeleted, apiId, newItem);
-  return apiId;
-};
-
 const getCommentMulti = (
   original: Feature,
   comment: string,
@@ -201,48 +114,11 @@ export const saveChanges = async (
   const changesetXml = getChangesetXml({ changesetComment, feature: original });
   const changesetId = await api.putChangeset(changesetXml);
 
-  // TODO refactor below
-  // or even better use osmChange xml https://wiki.openstreetmap.org/wiki/API_v0.6#Diff_upload:_POST_/api/0.6/changeset/#id/upload
-  const changesNodes = changes.filter(({ shortId }) => shortId[0] === 'n');
-  const savedNodesIds = await Promise.all(
-    changesNodes.map((change) => saveChange(changesetId, change)),
-  );
-  const nodeShortIds = changesNodes.map(({ shortId }) => shortId);
-  const savedNodeIdsMap = zipObject(nodeShortIds, savedNodesIds);
-
-  const changesWays = changes.filter(({ shortId }) => shortId[0] === 'w');
-  const savedWaysIds = await Promise.all(
-    changesWays.map((change) => saveChange(changesetId, change)),
-  );
-
-  const changesRelations = changes.filter(({ shortId }) => shortId[0] === 'r');
-
-  const changesRelationsWithNewNodeIds = changesRelations.map((change) => {
-    return {
-      ...change,
-      members: change.members?.map<Members[0]>((member) => {
-        const shortId = member.shortId;
-        const apiId = getApiId(shortId);
-        if (apiId.type === 'node' && apiId.id < 0) {
-          const newNodeId = savedNodeIdsMap[shortId];
-          return { ...member, shortId: getShortId(newNodeId) };
-        }
-
-        return member;
-      }),
-    };
-  });
-
-  const savedRelationsIds = await Promise.all(
-    changesRelationsWithNewNodeIds.map((change) =>
-      saveChange(changesetId, change),
-    ),
-  );
+  const diffXml = getDiffXml(changesetId, changes);
+  const diffResult = await api.uploadDiff(changesetId, diffXml);
+  const firstId = getFirstId(diffResult, changes);
 
   await api.putChangesetClose(changesetId);
-
-  const ids = [...savedNodesIds, ...savedWaysIds, ...savedRelationsIds];
-  const redirectId = original.point ? ids[0] : original.osmMeta;
 
   // TODO invalidate all changed also in server (?)
   clearFetchCache();
@@ -251,6 +127,6 @@ export const saveChanges = async (
     type: 'edit',
     text: changesetComment,
     url: `${OSM_WEBSITE}/changeset/${changesetId}`,
-    redirect: `/${getUrlOsmId(redirectId)}`,
+    redirect: `/${getUrlOsmId(firstId)}`,
   };
 };


### PR DESCRIPTION
This updates the way OsmAPP saves changes to OSM. Until now, we saved each node/way/relation in separate request as GET/PUT/POST. From this PR we send the osmChange diff (.xml.osc). 

This makes possible to delete old node and convert it to relation - https://github.com/zbycz/osmapp/pull/954. In this process we want to change the "deleted node id" in all parent relations to the new relation id instead. But without diff we were updating the parent relation refs to a not-yet-created relation. 

In future we would also be able to offer download of OSC file to edit it in different OSM editor.