### PR TITLE
climbingTiles: use REST XATA in getClimbingTile()

### DIFF
--- a/src/server/climbing-tiles/db.ts
+++ b/src/server/climbing-tiles/db.ts
@@ -1,5 +1,6 @@
 import { Client } from 'pg';
 import { CTFeature } from '../../types';
+import { fetchJson } from '../../services/fetch';
 
 export type ClimbingFeaturesRecords = {
   type: string;
@@ -17,6 +18,9 @@ if (!global.db) {
   global.db = { pool: false };
 }
 
+const XATA_DATABASE = 'osmapp_db:pr2'; //X
+const XATA_REST_URL = `https://osmapp-tvgiad.us-east-1.xata.sh/db/${XATA_DATABASE}/sql`;
+
 export async function getClient(): Promise<Client> {
   if (!process.env.XATA_PASSWORD) {
     throw new Error('XATA_PASSWORD must be set');
@@ -28,7 +32,7 @@ export async function getClient(): Promise<Client> {
       password: process.env.XATA_PASSWORD,
       host: 'us-east-1.sql.xata.sh',
       port: 5432,
-      database: 'osmapp_db:main',
+      database: XATA_DATABASE,
       ssl: {
         rejectUnauthorized: false,
       },
@@ -45,3 +49,53 @@ export async function closeClient(client: Client): Promise<void> {
   await client.end();
   global.db.pool = false;
 }
+
+type SQLResponseJSON = {
+  columns: { name: string; type: string }[];
+  total: number;
+  warning?: string;
+  records: Record<string, any>[];
+};
+export const xataRestQuery = async (statement: string, params?: any[]) => {
+  const headers = {
+    Authorization: `Bearer ${process.env.XATA_PASSWORD}`,
+    'Content-Type': 'application/json',
+  };
+  const result = await fetchJson<SQLResponseJSON>(XATA_REST_URL, {
+    nocache: true,
+    headers,
+    method: 'POST',
+    body: JSON.stringify({
+      statement: statement,
+      params: params,
+    }),
+  });
+
+  return result;
+};
+
+export const xataRestQueryPaginated = async (
+  statement: string,
+  params?: any[],
+) => {
+  const LIMIT = 1000;
+
+  let offset = 0;
+  let allRecords: any[] = [];
+  let hasMore = true;
+
+  while (hasMore) {
+    const paginatedStatement = `${statement} LIMIT ${LIMIT} OFFSET ${offset}`;
+    console.log(`Executing paginated query: ${paginatedStatement}`); //eslint-disable-line no-console
+    const result = await xataRestQuery(paginatedStatement, params);
+
+    allRecords = allRecords.concat(result.records);
+    if (result.records.length >= LIMIT) {
+      offset += LIMIT;
+    } else {
+      hasMore = false;
+    }
+  }
+
+  return allRecords;
+};

--- a/src/server/climbing-tiles/getClimbingTile.ts
+++ b/src/server/climbing-tiles/getClimbingTile.ts
@@ -1,4 +1,9 @@
-import { ClimbingFeaturesRecords, closeClient, getClient } from './db';
+import {
+  ClimbingFeaturesRecords,
+  getClient,
+  xataRestQuery,
+  xataRestQueryPaginated,
+} from './db';
 import { tileToBBOX } from './tileToBBOX';
 import { CTFeature, Tile } from '../../types';
 import { buildTileGeojson } from './buildTileGeojson';
@@ -19,7 +24,6 @@ const ZOOM_LEVELS = [0, 6, 9, 12]; // the zoom level is fetched, when Map reache
 
 export const getClimbingTile = async ({ z, x, y }: Tile) => {
   const start = performance.now();
-  const client = await getClient();
   const isOptimizedToGrid = z <= 6;
   const hasRoutes = z == 12;
   if (!ZOOM_LEVELS.includes(z)) {
@@ -27,13 +31,13 @@ export const getClimbingTile = async ({ z, x, y }: Tile) => {
   }
 
   const cacheKey = `${z}/${x}/${y}`;
-  const cache = await client.query(
-    `SELECT tile_geojson FROM climbing_tiles_cache WHERE zxy = $1`,
+  const cache = await xataRestQuery(
+    'SELECT tile_geojson FROM climbing_tiles_cache WHERE zxy = $1',
     [cacheKey],
   );
-  if (cache.rowCount > 0) {
+  if (cache.records.length > 0) {
     logCacheHit(start);
-    return cache.rows[0].tile_geojson as string;
+    return cache.records[0].tile_geojson as string;
   }
 
   const bbox = tileToBBOX({ z, x, y });
@@ -41,19 +45,18 @@ export const getClimbingTile = async ({ z, x, y }: Tile) => {
   const query = hasRoutes
     ? `SELECT geojson FROM climbing_features WHERE type IN ('gym', 'ferrata', 'group', 'route') AND ${bboxCondition}`
     : `SELECT geojson FROM climbing_features WHERE type IN ('gym', 'ferrata', 'group') AND ${bboxCondition}`;
-  const result = await client.query(query);
+  const records = await xataRestQueryPaginated(query);
 
-  const features = result.rows.map((record) => record.geojson as CTFeature);
+  const features = records.map((record) => record.geojson as CTFeature);
   const geojson = buildTileGeojson(isOptimizedToGrid, features, bbox);
 
   const duration = Math.round(performance.now() - start);
   logCacheMiss(duration, geojson.features.length);
 
-  await client.query(
+  await xataRestQuery(
     `INSERT INTO climbing_tiles_cache VALUES ($1, $2, $3, $4) ON CONFLICT (zxy) DO NOTHING`,
-    [cacheKey, geojson, duration, geojson.features.length],
+    [cacheKey, JSON.stringify(geojson), duration, geojson.features.length],
   );
-  await closeClient(client);
 
   return JSON.stringify(geojson);
 };

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -161,7 +161,7 @@ export const refreshClimbingTiles = async () => {
   const data = await fetchFromOverpass();
   log(`Overpass elements: ${data.elements.length}`);
 
-  const records = getNewRecords(data); // ~ 16k records
+  const records = getNewRecords(data); // ~ 55k records
   log(`Records: ${records.length}`);
 
   const columns = Object.keys(records[0]);


### PR DESCRIPTION
The get tile url was often hitting DB concurency limit. Using XATA REST endpoint should solve this. I was initially worried about the performance, but it looks ok.

eg http://localhost:3000/api/climbing-tiles/tile?z=6&x=33&y=22


The REST was not convenient for the tile 0/0/0 as fetching all 55k records by 1000 would be very many requests. But now the tile is cached during refresh (#1127), it is no longer an issue.



