### PR TITLE
images: fix - sort keys in defs, not in FeatureImages

### DIFF
--- a/src/components/FeaturePanel/FeatureImages/FeatureImages.tsx
+++ b/src/components/FeaturePanel/FeatureImages/FeatureImages.tsx
@@ -53,7 +53,7 @@ export const FeatureImages = () => {
   return (
     <Wrapper>
       <Slider>
-        {naturalSort(images, (item) => item.def.k).map((item, index) => (
+        {images.map((item, index) => (
           <Image
             key={item.image.imageUrl}
             def={item.def}

--- a/src/services/images/__tests__/getImageDefs.test.ts
+++ b/src/services/images/__tests__/getImageDefs.test.ts
@@ -79,7 +79,9 @@ test('conversion', () => {
 test('correctly sorted', () => {
   const tags = {
     'wikimedia_commons:3': 'Category:1.jpg',
+    'wikimedia_commons:10': 'File:15.jpg',
     wikidata: 'Q123',
+    'wikimedia_commons:9': 'File:14.jpg',
     wikimedia_commons: 'File:1.jpg',
     image: 'http://blah blah url',
     image2: 'File:image2 like commons image name',
@@ -90,6 +92,8 @@ test('correctly sorted', () => {
 
   expect(getImageDefs(tags, 'node', center).map((def: any) => def.k)).toEqual([
     'wikimedia_commons',
+    'wikimedia_commons:9',
+    'wikimedia_commons:10',
     'image',
     'image2',
     'image:2',

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -97,6 +97,9 @@ export const getInstantImage = ({ k, v }: KeyValue): ImageType | null => {
   return null; // API call needed
 };
 
+const naturalKeySorter = ([a]: string[], [b]: string[]) =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
 const wikipedia = ([k, _]) => k.match(/^wikipedia(\d*|:.*)$/);
 const wikidata = ([k, _]) => k.match(/^wikidata(\d*|:.*)$/);
 const image = ([k, v]) =>
@@ -112,7 +115,7 @@ const panoramax = ([k, _]) => k === 'panoramax';
 const getImagesFromTags = (tags: FeatureTags) => {
   const entries = Object.entries(tags);
   const imageTags = [
-    ...entries.filter(commonsFile),
+    ...entries.filter(commonsFile).sort(naturalKeySorter),
     ...entries.filter(image),
     ...entries.filter(wikipedia),
     ...entries.filter(wikidata),


### PR DESCRIPTION
The imageDefs keys are designed to show Wikimedia Commons Category as last item. This is especially needed for #1130, as the image load longer.

Broken since https://github.com/zbycz/osmapp/pull/810

e.g. way/295140461