### PR TITLE
general: remove Umami for osmapp.org

### DIFF
--- a/.env
+++ b/.env
@@ -27,10 +27,9 @@ NEXT_PUBLIC_API_KEY_GRAPHHOPPER=f189b841-6529-46c6-8a91-51f17477dcda
 UMAMI_WEBSITE_ID=5e4d4917-9031-42f1-a26a-e71d7ab8e3fe
 
 # keys for user telemetry
-NEXT_PUBLIC_UMAMI_ID_OSMAPP=8eb1792b-ba57-468b-a2cf-c8b050e11bb3
+NEXT_PUBLIC_UMAMI_ID_OSMAPP=
 NEXT_PUBLIC_UMAMI_ID_OPENCLIMBING=85c41d25-1a2a-4168-9786-a442a92e6171
-
 NEXT_PUBLIC_GTM_ID_OPENCLIMING=G-XCHYKP28FT
 
-# Use climbingTiles loaded from openclimbing.org (instead of Overpass version)
+# Use climbingTiles served from openclimbing.org (instead of Overpass version)
 #NEXT_PUBLIC_ENABLE_CLIMBING_TILES=true

--- a/src/components/App/umami.tsx
+++ b/src/components/App/umami.tsx
@@ -4,17 +4,19 @@ import { PROJECT_ID } from '../../services/project';
 
 export const Umami = () => {
   const isOpenClimbing = PROJECT_ID === 'openclimbing';
+  const websiteId = isOpenClimbing
+    ? process.env.NEXT_PUBLIC_UMAMI_ID_OPENCLIMBING
+    : process.env.NEXT_PUBLIC_UMAMI_ID_OSMAPP;
 
-  // we should disable tracking for osmapp in ~10/4/2025
+  if (!websiteId || process.env.NODE_ENV !== 'production') {
+    return null;
+  }
+
   return (
     <Script
       defer
       src="https://cloud.umami.is/script.js"
-      data-website-id={
-        isOpenClimbing
-          ? process.env.NEXT_PUBLIC_UMAMI_ID_OPENCLIMBING
-          : process.env.NEXT_PUBLIC_UMAMI_ID_OSMAPP
-      }
+      data-website-id={websiteId}
     />
   );
 };


### PR DESCRIPTION
It was introduced to mitigate the large cost of vercel executions. It is no longer needed.