### PR TITLE
Climbing: Fix wikimedia_commons encoded URI path

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/RoutesEditor.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesEditor.tsx
@@ -134,14 +134,18 @@ export const RoutesEditor = ({
     const photosToLoad = photoPaths.filter((path) => !loadedPhotos[path]);
 
     const tempLoadedPhotos = photosToLoad.reduce((acc, otherPhotoPath) => {
+      const sanitizedOtherPhotoPath = decodeURI(otherPhotoPath);
       const img = new Image();
-      const url = getCommonsImageUrl(`File:${otherPhotoPath}`, photoResolution);
+      const url = getCommonsImageUrl(
+        `File:${sanitizedOtherPhotoPath}`,
+        photoResolution,
+      );
       img.src = url;
 
       return {
         ...acc,
-        [otherPhotoPath]: {
-          ...acc[otherPhotoPath],
+        [sanitizedOtherPhotoPath]: {
+          ...acc[sanitizedOtherPhotoPath],
           [photoResolution]: true,
         },
       };


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
