### PR TITLE
EditDialog: add loading spinner to Members/ParentsEditor

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -113,9 +113,7 @@ export const MembersEditor = () => {
           key={member.shortId}
           shortId={member.shortId}
           label={member.label}
-          onClick={(e: React.MouseEvent) => {
-            handleClick(e, member.shortId);
-          }}
+          onClick={(e: React.MouseEvent) => handleClick(e, member.shortId)}
         />
       ))}
 

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -120,10 +120,7 @@ export const ParentsEditor = () => {
                 key={shortId}
                 shortId={shortId}
                 label={parent.tags.name}
-                onClick={(e) => {
-                  setIsExpanded(false);
-                  handleClick(e, shortId);
-                }}
+                onClick={(e) => handleClick(e, shortId)}
               />
             );
           })}

--- a/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
@@ -16,25 +16,18 @@ export const useHandleItemClick = (setIsExpanded: Setter<boolean>) => {
     const switchToNewTab = !isCmdClicked;
     const apiId = getApiId(shortId);
 
-    if (switchToNewTab) {
-      setIsExpanded?.(false);
-    }
+    if (!isInItems(items, shortId)) {
+      const newItem = await fetchFreshItem(apiId);
+      addItem(newItem);
 
-    // TODO merge these two conditions:
-    if (apiId.id < 0) {
-      if (switchToNewTab) setCurrent(shortId);
-      return;
-    }
-    if (isInItems(items, shortId)) {
-      if (switchToNewTab) setCurrent(shortId);
-      return;
-    }
-
-    const newItem = await fetchFreshItem(apiId);
-    addItem(newItem);
-
-    if (switchToNewTab) {
-      setCurrent(newItem.shortId);
+      if (switchToNewTab) {
+        setIsExpanded(false);
+        setCurrent(newItem.shortId);
+      }
+    } else {
+      if (switchToNewTab) {
+        setCurrent(shortId);
+      }
     }
   };
 };

--- a/src/components/FeaturePanel/EditDialog/utils.ts
+++ b/src/components/FeaturePanel/EditDialog/utils.ts
@@ -1,4 +1,6 @@
 import { useFeatureContext } from '../../utils/FeatureContext';
+import { useBoolState } from '../../helpers';
+import React, { useCallback, useEffect } from 'react';
 
 export const useEditDialogFeature = () => {
   const { feature } = useFeatureContext();


### PR DESCRIPTION
On slow connection - shows circular loading spinner.

![image](https://github.com/user-attachments/assets/711426c6-17cf-4e67-a2a5-b9053e65efe1)
