### PR TITLE
Map: use maptiler outdoor-v2 tiles

### DIFF
--- a/src/components/Map/consts.ts
+++ b/src/components/Map/consts.ts
@@ -33,15 +33,15 @@ export const OSMAPP_SOURCES: Record<string, SourceSpecification> = {
   },
   contours: {
     type: 'vector' as const,
-    url: `https://api.maptiler.com/tiles/contours/tiles.json?key=${apiKey}`,
+    url: `https://api.maptiler.com/tiles/contours-v2/tiles.json?key=${apiKey}`,
   },
   terrain3d: {
-    url: `https://api.maptiler.com/tiles/terrain-rgb/tiles.json?key=${apiKey}`, // this source must be duplicated for terrain/hillshade https://github.com/maplibre/maplibre-gl-js/issues/2035
+    url: `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${apiKey}`, // this source must be duplicated for terrain/hillshade https://github.com/maplibre/maplibre-gl-js/issues/2035
     type: 'raster-dem' as const,
     tileSize: 256,
   },
   terrainHillshade: {
-    url: `https://api.maptiler.com/tiles/terrain-rgb/tiles.json?key=${apiKey}`,
+    url: `https://api.maptiler.com/tiles/terrain-rgb-v2/tiles.json?key=${apiKey}`,
     type: 'raster-dem' as const,
     tileSize: 256,
   },

--- a/src/components/Map/styles/outdoorStyle.ts
+++ b/src/components/Map/styles/outdoorStyle.ts
@@ -9,6 +9,9 @@ import { motorwayConstruction } from './layers/contruction';
 import { overpassLayers } from './layers/overpassLayers';
 import { cliffsLayers } from './layers/cliffsLayers';
 
+// Maptiler Outdoor style is copyrighted – only to be used with valid Maptiler subscription
+// https://www.maptiler.com/maps/outdoor/
+
 // TODO add icons for outdoor to our sprite (guideposts, benches, etc)
 // https://api.maptiler.com/maps/outdoor/sprite.png?key=7dlhLl3hiXQ1gsth0kGu
 
@@ -255,7 +258,7 @@ export const outdoorStyle = addHoverPaint({
         'hillshade-exaggeration': {
           stops: [
             [6, 0.45],
-            [14, 0.55],
+            [14, 0.35],
           ],
         },
         'hillshade-shadow-color': 'rgba(107, 101, 100, 1)',


### PR DESCRIPTION
New tiles have better granularity for countours and hillshading, and also they are discontinuing the old tiles this year.

Update to outdoor-v2 *style* is in #444.

|old|new|
|--|--|
| ![Screenshot 2025-05-11 at 13 14 11](https://github.com/user-attachments/assets/55d35c3b-ce9a-4d76-bd7e-f7adebd8815e) | ![Screenshot 2025-05-11 at 13 14 15](https://github.com/user-attachments/assets/b5e24003-5595-4fe8-b01f-838e34417731) |
