### PR TITLE
layers: introduce emptyStyle when missing baseMap selected

### DIFF
--- a/src/components/Map/MapFooter/AttributionLinks.tsx
+++ b/src/components/Map/MapFooter/AttributionLinks.tsx
@@ -4,6 +4,7 @@ import uniq from 'lodash/uniq';
 import { Layer, useMapStateContext, View } from '../../utils/MapStateContext';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { Translation } from '../../../services/intl';
+import { isUrlForRasterLayer } from '../helpers';
 
 export const Attribution = ({ label, link, title }) => (
   <>
@@ -53,7 +54,13 @@ export const AttributionLinks = () => {
         }
 
         const userLayer = userLayers.find(({ url }) => url === layerUrl);
-        return userLayer?.attribution || decodeURI(new URL(layerUrl)?.hostname);
+        if (userLayer?.attribution) {
+          return userLayer?.attribution;
+        }
+        if (isUrlForRasterLayer(layerUrl)) {
+          return decodeURI(new URL(layerUrl)?.hostname);
+        }
+        return null;
       })
       .filter(Boolean),
   );

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -19,10 +19,11 @@ import { fetchCrags } from '../../../services/fetchCrags';
 import { intl } from '../../../services/intl';
 import { Layer } from '../../utils/MapStateContext';
 import { setUpHover } from './featureHover';
-import { layersWithOsmId } from '../helpers';
+import { isUrlForRasterLayer, layersWithOsmId } from '../helpers';
 import { Theme } from '../../../helpers/theme';
 import { addIndoorEqual, removeIndoorEqual } from './indoor';
 import { addClimbingTilesSource } from '../climbingTiles/climbingTilesSource';
+import { emptyStyle } from '../styles/emptyStyle';
 
 const ofrBasicStyle = {
   ...basicStyle,
@@ -50,7 +51,11 @@ const getBaseStyle = (key: string, currentTheme: Theme): StyleSpecification => {
     return outdoorStyle;
   }
 
-  return getRasterStyle(key, currentTheme);
+  if (isUrlForRasterLayer(key)) {
+    return getRasterStyle(key, currentTheme);
+  }
+
+  return emptyStyle;
 };
 
 const addRasterOverlay = (

--- a/src/components/Map/helpers.ts
+++ b/src/components/Map/helpers.ts
@@ -97,3 +97,7 @@ const isWebglSupported = () => {
 };
 
 export const webglSupported = isBrowser() ? isWebglSupported() : true;
+
+export const isUrlForRasterLayer = (layerUrl: string) => {
+  return layerUrl.match(/^https?:\/\//);
+};

--- a/src/components/Map/styles/emptyStyle.ts
+++ b/src/components/Map/styles/emptyStyle.ts
@@ -1,0 +1,11 @@
+import { GLYPHS } from '../consts';
+import { StyleSpecification } from 'maplibre-gl';
+
+export const emptyStyle = {
+  version: 8,
+  name: 'OSM Bright',
+  sources: {},
+  sprite: [],
+  glyphs: GLYPHS,
+  layers: [],
+} as StyleSpecification;


### PR DESCRIPTION
Preparation if we ever want to remove a layer from osmappLayers. The app would throw an exception. Now it displays empty style.