### PR TITLE
EditDialog: fix missing TabName + add NwrIcon

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
@@ -9,8 +9,8 @@ import {
 } from '@mui/material';
 import { useEditContext } from '../EditContext';
 import React from 'react';
-import { PoiIcon } from '../../../utils/icons/PoiIcon';
 import { EditDataItem } from '../useEditItems';
+import { getOsmTypeFromShortId, NwrIcon } from '../../NwrIcon';
 
 const StyledTypography = styled(Typography)<{ $deleted: boolean }>`
   ${({ $deleted }) => $deleted && 'text-decoration: line-through;'}
@@ -62,11 +62,11 @@ const TabLabel = ({
         whiteSpace="nowrap"
         $deleted={toBeDeleted}
       >
-        {tags.name ?? shortId}
+        {tags.name || shortId}
       </StyledTypography>
     </Stack>
     <Typography variant="caption" textTransform="lowercase" whiteSpace="nowrap">
-      {presetLabel}
+      {presetLabel} <NwrIcon osmType={getOsmTypeFromShortId(shortId)} />
     </Typography>
   </Stack>
 );


### PR DESCRIPTION
Fixes empty label:

![image](https://github.com/user-attachments/assets/03366bf1-bbf8-4f7b-a1eb-82dc737c47be)
