### PR TITLE
Images: Show the panoramax license

### DIFF
--- a/src/components/FeaturePanel/FeatureImages/Image/InfoButton.tsx
+++ b/src/components/FeaturePanel/FeatureImages/Image/InfoButton.tsx
@@ -7,7 +7,7 @@ import { TooltipButton } from '../../../utils/TooltipButton';
 
 const TooltipContent = ({ image }: { image: ImageType }) => (
   <>
-    {image.description}
+    <span dangerouslySetInnerHTML={{ __html: image.description }} />
     <br />
     <a href={image.linkUrl} target="_blank">
       {image.link}

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -116,6 +116,8 @@ export default {
   'featurepanel.show_tags': 'Zeige Tags an',
   'featurepanel.show_objects_around': 'Zeige Orte in der Nähe an',
   'featurepanel.uncertain_image': 'Dies ist das nächste Street View Bild von __from__. Es kann ein anders Objekt zeigen.',
+  'featurepanel.image_description': '__provider__ Bild vom __date__',
+  'featurepanel.image_license': 'Lizenziert unter __license__',
   'featurepanel.inline_edit_title': 'Bearbeiten',
   'featurepanel.objects_around': 'Orte in der Nähe',
   'featurepanel.more_in_openplaceguide': 'Weitere Information auf __instanceName__',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -181,6 +181,8 @@ export default {
   'featurepanel.show_tags': 'Show tags',
   'featurepanel.show_objects_around': 'Show nearby objects',
   'featurepanel.uncertain_image': 'This is the closest street view image from __from__. It may be inaccurate.',
+  'featurepanel.image_description': '__provider__ image from __date__',
+  'featurepanel.image_license': 'Licensed under __license__',
   'featurepanel.inline_edit_title': 'Edit',
   'featurepanel.objects_around': 'Nearby objects',
   'featurepanel.more_in_openplaceguide': 'More information on __instanceName__',

--- a/src/services/images/__tests__/getImageFromApi.test.ts
+++ b/src/services/images/__tests__/getImageFromApi.test.ts
@@ -11,6 +11,7 @@ import {
   WIKIPEDIA_CS,
 } from './apiMocks.fixture';
 import * as makeCategoryImageModule from '../makeCategoryImage';
+import english from '../../../locales/vocabulary';
 
 jest.mock('../makeCategoryImage', () => ({
   makeCategoryImage: jest.fn(),
@@ -32,6 +33,16 @@ beforeEach(() => {
   jest.restoreAllMocks();
   expect.hasAssertions();
 });
+
+jest.mock('../../intl', () => ({
+  intl: { lang: 'en' },
+  t: (key, obj) => {
+    return Object.entries(obj).reduce(
+      (acc, [key, val]) => acc.replace(`__${key}__`, val),
+      english[key],
+    );
+  },
+}));
 
 test('ImageFromCenter - mapillary', async () => {
   mockApi(MAPILLARY);

--- a/src/services/images/getImageFromCenterFactory.ts
+++ b/src/services/images/getImageFromCenterFactory.ts
@@ -1,3 +1,4 @@
+import { t, intl } from '../intl';
 import { Position } from '../types';
 import { ImageType } from './getImageDefs';
 
@@ -19,6 +20,7 @@ type ImageProvider<T> = {
   getImageLink: (img: T) => string;
   getImageLinkUrl: (img: T) => string;
   getPanoUrl: (img: T) => string;
+  getDescription?: (img: T, defaultDescription: string) => string;
 };
 
 export const getImageFromCenterFactory =
@@ -34,6 +36,7 @@ export const getImageFromCenterFactory =
       getImageLink,
       getImageLinkUrl,
       getPanoUrl,
+      getDescription,
     }: ImageProvider<T>,
   ) =>
   async (poiCoords: Position): Promise<ImageType | null> => {
@@ -62,10 +65,18 @@ export const getImageFromCenterFactory =
 
     const imageToUse = sorted[0];
 
+    const defaultDescription = t('featurepanel.image_description', {
+      provider,
+      date: getImageDate(imageToUse).toLocaleString(intl.lang),
+    });
+
+    const description =
+      getDescription?.(imageToUse, defaultDescription) ?? defaultDescription;
+
     return {
       provider,
+      description,
       imageUrl: getImageUrl(imageToUse),
-      description: `${provider} image from ${getImageDate(imageToUse).toLocaleString()}`,
       linkUrl: getImageLinkUrl(imageToUse),
       link: getImageLink(imageToUse),
       uncertainImage: true,

--- a/src/services/images/getPanoramaxImage.ts
+++ b/src/services/images/getPanoramaxImage.ts
@@ -1,4 +1,5 @@
 import { fetchJson } from '../fetch';
+import { t } from '../intl';
 import { getImageFromCenterFactory } from './getImageFromCenterFactory';
 
 type PanoramaxImage = {
@@ -14,7 +15,14 @@ type PanoramaxImage = {
     'pers:interior_orientation': {
       field_of_view: number;
     };
+    license: string;
   };
+  links: {
+    rel: string;
+    href: string;
+    title?: string;
+    type?: string;
+  }[];
 };
 
 type PanoramaxResponse = {
@@ -35,7 +43,15 @@ export const getPanoramaxImage = getImageFromCenterFactory('Panoramax', {
   getImageUrl: ({ assets }) => assets.sd.href,
   getImageDate: ({ properties }) => new Date(properties.datetime),
   getImageLink: ({ id }) => id,
-  getImageLinkUrl: ({ id, geometry }) =>
-    `https://api.panoramax.xyz/#focus=pic&map=17.44/${geometry.coordinates[0]}/${geometry.coordinates[0]}&pic=${id}`,
+  getImageLinkUrl: ({ id, geometry: { coordinates } }) =>
+    `https://api.panoramax.xyz/#focus=pic&map=17.44/${coordinates[0]}/${coordinates[0]}&pic=${id}`,
   getPanoUrl: ({ assets }) => assets.hd.href,
+  getDescription: ({ links, properties: { license } }, description) => {
+    const licenseHref = links.find(({ rel }) => rel === 'license')?.href;
+    const licenseHtml = licenseHref
+      ? `<a href="${licenseHref}">${license}</a>`
+      : license;
+
+    return `${description}<br>${t('featurepanel.image_license', { license: licenseHtml })}`;
+  },
 });


### PR DESCRIPTION
### Description

In #1116 @atchisson informed us that panoramax images can implement the license they want and that osmapp should show that license. 

### Example links

### Screenshots

![image](https://github.com/user-attachments/assets/d3581641-fa8b-4bcf-9a51-57eff956cec6)

### Checklist

- [x] all texts are localized (in vocabulary.ts)
