### PR TITLE
general: Respect safe areas

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -103,7 +103,11 @@ const MyApp = (props: Props) => {
                           <Head>
                             <meta
                               name="viewport"
-                              content="width=device-width, user-scalable=no, initial-scale=1"
+                              content="width=device-width, user-scalable=no, initial-scale=1, viewport-fit=cover"
+                            />
+                            <meta
+                              name="apple-mobile-web-app-status-bar-style"
+                              content="black-translucent"
                             />
                           </Head>
                           <Loading />

--- a/src/components/App/Loading.tsx
+++ b/src/components/App/Loading.tsx
@@ -7,7 +7,7 @@ import { useFeatureContext } from '../utils/FeatureContext';
 
 const Wrapper = styled.div`
   position: absolute;
-  top: 0;
+  top: env(safe-area-inset-top, 0);
   z-index: 1200;
 
   width: 100%;

--- a/src/components/FeaturePanel/FeatureHeading.tsx
+++ b/src/components/FeaturePanel/FeatureHeading.tsx
@@ -41,9 +41,12 @@ const EditNameButton = () => {
   );
 };
 
-const Container = styled.div<{ isStandalone: boolean }>`
-  margin: 20px 0 20px 0;
-  ${({ isStandalone }) => isStandalone && 'padding-bottom: 8px;'}
+const Container = styled.div<{ isStandalone: boolean; isCollapsed: boolean }>`
+  margin-bottom: 20px;
+  ${({ isStandalone, isCollapsed }) =>
+    isStandalone &&
+    isCollapsed &&
+    'padding-bottom: env(safe-area-inset-bottom, 8px);'}
 `;
 
 const HeadingsWrapper = styled.div`
@@ -115,12 +118,17 @@ const SecondaryHeading = styled.h2<{
   ${({ $deleted }) => $deleted && 'text-decoration: line-through;'}
 `;
 
-export const FeatureHeading = React.forwardRef<HTMLDivElement>((_, ref) => {
+type FeatureHeadingProps = { isCollapsed: boolean };
+
+export const FeatureHeading = React.forwardRef<
+  HTMLDivElement,
+  FeatureHeadingProps
+>(({ isCollapsed }, ref) => {
   // thw pwa needs space at the bottom
   const isStandalone = useMediaQuery('(display-mode: standalone)');
 
   return (
-    <Container ref={ref} isStandalone={isStandalone}>
+    <Container ref={ref} isStandalone={isStandalone} isCollapsed={isCollapsed}>
       <Headings />
       <PoiDescription />
 

--- a/src/components/FeaturePanel/FeaturePanel.tsx
+++ b/src/components/FeaturePanel/FeaturePanel.tsx
@@ -37,9 +37,13 @@ const Flex = styled.div`
 
 type FeaturePanelProps = {
   headingRef?: React.Ref<HTMLDivElement>;
+  isCollapsed?: boolean;
 };
 
-export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
+export const FeaturePanel = ({
+  headingRef,
+  isCollapsed,
+}: FeaturePanelProps) => {
   const { feature } = useFeatureContext();
   const [advanced, setAdvanced] = useState(false);
   const [showTags, toggleShowTags] = useToggleState(false);
@@ -69,7 +73,7 @@ export const FeaturePanel = ({ headingRef }: FeaturePanelProps) => {
         <PanelSidePadding>
           {!isMobileMode && <ParentLink />}
 
-          <FeatureHeading ref={headingRef} />
+          <FeatureHeading ref={headingRef} isCollapsed={isCollapsed ?? false} />
           <Stack spacing={1} alignItems="flex-start" sx={{ marginBottom: 1 }}>
             <ClimbingRouteGrade />
             <ClimbingTypeBadge feature={feature} />

--- a/src/components/FeaturePanel/FeaturePanelInDrawer.tsx
+++ b/src/components/FeaturePanel/FeaturePanelInDrawer.tsx
@@ -22,6 +22,7 @@ export const FeaturePanelInDrawer = ({
   const [collapsedHeight, setCollapsedHeight] = React.useState<number>(
     DRAWER_PREVIEW_HEIGHT,
   );
+  const [collapsed, setCollapsed] = React.useState(true);
   const { height: windowHeight } = useScreensize();
   const maxCollapsedHeight = windowHeight / 3;
 
@@ -42,8 +43,9 @@ export const FeaturePanelInDrawer = ({
       className={DRAWER_CLASSNAME}
       collapsedHeight={collapsedHeight}
       scrollRef={scrollRef}
+      onTransitionEnd={(_, open) => setCollapsed(!open)}
     >
-      <FeaturePanel headingRef={headingRef} />
+      <FeaturePanel headingRef={headingRef} isCollapsed={collapsed} />
     </Drawer>
   );
 };

--- a/src/components/FeaturePanel/helpers/Puller.tsx
+++ b/src/components/FeaturePanel/helpers/Puller.tsx
@@ -6,10 +6,12 @@ import { isMobileDevice } from '../../helpers';
 
 const HANDLE_WIDTH = 30;
 const HANDLE_HIP_SLOP = 10;
+const HANDLE_HEIGHT = 6;
+export const PULLER_HEIGHT = HANDLE_HEIGHT + HANDLE_HEIGHT * 2;
 
 const Handle = styled.div`
   width: ${HANDLE_WIDTH}px;
-  height: 6px;
+  height: ${HANDLE_HEIGHT}px;
   margin: auto;
   background-color: ${({ theme }) =>
     theme.palette.mode === 'light' ? grey[300] : grey[900]};
@@ -21,7 +23,7 @@ const PullerContainer = styled.div<{
   $isDesktop: boolean;
   $isClosed: boolean;
 }>`
-  position: absolute;
+  position: sticky;
   top: 0;
   left: calc(50% - ${HANDLE_WIDTH / 2}px - ${HANDLE_HIP_SLOP}px);
   z-index: 1;

--- a/src/components/LayerSwitcher/LayerSwitcher.tsx
+++ b/src/components/LayerSwitcher/LayerSwitcher.tsx
@@ -21,8 +21,20 @@ const LayerSwitcher = () => {
         disableBackdropTransition
         disableSwipeToOpen
       >
-        <div role="presentation" style={{ width: '280px', height: '100%' }}>
-          <ClosePanelButton right onClick={close} style={{ top: 13 }} />
+        <div
+          role="presentation"
+          style={{
+            width: '280px',
+            height: '100%',
+            paddingTop: 'env(safe-area-inset-top, 0)',
+            paddingBottom: 'env(safe-area-inset-bottom, 0)',
+          }}
+        >
+          <ClosePanelButton
+            right
+            onClick={close}
+            style={{ top: 'calc(13px + env(safe-area-inset-top, 0))' }}
+          />
           <LayerSwitcherContent />
         </div>
       </SwipeableDrawer>

--- a/src/components/Map/BrowserMap.tsx
+++ b/src/components/Map/BrowserMap.tsx
@@ -69,7 +69,15 @@ const BrowserMap = () => {
   useUpdateStyle(map, activeLayers, userLayers, mapLoaded, currentTheme);
   usePersistedScaleControl(map);
 
-  return <div ref={mapRef} style={{ height: '100%', width: '100%' }} />;
+  return (
+    <div
+      ref={mapRef}
+      style={{
+        height: '100%',
+        width: '100%',
+      }}
+    />
+  );
 };
 
 const BrowserMapCheck = () => {

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -6,7 +6,6 @@ import BugReport from '@mui/icons-material/BugReport';
 import { Button, CircularProgress } from '@mui/material';
 import { isDesktop, useBoolState } from '../helpers';
 import { MapFooter } from './MapFooter/MapFooter';
-import { SHOW_PROTOTYPE_UI } from '../../config.mjs';
 import { LayerSwitcherButton } from '../LayerSwitcher/LayerSwitcherButton';
 import { MaptilerLogo } from './MapFooter/MaptilerLogo';
 import { TopMenu } from './TopMenu/TopMenu';
@@ -38,7 +37,7 @@ const TopRight = styled.div`
   z-index: 1000;
   padding: 10px;
   right: 0;
-  top: 62px;
+  top: calc(env(safe-area-inset-top) + 62px);
 
   @media ${isDesktop} {
     top: 0;
@@ -48,7 +47,7 @@ const TopRight = styled.div`
 const BottomRight = styled.div`
   position: absolute;
   right: 0;
-  bottom: 0;
+  bottom: env(safe-area-inset-bottom);
   z-index: 1000;
   text-align: right;
   pointer-events: none;
@@ -61,13 +60,6 @@ const BottomRight = styled.div`
   padding: 0 4px 4px 4px;
 `;
 
-const BugReportButton = () => (
-  <Button size="small">
-    <BugReport width="10" height="10" />
-    Nahlásit chybu v mapě
-  </Button>
-);
-
 const NoscriptMessage = () => (
   <noscript>
     <span style={{ position: 'absolute', left: '50%', top: '50%' }}>
@@ -76,12 +68,22 @@ const NoscriptMessage = () => (
   </noscript>
 );
 
+const TopBlur = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: env(safe-area-inset-top);
+  backdrop-filter: blur(4px);
+`;
+
 const Map = () => {
   const { mapLoaded } = useMapStateContext();
 
   return (
     <>
       <BrowserMapDynamic />
+      <TopBlur />
       {!mapLoaded && <Spinner color="secondary" />}
       <NoscriptMessage />
       <TopRight>
@@ -89,7 +91,6 @@ const Map = () => {
         <LayerSwitcherDynamic />
       </TopRight>
       <BottomRight>
-        {SHOW_PROTOTYPE_UI && <BugReportButton />}
         <MaptilerLogo />
         <Weather />
         <MapFooter />

--- a/src/components/Map/behaviour/PersistedScaleControl.ts
+++ b/src/components/Map/behaviour/PersistedScaleControl.ts
@@ -53,7 +53,7 @@ export const usePersistedScaleControl = (map: Map) => {
     });
 
     const addControl = () => {
-      map.addControl(scaleControl);
+      map.addControl(scaleControl, 'bottom-left');
     };
 
     if (map.loaded()) {

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -20,7 +20,7 @@ const TopPanel = styled.div`
   padding: 8px;
   box-sizing: border-box;
 
-  top: 0;
+  top: env(safe-area-inset-top);
   z-index: 1200; // 1100 is PanelWrapper
 
   width: 100%;

--- a/src/components/utils/Drawer.tsx
+++ b/src/components/utils/Drawer.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Global, css } from '@emotion/react';
 import React, { Ref, useState } from 'react';
 import { SwipeableDrawer } from '@mui/material';
-import { Puller } from '../FeaturePanel/helpers/Puller';
+import { Puller, PULLER_HEIGHT } from '../FeaturePanel/helpers/Puller';
 
 type SettingsProps = {
   $collapsedHeight: number;
@@ -12,7 +12,7 @@ type SettingsProps = {
 
 const getPaperStyle = (className: string, offset: number) => css`
   .${className}.MuiDrawer-root > .MuiPaper-root {
-    height: calc(100% - ${offset}px);
+    height: calc(100% - ${offset}px - env(safe-area-inset-top));
     overflow: visible;
     background-color: transparent;
   }
@@ -33,6 +33,7 @@ const Container = styled.div<SettingsProps>`
       ${({ $topOffset }) => $topOffset}px
   );
   overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
 `;
 
 const Content = styled.main`
@@ -70,7 +71,12 @@ export const Drawer = ({
 
   return (
     <>
-      <Global styles={getPaperStyle(className, collapsedHeight + topOffset)} />
+      <Global
+        styles={getPaperStyle(
+          className,
+          collapsedHeight + topOffset + PULLER_HEIGHT,
+        )}
+      />
       <SwipeableDrawer
         anchor="bottom"
         open={open}
@@ -86,7 +92,10 @@ export const Drawer = ({
           onTransitionEnd?.(e, open);
         }}
       >
-        <Container $collapsedHeight={collapsedHeight} $topOffset={topOffset}>
+        <Container
+          $collapsedHeight={collapsedHeight + PULLER_HEIGHT}
+          $topOffset={topOffset}
+        >
           <Puller setOpen={setOpen} open={open} />
           <Content ref={ref}>{children}</Content>
         </Container>

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -1,7 +1,5 @@
 // This file is imported by next.config.mjs, keep clean
 
-export const SHOW_PROTOTYPE_UI = false;
-
 export const DEFAULT_MAP = 'basic';
 
 export const DEBUG_ID_SCHEMA = false;

--- a/src/helpers/GlobalStyle.tsx
+++ b/src/helpers/GlobalStyle.tsx
@@ -16,13 +16,21 @@ const globalStyle = (theme: Theme) => css`
   #__next {
     margin: 0;
     padding: 0;
-    height: 100%;
     border: 0;
     font-family: 'Roboto', sans-serif;
     background-color: ${theme.palette.background.default};
 
     // disable pulling the page around on mobile
     overscroll-behavior: none;
+  }
+
+  body,
+  #__next {
+    height: 100%;
+  }
+
+  html {
+    height: calc(100% + env(safe-area-inset-bottom) + env(safe-area-inset-top));
   }
 
   body {
@@ -106,15 +114,19 @@ const globalStyle = (theme: Theme) => css`
   }
 
   .maplibregl-ctrl-top-right {
-    top: 114px !important;
+    top: calc(114px + env(safe-area-inset-top)) !important;
 
     @media ${isTabletResolution} {
-      top: 54px !important;
+      top: calc(54px + env(safe-area-inset-top)) !important;
     }
 
     @media ${isDesktopResolution} {
-      top: 83px !important;
+      top: calc(83px + env(safe-area-inset-top)) !important;
     }
+  }
+
+  .maplibregl-ctrl-bottom-left {
+    bottom: max(calc(env(safe-area-inset-bottom) - 10px), 0px) !important;
   }
 
   .maplibregl-canvas:not(:focus) {
@@ -148,8 +160,9 @@ const globalStyle = (theme: Theme) => css`
     display: none;
   }
 
-  .MuiAutocomplete-noOptions {
-    padding: 0;
+  .MuiDialog-paperFullScreen {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
   }
 `;
 


### PR DESCRIPTION
### Description

Osmapp can run in standalone mode, but it doesn't respect the deivces safe areas. 
The safe area is the middle of the device where everything is easy to read and use, the very edges are excluded:
![image](https://github.com/user-attachments/assets/09043e3a-072a-4931-b185-954942681636)

This PR is a first exploration how osmapp might respect safe areas with these relevant planned differences to before:
1. Show the map everywhere, even in the status bar, but bur it.
2. Have floating overlays like the attribution or scale control in the safe area.

There are multiple things I still need to change:

- Generalize the extra paddings...
   - Currently I need to set the extra padding for absolutey every element individually, that is especially annoying for mui elements.
- Work with the left and right areas.
   - Currently only top and bottom are respected
  
Overall even these changes already feel way more like a native app on ios

### Screenshots

| Old | New |
| ----- | ------- |
| ![old-general](https://github.com/user-attachments/assets/c0247092-f50e-4954-84a1-a8cdbd18b831) | ![new-general](https://github.com/user-attachments/assets/afd9eeb9-4c85-4300-8171-f2545a4fea76) |
| | ![new-featurepanel](https://github.com/user-attachments/assets/f0cb0fb9-616c-470b-b8d1-f649ac95991a) |