### PR TITLE
FeaturePanel: Show intervals always as `HH:MM` or when needed as `HH:MM:SS`

### DIFF
--- a/src/components/FeaturePanel/Properties/__tests__/interval.test.ts
+++ b/src/components/FeaturePanel/Properties/__tests__/interval.test.ts
@@ -1,0 +1,27 @@
+import { humanInterval } from '../interval';
+
+describe('splitDateRangeAtMidnight', () => {
+  it('should format valid intervals correclty', () => {
+    expect(humanInterval('6')).toEqual('00:06');
+    expect(humanInterval('12')).toEqual('00:12');
+    expect(humanInterval('3:59')).toEqual('03:59');
+    expect(humanInterval('3:59')).toEqual('03:59');
+    expect(humanInterval('17:59:30')).toEqual('17:59:30');
+    expect(humanInterval('00:00:30')).toEqual('00:00:30');
+  });
+
+  it('should wrap too big values', () => {
+    expect(humanInterval('120')).toEqual('02:00');
+    expect(humanInterval('150')).toEqual('02:30');
+    expect(humanInterval('00:00:90')).toEqual('00:01:30');
+    expect(humanInterval('00:59:90')).toEqual('01:00:30');
+    expect(humanInterval('00:60')).toEqual('01:00');
+  });
+
+  it('should throw for invalid intervals', () => {
+    // From taginfo
+    expect(() => humanInterval('irregular')).toThrow(Error);
+    expect(() => humanInterval('school')).toThrow(Error);
+    expect(() => humanInterval('00:15-00:20')).toThrow(Error);
+  });
+});

--- a/src/components/FeaturePanel/Properties/interval.ts
+++ b/src/components/FeaturePanel/Properties/interval.ts
@@ -1,0 +1,58 @@
+const withSeconds = /^(\d+):(\d{2}):(\d{2})$/;
+const withHours = /^(\d{1,2}):(\d{2})$/;
+const onlyMinutes = /^\d+$/;
+
+type Interval = {
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+const parseInterval = (v: string): Interval => {
+  const matchWithSeconds = v.match(withSeconds);
+  if (matchWithSeconds) {
+    return {
+      hours: parseInt(matchWithSeconds[1], 10),
+      minutes: parseInt(matchWithSeconds[2], 10),
+      seconds: parseInt(matchWithSeconds[3], 10),
+    };
+  }
+
+  const matchWithHours = v.match(withHours);
+  if (matchWithHours) {
+    return {
+      hours: parseInt(matchWithHours[1], 10),
+      minutes: parseInt(matchWithHours[2], 10),
+      seconds: 0,
+    };
+  }
+
+  if (onlyMinutes.test(v)) {
+    return {
+      hours: 0,
+      minutes: parseInt(v, 10),
+      seconds: 0,
+    };
+  }
+
+  throw new Error('Unparsable interval');
+};
+
+export const humanInterval = (v: string) => {
+  let { hours, minutes, seconds } = parseInterval(v.trim());
+
+  minutes += Math.floor(seconds / 60);
+  seconds = seconds % 60;
+
+  hours += Math.floor(minutes / 60);
+  minutes = minutes % 60;
+
+  let hoursStr = hours.toString().padStart(2, '0');
+  let minutesStr = minutes.toString().padStart(2, '0');
+  let secondsStr = seconds.toString().padStart(2, '0');
+
+  if (seconds === 0) {
+    return `${hoursStr}:${minutesStr}`;
+  }
+  return `${hoursStr}:${minutesStr}:${secondsStr}`;
+};

--- a/src/components/FeaturePanel/Properties/renderTag.tsx
+++ b/src/components/FeaturePanel/Properties/renderTag.tsx
@@ -4,6 +4,7 @@ import { slashToOptionalBr } from '../../helpers';
 import { DirectionValue } from './Direction';
 import { osmColorToHex, whiteOrBlackText } from '../helpers/color';
 import styled from '@emotion/styled';
+import { humanInterval } from './interval';
 
 const getEllipsisHumanUrl = (humanUrl: string) => {
   const MAX_LENGTH = 40;
@@ -31,6 +32,13 @@ const getHumanValue = (k: string, v: string, featured: boolean) => {
   }
   if (k.match(/:?wikipedia$/) && v.match(/:/)) {
     return v.split(':', 2)[1];
+  }
+  if (k === 'interval') {
+    try {
+      return humanInterval(v);
+    } catch {
+      return v;
+    }
   }
   if (featured && k === 'wikidata') {
     return `Wikipedia (wikidata)`; // TODO fetch label from wikidata


### PR DESCRIPTION
### Description

There are many different formats for the interval tag on osm: https://wiki.openstreetmap.org/wiki/Key:interval
And sometimes it is mapped wrong, like `120` instead of `02:00`, or `168:00` (once every week)
Tries to always show the interval in either `HH:MM` or when needed `HH:MM:SS`

### Example links

`interval=*`