### PR TITLE
EditDialog: refactor EditContext to work with DataItem not Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-zoom-pan-pinch": "^3.6.1"
   },
   "devDependencies": {
-    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.3.0",
     "@types/autosuggest-highlight": "^3.2.3",
     "@types/jest": "^29.5.13",
     "@types/js-cookie": "^3.0.6",

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -87,7 +87,7 @@ export const AddMemberForm = ({
 
       const newShortId = newItem.shortId;
 
-      // TODO this code could be removed, if we lookup the label among editItems
+      // TODO this code could be removed, if we lookup the label in render among editItems
       const presetKey = getPresetKey(newItem);
       const presetLabel = getPresetTranslation(presetKey);
       const tags = Object.fromEntries(newItem.tagsEntries);

--- a/src/components/FeaturePanel/EditDialog/EditContent/helpers.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/helpers.tsx
@@ -6,6 +6,7 @@ import { useEditContext } from '../EditContext';
 import { getApiId, getShortId } from '../../../../services/helpers';
 
 import { getFullFeatureWithMemberFeatures } from '../../../../services/osm/getFullFeatureWithMemberFeatures';
+import { fetchFreshItem } from '../itemsHelpers';
 
 const CharacterCountContainer = styled.div`
   position: absolute;
@@ -63,28 +64,32 @@ export const useGetHandleClick = ({
 }: {
   setIsExpanded?: Dispatch<SetStateAction<boolean>>;
 }) => {
-  const { addFeature, items, setCurrent } = useEditContext();
+  const { addNewItem, items, setCurrent } = useEditContext();
 
   return async (e, shortId: string) => {
     const isCmdClicked = e.ctrlKey || e.metaKey;
+    const switchToNewTab = !isCmdClicked;
     const apiId = getApiId(shortId);
 
-    if (!isCmdClicked) {
+    if (switchToNewTab) {
       setIsExpanded?.(false);
     }
 
+    // TODO merge these two conditions:
     if (apiId.id < 0) {
-      if (!isCmdClicked) setCurrent(shortId);
+      if (switchToNewTab) setCurrent(shortId);
       return;
     }
-
     if (isInItems(items, shortId)) {
-      if (!isCmdClicked) setCurrent(shortId);
+      if (switchToNewTab) setCurrent(shortId);
       return;
     }
 
-    const feature = await getFullFeatureWithMemberFeatures(apiId);
-    addFeature(feature);
-    if (!isCmdClicked) setCurrent(getShortId(feature.osmMeta));
+    const newItem = await fetchFreshItem(apiId);
+    addNewItem(newItem);
+
+    if (switchToNewTab) {
+      setCurrent(newItem.shortId);
+    }
   };
 };

--- a/src/components/FeaturePanel/EditDialog/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 import { Feature, SuccessInfo } from '../../../services/types';
-import { EditDataItem, useEditItems } from './useEditItems';
+import { DataItem, EditDataItem, useEditItems } from './useEditItems';
 import { getShortId } from '../../../services/helpers';
 import { useEditDialogFeature } from './utils';
 
@@ -14,6 +14,7 @@ type EditContextType = {
   comment: string;
   setComment: (s: string) => void;
   addFeature: (feature: Feature) => void;
+  addNewItem: (newItem: DataItem) => void;
   items: Array<EditDataItem>;
   current: string;
   setCurrent: (s: string) => void;
@@ -32,7 +33,7 @@ export const EditContextProvider = ({ originalFeature, children }: Props) => {
   const [isSaving, setIsSaving] = useState(false);
   const [location, setLocation] = useState(''); // technically is "data", but only for note
   const [comment, setComment] = useState('');
-  const { items, addFeature } = useEditItems(originalFeature);
+  const { items, addFeature, addNewItem } = useEditItems(originalFeature);
   const [current, setCurrent] = React.useState(getShortId(feature.osmMeta));
 
   const value: EditContextType = {
@@ -45,6 +46,7 @@ export const EditContextProvider = ({ originalFeature, children }: Props) => {
     comment,
     setComment,
     addFeature,
+    addNewItem,
     items,
     current,
     setCurrent,

--- a/src/components/FeaturePanel/EditDialog/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContext.tsx
@@ -23,18 +23,17 @@ type EditContextType = {
 const EditContext = createContext<EditContextType>(undefined);
 
 type Props = {
-  originalFeature: Feature;
+  initialItem: DataItem;
   children: React.ReactNode;
 };
 
-export const EditContextProvider = ({ originalFeature, children }: Props) => {
-  const { feature } = useEditDialogFeature();
+export const EditContextProvider = ({ initialItem, children }: Props) => {
   const [successInfo, setSuccessInfo] = useState<undefined | SuccessInfo>();
   const [isSaving, setIsSaving] = useState(false);
   const [location, setLocation] = useState(''); // technically is "data", but only for note
   const [comment, setComment] = useState('');
-  const { items, addFeature, addNewItem } = useEditItems(originalFeature);
-  const [current, setCurrent] = React.useState(getShortId(feature.osmMeta));
+  const { items, addFeature, addNewItem } = useEditItems(initialItem);
+  const [current, setCurrent] = useState(initialItem.shortId);
 
   const value: EditContextType = {
     successInfo,

--- a/src/components/FeaturePanel/EditDialog/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContext.tsx
@@ -13,7 +13,6 @@ type EditContextType = {
   setLocation: (s: string) => void;
   comment: string;
   setComment: (s: string) => void;
-  addFeature: (feature: Feature) => void;
   addNewItem: (newItem: DataItem) => void;
   items: Array<EditDataItem>;
   current: string;
@@ -32,7 +31,7 @@ export const EditContextProvider = ({ initialItem, children }: Props) => {
   const [isSaving, setIsSaving] = useState(false);
   const [location, setLocation] = useState(''); // technically is "data", but only for note
   const [comment, setComment] = useState('');
-  const { items, addFeature, addNewItem } = useEditItems(initialItem);
+  const { items, addNewItem } = useEditItems(initialItem);
   const [current, setCurrent] = useState(initialItem.shortId);
 
   const value: EditContextType = {
@@ -44,7 +43,6 @@ export const EditContextProvider = ({ initialItem, children }: Props) => {
     setLocation,
     comment,
     setComment,
-    addFeature,
     addNewItem,
     items,
     current,

--- a/src/components/FeaturePanel/EditDialog/__tests__/useEditItems.test.tsx
+++ b/src/components/FeaturePanel/EditDialog/__tests__/useEditItems.test.tsx
@@ -1,47 +1,50 @@
-import { renderHook } from '@testing-library/react-hooks';
-import { useEditItems } from '../useEditItems';
-import { Feature } from '../../../../services/types';
-// @ts-ignore
-import { act } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { DataItem, useEditItems } from '../useEditItems';
 
-const originalFeature: Feature = {
-  osmMeta: { type: 'node', id: 1 },
-  tags: { amenity: 'cafe' },
-  type: 'Feature',
-  properties: { class: 'x', subclass: 'y' },
-  center: [14, 50],
+const initialItem: DataItem = {
+  shortId: 'n1',
+  version: 1,
+  tagsEntries: Object.entries({ amenity: 'cafe' }),
+  toBeDeleted: false,
+  nodeLonLat: [14, 50],
+  nodes: undefined,
+  members: undefined,
 };
 
 describe('useEditItems', () => {
   it('should initialize with the original feature', () => {
-    const { result } = renderHook(() => useEditItems(originalFeature));
+    const { result } = renderHook(() => useEditItems(initialItem));
 
     expect(result.current.items).toHaveLength(1);
     expect(result.current.items[0].shortId).toEqual('n1');
-    expect(result.current.items[0].tags).toEqual(originalFeature.tags);
+    expect(result.current.items[0].version).toEqual(1);
+    expect(result.current.items[0].presetKey).toEqual('amenity/cafe');
+    expect(result.current.items[0].tags).toEqual({ amenity: 'cafe' });
   });
 
   it('should add a new feature', () => {
-    const { result } = renderHook(() => useEditItems(originalFeature));
+    const { result } = renderHook(() => useEditItems(initialItem));
 
-    const newFeature: Feature = {
-      osmMeta: { type: 'node', id: 2 },
-      tags: { amenity: 'restaurant' },
-      type: 'Feature',
-      properties: { class: 'x', subclass: 'y' },
-      center: [14, 50],
+    const newItem: DataItem = {
+      shortId: 'n2',
+      version: 1,
+      tagsEntries: [['amenity', 'restaurant']],
+      toBeDeleted: false,
+      nodeLonLat: [14, 50],
+      nodes: undefined,
+      members: undefined,
     };
 
     act(() => {
-      result.current.addFeature(newFeature);
+      result.current.addNewItem(newItem);
     });
 
     expect(result.current.items).toHaveLength(2);
-    expect(result.current.items[1].tags).toEqual(newFeature.tags);
+    expect(result.current.items[1].tags).toEqual({ amenity: 'restaurant' });
   });
 
   it('should update tags of a feature', () => {
-    const { result } = renderHook(() => useEditItems(originalFeature));
+    const { result } = renderHook(() => useEditItems(initialItem));
 
     act(() => {
       result.current.items[0].setTag('name', 'Test Cafe');
@@ -54,7 +57,7 @@ describe('useEditItems', () => {
   });
 
   it('should toggle toBeDeleted flag', () => {
-    const { result } = renderHook(() => useEditItems(originalFeature));
+    const { result } = renderHook(() => useEditItems(initialItem));
 
     act(() => {
       result.current.items[0].toggleToBeDeleted();

--- a/src/components/FeaturePanel/EditDialog/itemsHelpers.ts
+++ b/src/components/FeaturePanel/EditDialog/itemsHelpers.ts
@@ -1,0 +1,60 @@
+import { FeatureTags, LonLat, OsmId } from '../../../services/types';
+import { DataItem } from './useEditItems';
+import {
+  fetchSchemaTranslations,
+  getPresetTranslation,
+} from '../../../services/tagging/translations';
+import { fetchJson } from '../../../services/fetch';
+import { OsmResponse } from '../../../services/osm/types';
+import { getOsmUrlOrFull } from '../../../services/osm/urls';
+import { getItemsMap } from '../../../services/osm/helpers';
+import { getShortId } from '../../../services/helpers';
+import { findPreset } from '../../../services/tagging/presets';
+import { getNewId } from '../../../services/getCoordsFeature';
+
+export const getNewNodeItem = (
+  [lon, lat]: LonLat,
+  tags: FeatureTags = {},
+): DataItem => ({
+  shortId: `n${getNewId()}`,
+  version: undefined,
+  tagsEntries: Object.entries(tags),
+  toBeDeleted: false,
+  nodeLonLat: [lon, lat],
+  nodes: undefined,
+  members: undefined,
+});
+
+export const fetchFreshItem = async (apiId: OsmId): Promise<DataItem> => {
+  await fetchSchemaTranslations();
+  const full = await fetchJson<OsmResponse>(getOsmUrlOrFull(apiId));
+  const itemsMap = getItemsMap(full.elements);
+  const main = itemsMap[apiId.type][apiId.id];
+
+  return {
+    shortId: getShortId(apiId),
+    version: main.version,
+    tagsEntries: Object.entries(main.tags),
+    toBeDeleted: false,
+    nodeLonLat: apiId.type === 'node' ? [main.lon, main.lat] : undefined,
+    nodes: apiId.type === 'way' ? main.nodes : undefined,
+    members: main.members?.map((member) => {
+      const memberEl = itemsMap[member.type][member.ref];
+      const label = memberEl
+        ? (() => {
+            if (memberEl.tags.name) {
+              return memberEl.tags.name;
+            }
+            const preset = findPreset(member.type, memberEl.tags);
+            return getPresetTranslation(preset.presetKey);
+          })()
+        : `${member.type} ${member.ref}`;
+
+      return {
+        shortId: getShortId({ type: member.type, id: member.ref }),
+        role: member.role,
+        label,
+      };
+    }),
+  };
+};

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -240,10 +240,8 @@ const toggleToBeDeletedFactory = (setDataItem: SetDataItem) => {
     }));
 };
 
-export const useEditItems = (originalFeature: Feature) => {
-  const [data, setData] = useState<DataItem[]>(() => [
-    buildDataItem(originalFeature),
-  ]);
+export const useEditItems = (initialItem: DataItem) => {
+  const [data, setData] = useState<DataItem[]>([initialItem]);
 
   const items = useMemo<Array<EditDataItem>>(
     () =>

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -16,6 +16,7 @@ export type Members = Array<{
   shortId: string;
   role: string;
   label: string; // cached from other dataItems, or from originalFeature
+  // TODO rename to originalLabel - only used when member is not among editItems
 }>;
 
 // internal type stored in the state
@@ -65,7 +66,7 @@ const buildDataItem = (feature: Feature): DataItem => {
   };
 };
 
-const getPresetKey = ({ shortId, tagsEntries }: DataItem) => {
+export const getPresetKey = ({ shortId, tagsEntries }: DataItem) => {
   const tags = Object.fromEntries(tagsEntries);
   const osmId = getApiId(shortId);
   const preset = findPreset(osmId.type, tags);
@@ -275,7 +276,11 @@ export const useEditItems = (originalFeature: Feature) => {
     setData((state) => [...state, newItem]);
   };
 
+  const addNewItem = (newItem: DataItem) => {
+    setData((state) => [...state, newItem]);
+  };
+
   publishDbgObject('EditContext state', data);
 
-  return { items, addFeature };
+  return { items, addFeature, addNewItem };
 };

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -269,16 +269,11 @@ export const useEditItems = (initialItem: DataItem) => {
     [data],
   );
 
-  const addFeature = (feature: Feature) => {
-    const newItem = buildDataItem(JSON.parse(JSON.stringify(feature)));
-    setData((state) => [...state, newItem]);
-  };
-
   const addNewItem = (newItem: DataItem) => {
     setData((state) => [...state, newItem]);
   };
 
   publishDbgObject('EditContext state', data);
 
-  return { items, addFeature, addNewItem };
+  return { items, addNewItem };
 };

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -17,7 +17,7 @@ export type Members = Array<{
   shortId: string;
   role: string;
   label: string; // cached from other dataItems, or from originalFeature
-  // TODO rename to originalLabel - only used when member is not among editItems
+  // TODO rename to originalLabel - only to be used when member is not among editItems
 }>;
 
 // internal type stored in the state

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -10,6 +10,7 @@ export const getUrlOsmId = ({ id, type }: OsmId): string => `${type}/${id}`;
 
 export const getReactKey = (feature: Feature) =>
   getUrlOsmId(feature.osmMeta) +
+  '_' +
   (feature.point ? feature.center.join(',') : feature.osmMeta.version);
 
 export const getApiId = (shortId: string): OsmId => {

--- a/src/services/osm/getFullFeatureWithMemberFeatures.ts
+++ b/src/services/osm/getFullFeatureWithMemberFeatures.ts
@@ -1,4 +1,4 @@
-import { OsmId } from '../types';
+import { Feature, OsmId } from '../types';
 import { fetchSchemaTranslations } from '../tagging/translations';
 import { fetchJson } from '../fetch';
 import { OsmResponse } from './types';
@@ -7,11 +7,10 @@ import { getItemsMap, getMemberFeatures } from './helpers';
 import { addSchemaToFeature } from '../tagging/idTaggingScheme';
 import { osmToFeature } from './osmToFeature';
 
-// - AddMemberForm - new feature from shortid
-// - MembersEditor+ParentsEditor - onClick handler
-// - EditDialog - change Feature to EditItem
-// - osmApi - fetchFeature (addMemberFeaturesToRelation)
-export const getFullFeatureWithMemberFeatures = async (apiId: OsmId) => {
+// For EditDialog - use fetchFreshItem() which returns DataItem
+export const getFullFeatureWithMemberFeatures = async (
+  apiId: OsmId,
+): Promise<Feature> => {
   await fetchSchemaTranslations();
   const full = await fetchJson<OsmResponse>(getOsmUrlOrFull(apiId));
   const itemsMap = getItemsMap(full.elements);

--- a/src/services/osm/getFullFeatureWithMemberFeatures.ts
+++ b/src/services/osm/getFullFeatureWithMemberFeatures.ts
@@ -7,6 +7,10 @@ import { getItemsMap, getMemberFeatures } from './helpers';
 import { addSchemaToFeature } from '../tagging/idTaggingScheme';
 import { osmToFeature } from './osmToFeature';
 
+// - AddMemberForm - new feature from shortid
+// - MembersEditor+ParentsEditor - onClick handler
+// - EditDialog - change Feature to EditItem
+// - osmApi - fetchFeature (addMemberFeaturesToRelation)
 export const getFullFeatureWithMemberFeatures = async (apiId: OsmId) => {
   await fetchSchemaTranslations();
   const full = await fetchJson<OsmResponse>(getOsmUrlOrFull(apiId));

--- a/src/services/osm/helpers.ts
+++ b/src/services/osm/helpers.ts
@@ -3,12 +3,14 @@ import { Feature } from '../types';
 import { addSchemaToFeature } from '../tagging/idTaggingScheme';
 import { osmToFeature } from './osmToFeature';
 
+export type ItemsMap = {
+  node: Record<number, OsmElement<'node'>>;
+  way: Record<number, OsmElement<'way'>>;
+  relation: Record<number, OsmElement<'relation'>>;
+};
+
 export const getItemsMap = (elements: OsmElement[]) => {
-  const itemsMap = {
-    node: {} as Record<number, OsmElement<'node'>>,
-    way: {} as Record<number, OsmElement<'way'>>,
-    relation: {} as Record<number, OsmElement<'relation'>>,
-  };
+  const itemsMap: ItemsMap = { node: {}, way: {}, relation: {} };
   elements.forEach((element) => {
     itemsMap[element.type][element.id] = element;
   });

--- a/src/services/osm/osmApi.ts
+++ b/src/services/osm/osmApi.ts
@@ -181,9 +181,7 @@ const addMemberFeaturesToRelation = async (relation: Feature) => {
 //  - wait until UI is prepared
 //  - maybe this can be merged in fetchFeatureWithCenter()
 //  - check: Warning: data for page "/[[...all]]" (path "/relation/4810774") is 627 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance. See more info here: https://nextjs.org/docs/messages/large-page-data
-export const addMembersAndParents = async (
-  feature: Feature,
-): Promise<Feature> => {
+const addMembersAndParents = async (feature: Feature): Promise<Feature> => {
   if (isFeatureClimbingRoute(feature)) {
     const parentFeatures = await fetchParentFeatures(feature.osmMeta);
     return { ...feature, parentFeatures };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,15 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
+"@babel/code-frame@^7.10.4":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
+  integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
@@ -190,6 +199,11 @@
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
   integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
+
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/helper-validator-option@^7.24.8":
   version "7.24.8"
@@ -1895,18 +1909,36 @@
   resolved "https://registry.yarnpkg.com/@teritorio/openmaptiles-gl-language/-/openmaptiles-gl-language-1.5.4.tgz#4959c78c0e7f9845746dbc414d431cd95655db2f"
   integrity sha512-S4kXGBBSMzX4fDrmcUdPSLBNBaIUUPihuQWeaLmNXniJbNsHOppo1NtZXlivzvvl874KCmN7+UWr4q2W2l/JaA==
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+"@testing-library/dom@^10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
+  integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^16.3.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.0.tgz#3a85bb9bdebf180cd76dba16454e242564d598a6"
+  integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/autosuggest-highlight@^3.2.3":
   version "3.2.3"
@@ -2442,6 +2474,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
+
 aria-query@~5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
@@ -2849,6 +2888,14 @@ chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -3289,6 +3336,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-libc@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
@@ -3329,6 +3381,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-css@^2.0.0:
   version "2.1.0"
@@ -5800,6 +5857,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@0.30.8:
   version "0.30.8"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.8.tgz#14e8624246d2bedba70d5462aa99ac9681844613"
@@ -6545,6 +6607,11 @@ picocolors@^1.0.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -6674,6 +6741,15 @@ prettier@^3.3.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -6800,17 +6876,15 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.0.0, react-is@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
Bigger refactoring of the EditDialog "backend". There were several issues with using Feature in EditDialog:

- multiple conversion - from `OsmElement` -> `Feature` -> `DataItem`  
  - some meaning was lost in the process, which made the code less readable and prone to future errors
  - e.g. we had to use `center` for reading the nodeLonLat - eventhough this was correct only for node
- for EditDialog we want fresh data, but Feature could have been older, potentially cached. 
- for EditDialog we need to fetch eg. all nodes for ways, which is not useful to have in FeaturePanel (SSR needs to serialize it and this could make the payload too big)
- for EditDialog we always need the FullFeature (with all member features) to see better label of members (name or preset name), but the FeaturePanel `Feature` was usually without this info.
- the logic for newNode is now much clearer


