### PR TITLE
EditDialog: remove "new" node converted to relation

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -8,7 +8,7 @@ import { getApiId, getShortId } from '../../../../../services/helpers';
 import { getOsmElement } from '../../../../../services/osm/quickFetchFeature';
 import { useEditContext } from '../../EditContext';
 import { useCurrentItem } from './CurrentContext';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Button, TextField } from '@mui/material';
 import { FeatureTags, OsmId } from '../../../../../services/types';
 import { t } from '../../../../../services/intl';
@@ -64,7 +64,7 @@ const getMemberTags = (parentTags: FeatureTags) => {
 
 export const AddMemberForm = () => {
   const { view } = useMapStateContext();
-  const { addNewItem, items, setCurrent } = useEditContext();
+  const { addItem, items, setCurrent } = useEditContext();
   const { members, setMembers, tags } = useCurrentItem();
   const [showInput, setShowInput] = React.useState(false);
   const [label, setLabel] = React.useState('');
@@ -95,7 +95,7 @@ export const AddMemberForm = () => {
       const tags2 = Object.fromEntries(newItem.tagsEntries);
       const newLabel = tags2.name ?? presetLabel;
 
-      addNewItem(newItem);
+      addItem(newItem);
 
       setMembers((prev) => [
         ...(prev ?? []),
@@ -107,10 +107,10 @@ export const AddMemberForm = () => {
         setCurrent(newShortId);
       }
     },
-    [addNewItem, items, label, members, setCurrent, setMembers, tags, view],
+    [addItem, items, label, members, setCurrent, setMembers, tags, view],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const downHandler = (e) => {
       if (!showInput) return;
 

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ConvertNodeToRelation.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ConvertNodeToRelation.tsx
@@ -5,17 +5,21 @@ import { NwrIcon } from '../../../NwrIcon';
 import { t } from '../../../../../services/intl';
 import React from 'react';
 import { FeatureTags } from '../../../../../services/types';
+import { getApiId } from '../../../../../services/helpers';
 
 export const isConvertible = (shortId: string, tags: FeatureTags) =>
   shortId.startsWith('n') && ['crag', 'area'].includes(tags.climbing);
 
 export const ConvertNodeToRelation = () => {
-  const { setCurrent } = useEditContext();
-  const { tags, convertToRelation } = useCurrentItem();
+  const { setCurrent, removeItem } = useEditContext();
+  const { shortId, tags, convertToRelation } = useCurrentItem();
 
   const handleConvertToRelation = async () => {
     const newShortId = await convertToRelation();
     setCurrent(newShortId);
+    if (getApiId(shortId).id < 0) {
+      removeItem(shortId);
+    }
   };
 
   return (

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSearchBox.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSearchBox.tsx
@@ -43,8 +43,8 @@ const useEmptyOptions = () => {
   const { shortId } = useCurrentItem();
   const isNode = shortId[0] === 'n';
   const isRelation = shortId[0] === 'r';
-  if ((PROJECT_ID === 'openclimbing' && isRelation) || isNode) {
-    return ['climbing/crag', 'climbing/route_bottom'];
+  if (PROJECT_ID === 'openclimbing' && (isRelation || isNode)) {
+    return ['climbing/area', 'climbing/crag', 'climbing/route_bottom'];
   }
   if (isNode) {
     return [

--- a/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
@@ -9,7 +9,7 @@ const isInItems = (items: Array<EditDataItem>, shortId: string) =>
   items.find((item) => item.shortId === shortId);
 
 export const useHandleItemClick = (setIsExpanded: Setter<boolean>) => {
-  const { addNewItem, items, setCurrent } = useEditContext();
+  const { addItem, items, setCurrent } = useEditContext();
 
   return async (e: React.MouseEvent, shortId: string) => {
     const isCmdClicked = e.ctrlKey || e.metaKey;
@@ -31,7 +31,7 @@ export const useHandleItemClick = (setIsExpanded: Setter<boolean>) => {
     }
 
     const newItem = await fetchFreshItem(apiId);
-    addNewItem(newItem);
+    addItem(newItem);
 
     if (switchToNewTab) {
       setCurrent(newItem.shortId);

--- a/src/components/FeaturePanel/EditDialog/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContext.tsx
@@ -13,7 +13,8 @@ type EditContextType = {
   setLocation: (s: string) => void;
   comment: string;
   setComment: (s: string) => void;
-  addNewItem: (newItem: DataItem) => void;
+  addItem: (newItem: DataItem) => void;
+  removeItem: (shortId: string) => void;
   items: Array<EditDataItem>;
   current: string;
   setCurrent: (s: string) => void;
@@ -31,7 +32,7 @@ export const EditContextProvider = ({ initialItem, children }: Props) => {
   const [isSaving, setIsSaving] = useState(false);
   const [location, setLocation] = useState(''); // technically is "data", but only for note
   const [comment, setComment] = useState('');
-  const { items, addNewItem } = useEditItems(initialItem);
+  const { items, addItem, removeItem } = useEditItems(initialItem);
   const [current, setCurrent] = useState(initialItem.shortId);
 
   const value: EditContextType = {
@@ -43,7 +44,8 @@ export const EditContextProvider = ({ initialItem, children }: Props) => {
     setLocation,
     comment,
     setComment,
-    addNewItem,
+    addItem,
+    removeItem,
     items,
     current,
     setCurrent,

--- a/src/components/FeaturePanel/EditDialog/__tests__/useEditItems.test.tsx
+++ b/src/components/FeaturePanel/EditDialog/__tests__/useEditItems.test.tsx
@@ -36,7 +36,7 @@ describe('useEditItems', () => {
     };
 
     act(() => {
-      result.current.addNewItem(newItem);
+      result.current.addItem(newItem);
     });
 
     expect(result.current.items).toHaveLength(2);

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -249,11 +249,18 @@ export const useEditItems = (initialItem: DataItem) => {
     [data],
   );
 
-  const addNewItem = (newItem: DataItem) => {
+  const addItem = (newItem: DataItem) => {
     setData((state) => [...state, newItem]);
+  };
+
+  const removeItem = (shortId: string) => {
+    if (getApiId(shortId).id > 0) {
+      throw new Error('Existing item should not be removed from items.');
+    }
+    setData((state) => state.filter((item) => item.shortId !== shortId));
   };
 
   publishDbgObject('EditContext state', data);
 
-  return { items, addNewItem };
+  return { items, addItem, removeItem };
 };

--- a/src/services/osm/auth/getDIffXml.ts
+++ b/src/services/osm/auth/getDIffXml.ts
@@ -77,6 +77,7 @@ const getXmlByAction = (
     way: items.filter(isWay).map((way) => wayItemToXml(way, changesetId)),
     relation: items
       .filter(isRelation)
+      .toReversed() // new relation can be referenced by another only above, but OSM needs the reference beforehand
       .map((relation) => relationItemToXml(relation, changesetId)),
   };
 };


### PR DESCRIPTION
We can safely remove a node from items, if it was a new one.