### PR TITLE
ShareDialog: Open external maps with appropiate layer

### DIFF
--- a/src/components/FeaturePanel/QuickActions/ShareDialog/items.ts
+++ b/src/components/FeaturePanel/QuickActions/ShareDialog/items.ts
@@ -29,19 +29,23 @@ type ExternalMapLink = {
   image?: string;
 };
 
+type ItemArgs = {
+  osmQuery: string;
+  appleMaps: string;
+  idEditor: string;
+  position: PositionBoth;
+  zoomInt: number;
+  isSateliteActive: boolean;
+};
+
 export const items = ({
   osmQuery,
   appleMaps,
   idEditor,
   position: [lon, lat],
   zoomInt,
-}: {
-  osmQuery: string;
-  appleMaps: string;
-  idEditor: string;
-  position: PositionBoth;
-  zoomInt: number;
-}): ExternalMapLink[] => [
+  isSateliteActive,
+}: ItemArgs): ExternalMapLink[] => [
   {
     label: 'OpenStreetMap.org',
     href: `https://openstreetmap.org/${osmQuery}`,
@@ -60,7 +64,13 @@ export const items = ({
     : []),
   {
     label: 'Google Maps',
-    href: `https://google.com/maps/search/${lat}%C2%B0%20${lon}%C2%B0/@${lat},${lon},${zoomInt}z`,
+    // https://developers.google.com/maps/documentation/urls/get-started#map-action
+    href:
+      `https://www.google.com/maps/@?api=1` +
+      '&map_action=map' +
+      `&center=${lat},${lon}` +
+      `&zoom=${zoomInt}` +
+      `&basemap=${isSateliteActive ? 'satellite' : 'roadmap'}`,
     image:
       'https://upload.wikimedia.org/wikipedia/commons/a/aa/Google_Maps_icon_%282020%29.svg',
   },

--- a/src/components/FeaturePanel/QuickActions/ShareDialog/useGetItems.ts
+++ b/src/components/FeaturePanel/QuickActions/ShareDialog/useGetItems.ts
@@ -8,7 +8,8 @@ import { imageAttributions, items } from './items';
 const MAPLIBREGL_ZOOM_DIFFERENCE = 1;
 
 export const useGetItems = () => {
-  const { view, activeLayers } = useMapStateContext();
+  const { view, allActiveLayers } = useMapStateContext();
+
   const { feature } = useFeatureContext();
   const { center, roundedCenter = undefined } = feature;
   const position = roundedCenter ?? center;
@@ -25,6 +26,8 @@ export const useGetItems = () => {
   const zoom = parseFloat(ourZoom) + MAPLIBREGL_ZOOM_DIFFERENCE;
   const zoomInt = Math.round(zoom);
 
+  const isSateliteActive = allActiveLayers.some((layer) => layer.isSatelite);
+
   const osmQuery = feature?.osmMeta?.id
     ? `${feature.osmMeta.type}/${feature.osmMeta.id}`
     : `?mlat=${lat}&mlon=${lon}&zoom=${zoomInt}`;
@@ -35,7 +38,8 @@ export const useGetItems = () => {
       position,
       osmQuery,
       zoomInt,
-      appleMaps: getAppleMapsLink(feature, position, activeLayers),
+      isSateliteActive,
+      appleMaps: getAppleMapsLink(feature, position, isSateliteActive),
       idEditor: getIdEditorLink(feature, view), // TODO coordsFeature has random id which gets forwarded LOL
     }),
   };

--- a/src/components/FeaturePanel/helpers/externalLinks.ts
+++ b/src/components/FeaturePanel/helpers/externalLinks.ts
@@ -1,6 +1,6 @@
 import { getLabel } from '../../../helpers/featureLabel';
 import { Feature, PositionBoth } from '../../../services/types';
-import { View } from '../../utils/MapStateContext';
+import { Layer, View } from '../../utils/MapStateContext';
 import { OSM_WEBSITE } from '../../../services/osm/consts';
 
 export const getIdEditorLink = (feature: Feature, view?: View) => {
@@ -14,12 +14,9 @@ export const getIdEditorLink = (feature: Feature, view?: View) => {
 export const getAppleMapsLink = (
   feature: Feature,
   position: PositionBoth,
-  activeLayers: string[],
+  isSateliteActive: boolean,
 ) => {
-  // TODO: satelite detection on userLayers
-  const layer = activeLayers.some((layer) =>
-    ['sat', 'bingSat', 'cuzkSat'].includes(layer),
-  )
+  const layer = isSateliteActive
     ? 'h' // satelite
     : 'm'; // normal
 

--- a/src/components/LayerSwitcher/AddLayerButton.tsx
+++ b/src/components/LayerSwitcher/AddLayerButton.tsx
@@ -34,6 +34,7 @@ export const AddUserLayerButton = () => {
             min_zoom: minzoom,
             attribution,
             bbox: bboxes,
+            category,
           } = layer;
 
           const newLayer: Layer = {
@@ -43,6 +44,7 @@ export const AddUserLayerButton = () => {
             name,
             url,
             bboxes,
+            isSatelite: category === 'photo',
             ...(attribution && {
               attribution: [fmtAttributionHtml(attribution)],
             }),

--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -89,6 +89,7 @@ export const osmappLayers: Layers = {
     url: `https://api.maptiler.com/tiles/satellite-v2/tiles.json?key=${process.env.NEXT_PUBLIC_API_KEY_MAPTILER}`,
     Icon: SatelliteIcon,
     attribution: ['maptiler'],
+    isSatelite: true,
   },
   bingSat: {
     name: t('layers.bingSat'),
@@ -97,6 +98,7 @@ export const osmappLayers: Layers = {
     Icon: SatelliteIcon,
     attribution: ['&copy; <a href="https://www.bing.com/maps">Microsoft</a>'],
     maxzoom: 19,
+    isSatelite: true,
   },
   cuzkSat: {
     name: 'ČÚZK ortofoto (CZ)',
@@ -105,6 +107,7 @@ export const osmappLayers: Layers = {
     Icon: SatelliteIcon,
     attribution: ['&copy; <a href="https://geoportal.cuzk.cz">ČÚZK</a>'],
     bboxes: [czBbox],
+    isSatelite: true,
   },
   // mtb: {
   //   name: t('layers.mtb'),


### PR DESCRIPTION
### Description

The share dialog allows for opening a feature in many other map providers, previously apple maps already was opened with the normal/satellite layer depending on the currently active layer in osmapp.
The detection whether a layer is a satellite layer now also supports user layers.
Google-Maps now also opens with the appropiate layer, allthough it isn't possible to force google maps from satellite to roadmap :(