### PR TITLE
images: strip nonsense `image*=*` tags

### DIFF
--- a/src/services/images/__tests__/getImageDefs.test.ts
+++ b/src/services/images/__tests__/getImageDefs.test.ts
@@ -11,8 +11,9 @@ test('conversion', () => {
     'wikimedia_commons:2': 'File:2.jpg',
     'wikimedia_commons:2:path': '0.1,0.2|0.8,0.9whatever🙂',
     'wikimedia_commons:xy': 'Category:cat.jpg',
-    image: 'blah blah url',
-    image2: 'image2 url',
+    image: 'http://blah blah url',
+    image2: 'File:image2 like commons image name',
+    'image:license': 'to be ignored',
     website: 'https://site-may-have-og-image',
   };
 
@@ -40,13 +41,13 @@ test('conversion', () => {
     {
       type: 'tag',
       k: 'image',
-      v: 'blah blah url',
+      v: 'http://blah blah url',
       instant: true,
     },
     {
       type: 'tag',
       k: 'image2',
-      v: 'image2 url',
+      v: 'File:image2 like commons image name',
       instant: true,
     },
     {
@@ -80,8 +81,8 @@ test('correctly sorted', () => {
     'wikimedia_commons:3': 'Category:1.jpg',
     wikidata: 'Q123',
     wikimedia_commons: 'File:1.jpg',
-    image: '2.jpg',
-    image2: '3.jpg',
+    image: 'http://blah blah url',
+    image2: 'File:image2 like commons image name',
     'wikipedia:cs': '2.jpg',
     'image:2': 'https://commons.wikimedia.org/wiki/File%3Axxxx4.jpg',
     'ignored-non-image-tag': 'x',

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -99,10 +99,11 @@ export const getInstantImage = ({ k, v }: KeyValue): ImageType | null => {
 
 const wikipedia = ([k, _]) => k.match(/^wikipedia(\d*|:.*)$/);
 const wikidata = ([k, _]) => k.match(/^wikidata(\d*|:.*)$/);
-const image = ([k, _]) => k.match(/^image(\d*|:(?!path).*)$/);
+const image = ([k, v]) =>
+  k.match(/^image(\d*|:(?!path).*)$/) && v.match(/^File:|^https?:/);
 
 const commons = (k: string) => k.match(/^wikimedia_commons(\d*|:(?!path).*)$/);
-const commonsFile = ([k, v]) => commons(k) && v.startsWith('File:');
+const commonsFile = ([k, v]) => commons(k) && v.startsWith('File:'); // TODO sometimes full url to the file may be present, but lets not support it for now
 const commonsCategory = ([k, v]) => commons(k) && v.startsWith('Category:');
 
 const mapillary = ([k, v]) => k === 'mapillary' && v.match(/^\d+$/);


### PR DESCRIPTION

### Example links
node/5064026138

way/75585401



| 1 | 2 |
|--|--|
| ![image](https://github.com/user-attachments/assets/48256229-6087-4748-b2f4-744b0461f25a) |![image](https://github.com/user-attachments/assets/0b78f09c-faa8-471d-8413-652c5a44d742) |

