### PR TITLE
general: Move telemetry website IDs to env (Umami, GTM) as well as OSM Test server

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@
 # https://www.openstreetmap.org/oauth2/applications
 NEXT_PUBLIC_OSM_CLIENT_ID=vWUdEL3QMBCB2O9q8Vsrl3i2--tcM34rKrxSHR9Vg68
 NEXT_PUBLIC_ENABLE_TEST_API=
+NEXT_PUBLIC_OSM_TEST_CLIENT_ID=a_f_aB7ADY_kdwe4YHpmCSBtNtDZ-BitW8m5I6ijDwI
 
 # https://indoorequal.com/dashboard/apikeys
 # optional, fill blank to disable
@@ -24,6 +25,12 @@ NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda
 # Umami anylytics is used to track server load only. We don't want to track clicks in browser.
 # optional, fill blank to disable
 UMAMI_WEBSITE_ID=5e4d4917-9031-42f1-a26a-e71d7ab8e3fe
+
+# keys for user telemetry
+NEXT_PUBLIC_UMAMI_ID_OSMAPP=8eb1792b-ba57-468b-a2cf-c8b050e11bb3
+NEXT_PUBLIC_UMAMI_ID_OPENCLIMBING=85c41d25-1a2a-4168-9786-a442a92e6171
+
+NEXT_PUBLIC_GTM_ID_OPENCLIMING=G-XCHYKP28FT
 
 # Use climbingTiles loaded from openclimbing.org (instead of Overpass version)
 #NEXT_PUBLIC_ENABLE_CLIMBING_TILES=true

--- a/src/components/App/google-analytics.tsx
+++ b/src/components/App/google-analytics.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Script from 'next/script';
 
-const OPENCLIMBING_ID = 'G-XCHYKP28FT';
+const OPENCLIMBING_ID = process.env.NEXT_PUBLIC_GTM_ID_OPENCLIMING;
 
 export const GoogleAnalytics = () => (
   <>

--- a/src/components/App/umami.tsx
+++ b/src/components/App/umami.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import Script from 'next/script';
 import { PROJECT_ID } from '../../services/project';
 
-const UMAMI_ID_OSMAPP = '8eb1792b-ba57-468b-a2cf-c8b050e11bb3';
-const UMAMI_ID_OPENCLIMBING = '85c41d25-1a2a-4168-9786-a442a92e6171';
-
 export const Umami = () => {
   const isOpenClimbing = PROJECT_ID === 'openclimbing';
 
@@ -13,7 +10,11 @@ export const Umami = () => {
     <Script
       defer
       src="https://cloud.umami.is/script.js"
-      data-website-id={isOpenClimbing ? UMAMI_ID_OPENCLIMBING : UMAMI_ID_OSMAPP}
+      data-website-id={
+        isOpenClimbing
+          ? process.env.NEXT_PUBLIC_UMAMI_ID_OPENCLIMBING
+          : process.env.NEXT_PUBLIC_UMAMI_ID_OSMAPP
+      }
     />
   );
 };

--- a/src/services/osm/consts.ts
+++ b/src/services/osm/consts.ts
@@ -9,7 +9,7 @@ export const OSM_WEBSITE = USE_PROD_API
 export const API_SERVER = USE_PROD_API ? PROD_SERVER : TEST_SERVER;
 
 export const PROD_CLIENT_ID = process.env.NEXT_PUBLIC_OSM_CLIENT_ID;
-export const TEST_CLIENT_ID = 'a_f_aB7ADY_kdwe4YHpmCSBtNtDZ-BitW8m5I6ijDwI';
+export const TEST_CLIENT_ID = process.env.NEXT_PUBLIC_OSM_TEST_CLIENT_ID;
 
 export const OSM_USER_COOKIE = USE_PROD_API
   ? 'osmUserForSSR'


### PR DESCRIPTION
Closes: #984

### Description

Centralizes IDs
