### PR TITLE
osmApi: remove `nodes` for ways

### DIFF
--- a/src/services/__tests__/osmApi.fixture.ts
+++ b/src/services/__tests__/osmApi.fixture.ts
@@ -77,7 +77,6 @@ export const WAY_FEATURE = {
     { type: 'center', service: 'kartaview', center: [14, 50] },
     { type: 'center', service: 'mapillary', center: [14, 50] },
   ],
-  nodes: [1, 2],
 };
 export const RELATION = {
   elements: [

--- a/src/services/osm/osmToFeature.ts
+++ b/src/services/osm/osmToFeature.ts
@@ -20,7 +20,6 @@ export const osmToFeature = (element): Feature => {
     osmMeta,
     tags,
     members,
-    nodes, // TODO find a way to not pass it between SSR and client
     imageDefs: getImageDefs(tags, osmMeta.type, center),
     properties: { ...getPoiClass(tags) }, // TODO PoiClass is computed from tags, this can be removed
     deleted: osmappDeletedMarker,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -110,7 +110,6 @@ export type Feature = {
   tags: FeatureTags;
   members?: RelationMember[]; // only for relations
   memberFeatures?: Feature[]; // for relations with children (full)
-  nodes?: number[]; // only for ways
   parentFeatures?: Feature[];
   imageDefs?: ImageDef[];
   properties: FeatureProperties;


### PR DESCRIPTION
It is not needed anymore, as EditDialog fetches its own "full" featues, and stores `nodes` in `DataItems`.