### PR TITLE
Revert "general: add Cache-control headers (#1004)"

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -164,11 +164,6 @@ MyApp.getInitialProps = async ({
     }
   }
 
-  ctx.res?.setHeader(
-    'Cache-Control',
-    'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
-  );
-
   const initialMapView = await getInitialMapView(ctx);
 
   return {

--- a/pages/api/climbing-tiles/stats.ts
+++ b/pages/api/climbing-tiles/stats.ts
@@ -7,11 +7,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const json = await getClimbingStats();
 
-    res.setHeader(
-      'Cache-Control',
-      'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
-    );
-
     res.status(200).setHeader('Content-Type', 'application/json').send(json);
   } catch (err) {
     console.error(err); // eslint-disable-line no-console

--- a/pages/api/climbing-tiles/tile.ts
+++ b/pages/api/climbing-tiles/tile.ts
@@ -14,11 +14,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     const geojson = await getClimbingTile(tileNumber);
 
-    res.setHeader(
-      'Cache-Control',
-      'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
-    );
-
     res.status(200).setHeader('Content-Type', 'application/json').send(geojson);
   } catch (err) {
     console.error(err); // eslint-disable-line no-console

--- a/pages/api/og-image.tsx
+++ b/pages/api/og-image.tsx
@@ -108,11 +108,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       }ms, fetchImage+renderSvg: ${t4 - t3}ms, svg2png: ${t5 - t4}ms`,
     );
 
-    res.setHeader(
-      'Cache-Control',
-      'public, max-age=600, s-maxage=3600, stale-while-revalidate=86400',
-    );
-
     sendImageResponse(res, feature, png, PNG_TYPE);
     return;
   } catch (err) {


### PR DESCRIPTION
No improvement in number of exections. 
It doesnt work much thanks to:
- pages are using set-cookie = no CDN cache
- climbing-tiles sets CORS based on origin = wrong CDN cache
