### PR TITLE
SearchBox: refactor useInputValueState() with valueRef

### DIFF
--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -37,8 +37,8 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
   autocompleteRef,
   setIsLoading,
 }) => {
-  const { inputValue, setInputValue } = useInputValueState();
-  const options = useGetOptions(inputValue);
+  const { inputValue, valueRef, setInputValue } = useInputValueState();
+  const options = useGetOptions(inputValue, valueRef);
   const onHighlight = useGetOnHighlight();
   const onSelected = useGetOnSelected(setIsLoading);
 


### PR DESCRIPTION
This PR removes the global variable which was used for canceling render of late-coming geocoder responses. SInce they often take 2secs, they easily can come out of order.

This is prerequisite for #1066