### PR TITLE
Images: No duplicate wikimedia images

### DIFF
--- a/src/components/FeaturePanel/FeatureImages/Image/InfoButton.tsx
+++ b/src/components/FeaturePanel/FeatureImages/Image/InfoButton.tsx
@@ -43,7 +43,7 @@ export const InfoButton = ({ image }: { image: ImageType }) => (
         <>
           <TooltipContent image={image} />
           {image.sameUrlResolvedAlsoFrom?.map((item) => (
-            <Box key={item.imageUrl} mt={1}>
+            <Box key={item.link} mt={1}>
               <TooltipContent image={item} />
             </Box>
           ))}

--- a/src/components/FeaturePanel/FeatureImages/useLoadImages.tsx
+++ b/src/components/FeaturePanel/FeatureImages/useLoadImages.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+  getImageDefId,
   getInstantImage,
   ImageType,
 } from '../../../services/images/getImageDefs';
@@ -7,8 +8,76 @@ import { not, publishDbgObject } from '../../../utils';
 import { getImageFromApi } from '../../../services/images/getImageFromApi';
 import { useFeatureContext } from '../../utils/FeatureContext';
 import { ImageDef, isInstant } from '../../../services/types';
+import uniqBy from 'lodash/uniqBy';
 
-export type ImagesType = { def: ImageDef; image: ImageType }[];
+type ImageWithDef = { def: ImageDef; image: ImageType };
+export type ImagesType = ImageWithDef[];
+
+const betterWikimediaImg = (imageA: ImageWithDef, imageB: ImageWithDef) => {
+  const imageAUrl = imageA.image.imageUrl;
+  const imageBUrl = imageB.image.imageUrl;
+
+  const start = 'https://upload.wikimedia.org/';
+  if (!(imageAUrl.startsWith(start) && imageBUrl.startsWith(start))) {
+    return null;
+  }
+
+  const partsA = imageAUrl.split('/');
+  const partsB = imageBUrl.split('/');
+
+  const startA = partsA.slice(0, -1).join('/');
+  const startB = partsB.slice(0, -1).join('/');
+
+  const endA = partsA.at(-1);
+  const endB = partsB.at(-1);
+
+  const endAMatch = endA.match(/^\d+px-/)?.[0];
+  const endBMatch = endB.match(/^\d+px-/)?.[0];
+
+  if (startA !== startB || !endAMatch || !endBMatch) {
+    return false;
+  }
+  const isIdentical =
+    endA.slice(endAMatch.length) === endB.slice(endBMatch.length);
+  if (!isIdentical) {
+    return false;
+  }
+
+  const pxA = parseInt(endA.match(/^\d+/)[0]);
+  const pxB = parseInt(endB.match(/^\d+/)[0]);
+
+  const preferred = pxA >= pxB ? imageA : imageB;
+  const unpreferred = !(pxA >= pxB) ? imageA : imageB;
+
+  return { preferred, unpreferred };
+};
+
+const mergeTwoImages = (
+  imageA: ImageWithDef,
+  imageB: ImageWithDef,
+): ImageWithDef | null => {
+  const imageAUrl = imageA.image.imageUrl;
+  const imageBUrl = imageB.image.imageUrl;
+
+  const mergingData =
+    imageAUrl === imageBUrl
+      ? { preferred: imageA, unpreferred: imageB }
+      : betterWikimediaImg(imageA, imageB);
+
+  if (!mergingData) {
+    return null;
+  }
+
+  const { preferred, unpreferred } = mergingData;
+  const newImage = { ...preferred };
+
+  newImage.image.sameUrlResolvedAlsoFrom = uniqBy(
+    [...(newImage.image.sameUrlResolvedAlsoFrom ?? []), unpreferred.image],
+    ({ link }) => link,
+  );
+
+  return newImage;
+};
 
 export const mergeResultFn =
   (def: ImageDef, image: ImageType, defs: ImageDef[]) =>
@@ -17,20 +86,20 @@ export const mergeResultFn =
       return prevImages;
     }
 
-    const found = prevImages.find(
-      (item) => item.image?.imageUrl === image.imageUrl,
+    const defIds = defs.map(getImageDefId);
+
+    const mergedUnsorted = prevImages.map(
+      (item) => mergeTwoImages(item, { image, def }) ?? item,
     );
-    if (found) {
-      (found.image.sameUrlResolvedAlsoFrom ??= []).push(image);
-      return [...prevImages];
+    if (!prevImages.some((item) => mergeTwoImages(item, { image, def }))) {
+      mergedUnsorted.push({ image, def });
     }
 
-    const sorted = [...prevImages, { def, image }].sort((a, b) => {
-      const aIndex = defs.findIndex((item) => item === a.def);
-      const bIndex = defs.findIndex((item) => item === b.def);
+    return mergedUnsorted.sort((a, b) => {
+      const aIndex = defIds.indexOf(getImageDefId(a.def));
+      const bIndex = defIds.indexOf(getImageDefId(b.def));
       return aIndex - bIndex;
     });
-    return sorted;
   };
 
 const getInitialState = (defs: ImageDef[]) =>

--- a/src/components/Map/MapFooter/AttributionLinks.tsx
+++ b/src/components/Map/MapFooter/AttributionLinks.tsx
@@ -4,7 +4,6 @@ import uniq from 'lodash/uniq';
 import { Layer, useMapStateContext, View } from '../../utils/MapStateContext';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { Translation } from '../../../services/intl';
-import { usePersistedState } from '../../utils/usePersistedState';
 
 export const Attribution = ({ label, link, title }) => (
   <>


### PR DESCRIPTION
### Description

Previously we filtered out duplicate images with the exact same url.
But it is possible that the wikimedia and wikipedia image show the same image but with a different resolution (e.g. 500 and 410px). 
This pr now also filters out such duplicates and only shows the image with the higher resolution

### Example links


[Frankfurt Central Station](https://osmapp-git-fork-dlurak-wikimedia-duplicates-osm-app-team.vercel.app/node/205364328)