### PR TITLE
Images: Load og-image for features

### DIFF
--- a/pages/api/load-og-image.tsx
+++ b/pages/api/load-og-image.tsx
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PROJECT_NAME, PROJECT_URL } from '../../src/services/project';
+
+// Abort after approximately 200kb
+const READ_LIMIT = 200_000;
+
+const regex1 = /<meta\s+property="og:image"\s+content="([^"]+)"/;
+const regex2 = /<meta\s+content="([^"]+)"\s+property="og:image"/;
+
+const loadOgImage = async (url: string): Promise<string | null> => {
+  const abortController = new AbortController();
+
+  const response = await fetch(url, {
+    signal: abortController.signal,
+    headers: {
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'User-Agent': `${PROJECT_NAME} (+${PROJECT_URL})`,
+    },
+  });
+
+  const reader = response.body.getReader();
+
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+
+    buffer += decoder.decode(value, { stream: true });
+
+    const match = buffer.match(regex1) ?? buffer.match(regex2);
+    if (match) {
+      abortController.abort();
+      return match[1];
+    }
+
+    if (done || buffer.length > READ_LIMIT) {
+      break;
+    }
+  }
+
+  return null;
+};
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { href } = req.query;
+  if (!href || Array.isArray(href)) {
+    return res
+      .status(400)
+      .json({ error: 'provide an url under the query parameter `href`' });
+  }
+
+  const ogImage = await loadOgImage(href);
+
+  if (ogImage) {
+    return res.status(200).json({ ogImage });
+  }
+  return res.status(404).json({ error: 'og:image not found/available' });
+};

--- a/src/components/FeaturePanel/renderers/WebsiteRenderer.tsx
+++ b/src/components/FeaturePanel/renderers/WebsiteRenderer.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import Language from '@mui/icons-material/Language';
+import { displayForm, protocol } from './helpers';
 
-const protocol = /^\w+:\/\//;
 const fixHttp = (url: string) => (url.match(protocol) ? url : `http://${url}`);
-const displayForm = (url: string) =>
-  decodeURI(url.replace(protocol, '').replace(/([^/]+)\/$/, '$1'));
 
 export const WebsiteRenderer = ({ v }) => (
   <>

--- a/src/components/FeaturePanel/renderers/helpers.ts
+++ b/src/components/FeaturePanel/renderers/helpers.ts
@@ -1,0 +1,3 @@
+export const protocol = /^\w+:\/\//;
+export const displayForm = (url: string) =>
+  decodeURI(url.replace(protocol, '').replace(/([^/]+)\/$/, '$1'));

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -118,6 +118,7 @@ export default {
   'featurepanel.uncertain_image': 'Dies ist das nächste Street View Bild von __from__. Es kann ein anders Objekt zeigen.',
   'featurepanel.image_description': '__provider__ Bild vom __date__',
   'featurepanel.image_license': 'Lizenziert unter __license__',
+  'featurepanel.og_image': 'Ausgewähltes Bild von __url__',
   'featurepanel.inline_edit_title': 'Bearbeiten',
   'featurepanel.objects_around': 'Orte in der Nähe',
   'featurepanel.more_in_openplaceguide': 'Weitere Information auf __instanceName__',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -183,6 +183,7 @@ export default {
   'featurepanel.uncertain_image': 'This is the closest street view image from __from__. It may be inaccurate.',
   'featurepanel.image_description': '__provider__ image from __date__',
   'featurepanel.image_license': 'Licensed under __license__',
+  'featurepanel.og_image': 'Featured image from __url__',
   'featurepanel.inline_edit_title': 'Edit',
   'featurepanel.objects_around': 'Nearby objects',
   'featurepanel.more_in_openplaceguide': 'More information on __instanceName__',

--- a/src/services/images/__tests__/getImageDefs.test.ts
+++ b/src/services/images/__tests__/getImageDefs.test.ts
@@ -57,6 +57,12 @@ test('conversion', () => {
       instant: false,
     },
     {
+      type: 'tag',
+      k: 'website',
+      v: 'https://site-may-have-og-image',
+      instant: false,
+    },
+    {
       type: 'center',
       service: 'panoramax',
       center: [14, 50],

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -20,7 +20,7 @@ export type ImageType = {
   link: string;
   uncertainImage?: true;
   sameUrlResolvedAlsoFrom?: ImageType[]; // only 1 level
-  panoramaUrl?: string; // only for Mapillary (ImageDefFromCenter)
+  panoramaUrl?: string; // only for street side photography (ImageDefFromCenter)
   provider?: string;
 };
 
@@ -111,6 +111,7 @@ const commonsCategory = ([k, v]) => commons(k) && v.startsWith('Category:');
 
 const mapillary = ([k, v]) => k === 'mapillary' && v.match(/^\d+$/);
 const panoramax = ([k, _]) => k === 'panoramax';
+const website = ([k, _]) => k === 'website' || k === 'contact:website';
 
 const getImagesFromTags = (tags: FeatureTags) => {
   const entries = Object.entries(tags);
@@ -122,6 +123,7 @@ const getImagesFromTags = (tags: FeatureTags) => {
     ...entries.filter(commonsCategory),
     ...entries.filter(mapillary),
     ...entries.filter(panoramax),
+    ...entries.filter(website),
   ];
 
   return imageTags


### PR DESCRIPTION
### Description

There is a very old idea to fetch the og:image (see #132) from websites which provide one. Here I've implemented it.

### Example links

https://osmapp-git-fork-dlurak-external-og-image-osm-app-team.vercel.app/node/11243721137
https://osmapp-git-fork-dlurak-external-og-image-osm-app-team.vercel.app/node/313822575

### Screenshots

### Checklist

- [x] server-side-rendering (SSR)
- [x] all texts are localized (in vocabulary.ts)
