### PR TITLE
general: add eslint rule for transient props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["eslint-plugin-local-rules"],
+  "extends": ["next/core-web-vitals", "prettier", "plugin:local-rules/all"],
   "rules": {
     "import/no-anonymous-default-export": "off",
     "@next/next/no-img-element": "off",

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,53 @@
+module.exports = {
+  'no-styled-missing-transient-props': {
+    meta: {
+      type: 'problem',
+      docs: {
+        description:
+          'Warns when a styled component has custom props but is missing shouldForwardProp.',
+        category: 'Possible Errors',
+        recommended: true,
+        url: '',
+      },
+      schema: [],
+      messages: {
+        missingShouldForwardProp:
+          "styled() has custom props, but is missing `shouldForwardProp`. Add `styled(..., { shouldForwardProp: (prop) => !prop.startsWith('$') })`.",
+      },
+    },
+    create(context) {
+      return {
+        CallExpression(callExpression) {
+          if (
+            callExpression.callee.type === 'Identifier' &&
+            callExpression.callee.name === 'styledd'
+          ) {
+            let hasCustomProps = false;
+            let hasShouldForwardProp = false;
+            const taggedTemplate = callExpression.parent;
+
+            if (
+              taggedTemplate.typeArguments &&
+              taggedTemplate.typeArguments.type ===
+                'TSTypeParameterInstantiation' &&
+              taggedTemplate.typeArguments.params.length > 0
+            ) {
+              hasCustomProps = true;
+            }
+
+            if (callExpression.arguments.length > 1) {
+              hasShouldForwardProp = true;
+            }
+
+            if (hasCustomProps && !hasShouldForwardProp) {
+              context.report({
+                node: callExpression,
+                messageId: 'missingShouldForwardProp',
+              });
+            }
+          }
+        },
+      };
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.15",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-local-rules": "^3.0.2",
     "husky": "^4",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3795,6 +3795,11 @@ eslint-plugin-jsx-a11y@^6.7.1:
     safe-regex-test "^1.0.3"
     string.prototype.includes "^2.0.0"
 
+eslint-plugin-local-rules@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz#84c02ea1d604ecb00970779ad27f00738ff361ae"
+  integrity sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==
+
 "eslint-plugin-react-hooks@^4.5.0 || 5.0.0-canary-7118f5dd7-20230705":
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"


### PR DESCRIPTION
Correct:
```
const Wrapper = styled(Stack, {
  shouldForwardProp: (prop) => !prop.startsWith('$'),
})<{ $isMobileMode: boolean }>`
```

https://typescript-eslint.io/play/#ts=5.8.2&showAST=es&fileType=.ts&code=MYewdgzgLgBA6gJwIYAcUFMEwLw2gTwBt0ATEgCgGUolgBrAShgB4BvGAEgEsIBZEAEZdi-EugBcMASBDEkYGAF8AfAAMAUDBgoQELlC7hJSARFkBXKOgDc61baA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false