### PR TITLE
SearchBox: add modifier for global overpass query

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@openstreetmap/id-tagging-schema": "^6.8.1",
     "@sentry/nextjs": "^8.34.0",
     "@teritorio/openmaptiles-gl-language": "^1.5.4",
+    "@turf/bbox": "^7.2.0",
     "@xmldom/xmldom": "^0.9.3",
     "accept-language-parser": "^1.5.0",
     "autosuggest-highlight": "^3.3.4",

--- a/src/components/Map/behaviour/useInitMap.tsx
+++ b/src/components/Map/behaviour/useInitMap.tsx
@@ -51,7 +51,7 @@ export const useInitMap = () => {
 
     const map = new maplibregl.Map({
       container: mapRef.current,
-      style: basicStyle,
+      // style: basicStyle,
       attributionControl: false,
       refreshExpiredTiles: false,
       locale: {

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -130,6 +130,8 @@ const openFreeMapCheck = (activeLayers: string[], showToast: ShowToast) => {
   prevLayers = activeLayers;
 };
 
+let prevMapLoaded = false;
+
 export const useUpdateStyle = createMapEffectHook(
   (
     map,
@@ -139,6 +141,11 @@ export const useUpdateStyle = createMapEffectHook(
     currentTheme: Theme,
     showToast: ShowToast,
   ) => {
+    if (mapLoaded && !prevMapLoaded) {
+      prevMapLoaded = true; //we don't want to update the style after mapLoaded finished
+      return;
+    }
+
     const [basemap, ...overlays] = activeLayers;
     const key = basemap ?? DEFAULT_MAP;
 

--- a/src/services/mapStorage.ts
+++ b/src/services/mapStorage.ts
@@ -8,7 +8,8 @@ export const mapIdlePromise = new Promise<maplibregl.Map>((resolve) => {
 let map: maplibregl.Map | undefined = undefined;
 export const setGlobalMap = (newMap: maplibregl.Map) => {
   map = newMap;
-  map?.on('idle', () => mapIsIdle(newMap));
+  global.DEBUG_map = newMap;
+  map.on('idle', () => mapIsIdle(newMap));
 };
 export const getGlobalMap = () => map;
 

--- a/src/services/overpass/overpassSearch.ts
+++ b/src/services/overpass/overpassSearch.ts
@@ -131,6 +131,7 @@ export const overpassGeomToGeojson = (
 ): OverpassFeature[] =>
   response.elements
     .filter((element) => !(element.type === 'node' && !element.tags))
+    .filter((element) => ['node', 'way', 'relation'].includes(element.type)) // overpass may return type `area` for queries like `area(3611589457);nwr["amenity"="bar"][name](area)`
     .map((element) => {
       const { type, id, tags = {} } = element;
       const geometry = GEOMETRY[type]?.(element);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,32 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@turf/bbox@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-7.2.0.tgz#9db338d6407380f66a72050657f1998c5c5ccc4a"
+  integrity sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/helpers@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.2.0.tgz#5771308108c98d608eb8e7f16dcd0eb3fb8a3417"
+  integrity sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==
+  dependencies:
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
+
+"@turf/meta@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.2.0.tgz#6a6b1918890b4d9d2b5ff10b3ad47e2fd7470912"
+  integrity sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+
 "@types/aria-query@^5.0.1":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
@@ -2006,6 +2032,11 @@
   version "7946.0.14"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
   integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
+
+"@types/geojson@^7946.0.10":
+  version "7946.0.16"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
+  integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
@@ -7890,6 +7921,11 @@ tslib@^2.4.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
   integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
If overpass query starts with `!global:` the current view Bbox is ignored and the query is launched worldwide. 

Mind to get reasonable sized queries. Over 10 MB could break the browser.

via: https://github.com/zbycz/osmapp/issues/119#issuecomment-2894942191


Example link:
```
https://osmapp-git-global-overpass-osm-app-team.vercel.app/?qd=overpass:!global:area(3611589457);nwr[%22amenity%22=%22bar%22][name](area)
```