### PR TITLE
EditDialog: fix osmElement.tags may be undefined

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useStaticMarkers.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useStaticMarkers.tsx
@@ -44,7 +44,7 @@ const useUpdateFeatureMarkers = createMapEffectHook<
       return (
         <Stack direction="column" gap={2}>
           <Typography variant="subtitle2" color="primary">
-            {item.tags.name}
+            {item.tags?.name || item.shortId}
           </Typography>
           <Button
             size="small"

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -119,7 +119,7 @@ export const ParentsEditor = () => {
               <FeatureRow
                 key={shortId}
                 shortId={shortId}
-                label={parent.tags.name}
+                label={parent.tags?.name || shortId}
                 onClick={(e) => handleClick(e, shortId)}
               />
             );

--- a/src/components/FeaturePanel/EditDialog/itemsHelpers.ts
+++ b/src/components/FeaturePanel/EditDialog/itemsHelpers.ts
@@ -38,11 +38,11 @@ const getLabel = (itemsMap: ItemsMap, member: RelationMember) => {
     return `${member.type} ${member.ref}`;
   }
 
-  if (element.tags.name) {
+  if (element.tags?.name) {
     return element.tags.name;
   }
 
-  const preset = findPreset(member.type, element.tags);
+  const preset = findPreset(member.type, element.tags ?? {});
   return getPresetTranslation(preset.presetKey);
 };
 


### PR DESCRIPTION
We need typescript strict mode #571, this could have been caught statically.