### PR TITLE
EditDialog: Add simple validation for upload photo

### DIFF
--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -184,6 +184,7 @@ export default {
   'editdialog.add_major_tag': 'Přidat',
   'editdialog.upload_photo': 'Nahrát fotku',
   'editdialog.upload_photo_tooltip': 'Po nahrání fotky na Wikimedia Commons, vložit její název do vstupního pole. Např. File:Crag photo example.jpg',
+  'editdialog.upload_photo_filename_error': 'Neplatný název souboru na Wikimedia Commons. Měl by vypadat následovně: File:Photo example.jpg',
   'editdialog.location_checkbox': 'Zadat novou polohu',
   'editdialog.location_placeholder': 'např. naproti přes ulici',
   'editdialog.location_editor_to_be_added': 'Polohu zde zatím upravit nelze, můžete to provést třeba v <a href="__link__">editoru iD</a>.',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -222,7 +222,9 @@ export default {
   'editdialog.anonymousMessage': 'An <b>anonymous</b> note will be added to the map. If you log in to OpenStreetMap, your changes will be immediate.',
   'editdialog.add_major_tag': 'Add',
   'editdialog.upload_photo': 'Upload photo',
-  'editdialog.upload_photo_tooltip': 'After uploading photo to Wikimedia Common, paste its name to the input field. E.g. File:Crag photo example.jpg',
+  'editdialog.upload_photo_tooltip':
+    'After uploading photo to Wikimedia Commons, paste its name to the input field. For example: File:Photo example.jpg',
+  'editdialog.upload_photo_filename_error': 'Invalid Wikimedia Commons filename. It should look like this: File:Photo example.jpg',
   'editdialog.location_checkbox': 'New location',
   'editdialog.location_placeholder': 'eg. across the street',
   'editdialog.location_editor_to_be_added': 'The position cannot be edited here yet, you can do so in the <a href="__link__">iD editor</a>.',


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<img width="1004" alt="Screenshot 2025-05-01 at 6 21 45" src="https://github.com/user-attachments/assets/ccdb2a11-1e2a-4725-a39f-4f0d1adf46e9" />

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
