### PR TITLE
climbingTiles: set vercel cache + cors wildcard

### DIFF
--- a/pages/api/climbing-tiles/stats.ts
+++ b/pages/api/climbing-tiles/stats.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addCorsHeaders } from '../../../src/server/climbing-tiles/utils';
+import { addCorsAndCache } from '../../../src/server/climbing-tiles/utils';
 import { getClimbingStats } from '../../../src/server/climbing-tiles/getClimbingStats';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  addCorsHeaders(req, res);
+  addCorsAndCache(res);
   try {
     const json = await getClimbingStats();
 

--- a/pages/api/climbing-tiles/stats.ts
+++ b/pages/api/climbing-tiles/stats.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { addCorsAndCache } from '../../../src/server/climbing-tiles/utils';
 import { getClimbingStats } from '../../../src/server/climbing-tiles/getClimbingStats';
+import { addCorsAndCache } from '../../../src/server/climbing-tiles/addCorsAndCache';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   addCorsAndCache(res);

--- a/pages/api/climbing-tiles/tile.ts
+++ b/pages/api/climbing-tiles/tile.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getClimbingTile } from '../../../src/server/climbing-tiles/getClimbingTile';
-import { addCorsAndCache } from '../../../src/server/climbing-tiles/utils';
 import { Tile } from '../../../src/types';
+import { addCorsAndCache } from '../../../src/server/climbing-tiles/addCorsAndCache';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   addCorsAndCache(res);

--- a/pages/api/climbing-tiles/tile.ts
+++ b/pages/api/climbing-tiles/tile.ts
@@ -1,10 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getClimbingTile } from '../../../src/server/climbing-tiles/getClimbingTile';
-import { addCorsHeaders } from '../../../src/server/climbing-tiles/utils';
+import { addCorsAndCache } from '../../../src/server/climbing-tiles/utils';
 import { Tile } from '../../../src/types';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  addCorsHeaders(req, res);
+  addCorsAndCache(res);
   try {
     const tileNumber: Tile = {
       z: Number(req.query.z),

--- a/src/components/Map/climbingTiles/__tests__/computeTiles.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/computeTiles.test.ts
@@ -1,0 +1,15 @@
+import { computeTiles } from '../computeTiles';
+import { LngLat } from 'maplibre-gl';
+
+describe('computeTiles', () => {
+  it('should correctly compute tiles for a given zoom level and bounding box', () => {
+    // map bounds: '-137.03852', '85.05113', '126.13032', '-45.05821'
+    // gives:
+    const northWest = { lng: -180, lat: 90 } as LngLat;
+    const southEast = { lng: 180, lat: -23.081054434821873 } as LngLat;
+
+    const result = computeTiles(0, northWest, southEast);
+    const asString = result.map(({ z, x, y }) => `${z}/${x}/${y}`);
+    expect(asString).toEqual(['0/0/0']);
+  });
+});

--- a/src/components/Map/climbingTiles/computeTiles.ts
+++ b/src/components/Map/climbingTiles/computeTiles.ts
@@ -11,7 +11,7 @@ import { publishDbgObject } from '../../../utils';
   = y = latitude
 * */
 const getTile = (z: number, { lng, lat }: LngLat): Tile => {
-  const xNorm = (lng + 180) / 360;
+  const xNorm = ((lng + 180) % 360) / 360;
   const x = Math.floor(xNorm * Math.pow(2, z));
 
   const yRad = (lat * Math.PI) / 180;

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -378,5 +378,5 @@ export default {
 
   weather: 'Počasí',
 
-  'climbing_tiles.stats': `Obnovuje se: 1× / noc<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__`,
+  'climbing_tiles.stats': `Obnovuje se: 1× / noc<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hodina`,
 };

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -429,5 +429,5 @@ export default {
 
   weather: 'Weather',
 
-  'climbing_tiles.stats': `Refreshed: 1× / night<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__`,
+  'climbing_tiles.stats': `Refreshed: 1× / night<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hour`,
 };

--- a/src/server/climbing-tiles/__tests__/utils.test.ts
+++ b/src/server/climbing-tiles/__tests__/utils.test.ts
@@ -1,0 +1,13 @@
+import { getHoursUntilNextRefresh } from '../addCorsAndCache';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('getHoursUntilNextRefresh', () => {
+  jest.spyOn(Date.prototype, 'getUTCHours').mockReturnValue(2);
+  expect(getHoursUntilNextRefresh()).toBe(0);
+
+  jest.spyOn(Date.prototype, 'getUTCHours').mockReturnValue(3);
+  expect(getHoursUntilNextRefresh()).toBe(23);
+});

--- a/src/server/climbing-tiles/addCorsAndCache.ts
+++ b/src/server/climbing-tiles/addCorsAndCache.ts
@@ -1,0 +1,26 @@
+import type { NextApiResponse } from 'next';
+import vercelJson from '../../../vercel.json';
+
+const REFRESH_TIME = Number(vercelJson.crons[0].schedule.split(' ')[1]);
+
+export const getHoursUntilNextRefresh = () => {
+  const currentTimeUtc = new Date().getUTCHours() + 1; // 1-24 (we ceil 2:29 up to 3)
+  const hoursUntilNextRefresh = (REFRESH_TIME - currentTimeUtc + 24) % 24;
+  return hoursUntilNextRefresh;
+};
+
+const getSwrAge = () => {
+  const hoursUntilNextRefresh = getHoursUntilNextRefresh();
+
+  return hoursUntilNextRefresh > 1
+    ? `, stale-while-revalidate=${hoursUntilNextRefresh * 3600}`
+    : '';
+};
+
+export const addCorsAndCache = (res: NextApiResponse) => {
+  const maxAge = 'max-age=3600, s-maxage=3600'; // update also in `climbing_tiles.stats` message
+  const swrAge = getSwrAge();
+
+  res.setHeader('Access-Control-Allow-Origin', '*'); // wildcard is needed to enable the vercel cache, it ignores the `origin` and caches randomnly one TODO consider Vary header if need be
+  res.setHeader('Cache-Control', `public, ${maxAge}${swrAge}`);
+};

--- a/src/server/climbing-tiles/addCorsAndCache.ts
+++ b/src/server/climbing-tiles/addCorsAndCache.ts
@@ -19,6 +19,10 @@ export const addCorsAndCache = (res: NextApiResponse) => {
   const maxAge = 'max-age=3600, s-maxage=3600'; // update also in `climbing_tiles.stats` message
   const swrAge = getSwrAge();
 
+  if (swrAge) {
+    console.log(`Adding SWR age: ${swrAge}`); // eslint-disable-line no-console
+  }
+
   res.setHeader('Access-Control-Allow-Origin', '*'); // wildcard is needed to enable the vercel cache, it ignores the `origin` and caches randomnly one TODO consider Vary header if need be
   res.setHeader('Cache-Control', `public, ${maxAge}${swrAge}`);
 };

--- a/src/server/climbing-tiles/addCorsAndCache.ts
+++ b/src/server/climbing-tiles/addCorsAndCache.ts
@@ -1,12 +1,10 @@
 import type { NextApiResponse } from 'next';
-import vercelJson from '../../../vercel.json';
 
-const REFRESH_TIME = Number(vercelJson.crons[0].schedule.split(' ')[1]);
+const REFRESH_TIME = 3; // taken from vercel.json cron schedule
 
 export const getHoursUntilNextRefresh = () => {
   const currentTimeUtc = new Date().getUTCHours() + 1; // 1-24 (we ceil 2:29 up to 3)
-  const hoursUntilNextRefresh = (REFRESH_TIME - currentTimeUtc + 24) % 24;
-  return hoursUntilNextRefresh;
+  return (REFRESH_TIME - currentTimeUtc + 24) % 24;
 };
 
 const getSwrAge = () => {

--- a/src/server/climbing-tiles/utils.ts
+++ b/src/server/climbing-tiles/utils.ts
@@ -1,15 +1,7 @@
-import type { NextApiResponse } from 'next';
 import { Client } from 'pg';
 import { OsmResponse } from './overpass/overpassToGeojsons';
 import { ClimbingFeaturesRecords, getClient } from './db';
 import format from 'pg-format';
-
-export const addCorsAndCache = (res: NextApiResponse) => {
-  res.setHeader('Access-Control-Allow-Origin', '*'); // wildcard is needed to enable the vercel cache, it ignores the `origin` and caches randomnly one
-  res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=3600'); // Update also in `climbing_tiles.stats` message
-  // TODO maybe try `stale-while-revalidate=7200`
-  // TODO maybe set longer time right after refresh
-};
 
 type TileStats =
   | {}

--- a/src/server/climbing-tiles/utils.ts
+++ b/src/server/climbing-tiles/utils.ts
@@ -1,16 +1,14 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiResponse } from 'next';
 import { Client } from 'pg';
 import { OsmResponse } from './overpass/overpassToGeojsons';
 import { ClimbingFeaturesRecords, getClient } from './db';
 import format from 'pg-format';
 
-export const addCorsHeaders = (req: NextApiRequest, res: NextApiResponse) => {
-  const origin = req.headers.origin;
-  if (origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  }
+export const addCorsAndCache = (res: NextApiResponse) => {
+  res.setHeader('Access-Control-Allow-Origin', '*'); // wildcard is needed to enable the vercel cache, it ignores the `origin` and caches randomnly one
+  res.setHeader('Cache-Control', 'public, max-age=3600, s-maxage=3600'); // Update also in `climbing_tiles.stats` message
+  // TODO maybe try `stale-while-revalidate=7200`
+  // TODO maybe set longer time right after refresh
 };
 
 type TileStats =

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
   "crons": [
     {
       "path": "/api/climbing-tiles/refresh",
-      "schedule": "0 2 * * *"
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
Cache is set for 1 hour, so after the refresh 3:00 AM UTC, it may still give old results until 4:00 AM UTC.

Also `stale-while-revalidate: until next refresh` used to speed up the data recovery during the day. In theory, it should give the old data until refresh is run, and in background fetch data from backend. This could be useful if we ever want to refresh the data during the day again.

Wildcard is needed to enable the vercel cache, it ignores the `origin` and caches randomnly one

