### PR TITLE
climbingTiles: cache tile 0/0/0 in refresh + some refactors

### DIFF
--- a/src/server/climbing-tiles/__tests__/tileToBBOX.test.ts
+++ b/src/server/climbing-tiles/__tests__/tileToBBOX.test.ts
@@ -1,0 +1,43 @@
+import { tileToBBOX } from '../tileToBBOX';
+import { Tile } from '../../../types';
+
+describe('tileToBBOX', () => {
+  // -180      180
+  // +-----------+ 85
+  // |           |
+  // +-----------+ -85
+  it('should return correct BBox for tile 0/0/0', () => {
+    const tile: Tile = { z: 0, x: 0, y: 0 };
+    const bbox = tileToBBOX(tile);
+    expect(bbox[0]).toBe(-180);
+    expect(bbox[1]).toBeCloseTo(-85.0511, 3);
+    expect(bbox[2]).toBe(180);
+    expect(bbox[3]).toBeCloseTo(85.0511, 3);
+  });
+
+  // +-----+
+  // | X   |
+  // |     |
+  // +-----+
+  it('should return correct BBox for tile 1/0/0', () => {
+    const tile: Tile = { z: 1, x: 0, y: 0 };
+    const bbox = tileToBBOX(tile);
+    expect(bbox[0]).toBe(-180);
+    expect(bbox[1]).toBe(0);
+    expect(bbox[2]).toBe(0);
+    expect(bbox[3]).toBeCloseTo(85.0511, 3);
+  });
+
+  // +-----+
+  // |     |
+  // |   X |
+  // +-----+
+  it('should return correct BBox for tile 1/1/1', () => {
+    const tile: Tile = { z: 1, x: 1, y: 1 };
+    const bbox = tileToBBOX(tile);
+    expect(bbox[0]).toBe(0);
+    expect(bbox[1]).toBeCloseTo(-85.0511, 3);
+    expect(bbox[2]).toBe(180);
+    expect(bbox[3]).toBe(0);
+  });
+});

--- a/src/server/climbing-tiles/db.ts
+++ b/src/server/climbing-tiles/db.ts
@@ -1,4 +1,5 @@
 import { Client } from 'pg';
+import { CTFeature } from '../../types';
 
 export type ClimbingFeaturesRecords = {
   type: string;
@@ -9,7 +10,7 @@ export type ClimbingFeaturesRecords = {
   count: number;
   lon: number;
   lat: number;
-  geojson: string;
+  geojson: CTFeature;
 }[];
 
 if (!global.db) {

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -11,6 +11,7 @@ import {
   centerGeometry,
   recordsFactory,
 } from './refreshClimbingTilesHelpers';
+import { cacheTile000 } from './getClimbingTile';
 
 const fetchFromOverpass = async () => {
   if (process.env.NODE_ENV === 'development') {
@@ -179,14 +180,15 @@ export const refreshClimbingTiles = async () => {
 
   await client.query('TRUNCATE TABLE climbing_tiles_cache');
 
+  log('Caching tile 0/0/0');
+  await cacheTile000(records);
+
   const buildDuration = Math.round(performance.now() - start);
   log(`Duration: ${buildDuration} ms`);
   log('Done.');
 
   await updateStats(data, getBuildLog(), buildDuration, tileStats, records);
   await closeClient(client);
-
-  // consider cache the tile 0/0/0 here - it takes too long to compute (15s)
 
   return getBuildLog();
 };

--- a/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
+++ b/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
@@ -1,6 +1,7 @@
 import { GeojsonFeature } from './overpass/overpassToGeojsons';
 import { LineString, LonLat, Point } from '../../services/types';
 import { ClimbingFeaturesRecords } from './db';
+import { CTFeature } from '../../types';
 
 export const centerGeometry = (
   feature: GeojsonFeature,
@@ -25,13 +26,12 @@ const firstPointGeometry = (
 const prepareGeojson = (
   type: string,
   { id, geometry, properties }: GeojsonFeature,
-) =>
-  JSON.stringify({
-    type: 'Feature',
-    id,
-    geometry,
-    properties: { ...properties, type },
-  });
+): CTFeature => ({
+  type: 'Feature',
+  id,
+  geometry,
+  properties: { ...properties, type },
+});
 
 const removeDiacritics = (str: string) =>
   str?.normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Feature } from 'geojson';
+
 export type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
 
 export type Tile = { z: number; x: number; y: number };
@@ -10,3 +12,5 @@ export type ClimbingStatsResponse = {
   groupsWithNameCount: number;
   routesCount: number;
 };
+
+export type CTFeature = Feature;


### PR DESCRIPTION
The tile 0/0/0 had to download all the data in DB and then compute the optimized tile to grid 500x500 cells. Sometimes it took > 15s.

Now, it is done during the refresh process, when all the records are in memory, and thus is blazing fast.