### PR TITLE
RouteDistribution: Add distribution also for climbing areas

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
@@ -93,7 +93,7 @@ export const ClimbingViewContent = ({ isMapVisible }) => {
             </>
           )}
         </ContentContainer>
-        <RouteDistribution />
+        <RouteDistribution features={feature.memberFeatures} />
 
         {feature.tags.description ? (
           <>

--- a/src/components/FeaturePanel/CragsInArea.tsx
+++ b/src/components/FeaturePanel/CragsInArea.tsx
@@ -22,9 +22,7 @@ import { naturalSort } from './Climbing/utils/array';
 import { PanelLabel } from './Climbing/PanelLabel';
 import { PROJECT_ID } from '../../services/project';
 import { MemberItem } from './MemberFeatures/MemberItem';
-import { RouteDistributionInPanel } from './Climbing/RouteDistribution';
-import { GradeSystemSelect } from './Climbing/GradeSystemSelect';
-import { useUserSettingsContext } from '../utils/UserSettingsContext';
+import { RouteDistribution } from './Climbing/RouteDistribution';
 
 const isOpenClimbing = PROJECT_ID === 'openclimbing';
 
@@ -171,7 +169,11 @@ const CragItem = ({ feature }: { feature: Feature }) => {
           {images.length ? <Gallery images={images} feature={feature} /> : null}
         </InnerContainer>
       </StyledLink>
-      <RouteDistributionInPanel feature={feature} />
+      {feature.memberFeatures.length > 0 && (
+        <Box mb={2}>
+          <RouteDistribution features={feature.memberFeatures} />
+        </Box>
+      )}
     </Container>
   );
 };
@@ -190,8 +192,14 @@ export const CragsInArea = () => {
     return acc + (members?.length ?? 0);
   }, 0);
 
+  const allCragRoutes = crags.reduce((acc, crag) => {
+    return [...acc, ...crag.memberFeatures];
+  }, []);
+
   return (
     <>
+      {crags.length > 1 && <RouteDistribution features={allCragRoutes} />}
+
       <PanelLabel
         addition={
           <Chip

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -18,18 +18,17 @@ import { ClimbingRestriction } from './Climbing/ClimbingRestriction';
 import { Runways } from './Runways/Runways';
 import { EditButton } from './EditButton';
 import { EditDialog } from './EditDialog/EditDialog';
-import { RouteDistributionInPanel } from './Climbing/RouteDistribution';
+import { RouteDistribution } from './Climbing/RouteDistribution';
 import { FeaturePanelFooter } from './FeaturePanelFooter';
 import { ClimbingRouteGrade } from './ClimbingRouteGrade';
 import { Box, Stack } from '@mui/material';
 import { ClimbingStructuredData } from './Climbing/ClimbingStructuredData';
-import { isPublictransportRoute } from '../../utils';
+import { isClimbingCrag, isPublictransportRoute } from '../../utils';
 import { Sockets } from './Sockets/Sockets';
 import { ClimbingTypeBadge } from './Climbing/ClimbingTypeBadge';
 import { TestApiWarning } from './helpers/TestApiWarning';
 import { FeaturePanelClimbingGuideInfo } from './Climbing/FeaturePanelClimbingGuideInfo';
 import { FeaturedTag } from './FeaturedTag';
-import { climbingTagValues } from './Climbing/utils/climbingTagValues';
 
 const Flex = styled.div`
   flex: 1;
@@ -95,7 +94,9 @@ export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
 
               <PanelSidePadding>
                 {!movePropertiesBelowMembers && <PropertiesComponent />}
-                <RouteDistributionInPanel feature={feature} />
+                {isClimbingCrag(feature) && (
+                  <RouteDistribution features={feature.memberFeatures} />
+                )}
                 {!isPublictransportRoute(feature) && <MemberFeatures />}
                 {advanced && <Members />}
                 {movePropertiesBelowMembers && <PropertiesComponent />}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,9 @@ export const isClimbingRelation = (feature: Feature) =>
   feature.osmMeta.type === 'relation' &&
   (feature.tags.climbing === 'crag' || feature.tags.climbing === 'area');
 
+export const isClimbingCrag = (feature: Feature) =>
+  feature.osmMeta.type === 'relation' && feature.tags.climbing === 'crag';
+
 export const isFeatureClimbingRoute = (feature: Feature) =>
   isClimbingRoute(feature?.tags);
 


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

+ refactor RouteDistribution to load it from features, not climbing context

### Example links

### Screenshots

<img width="450" alt="image" src="https://github.com/user-attachments/assets/ff862cd6-ab14-47fc-8d3a-82c0cd07b43d" />


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
