### PR TITLE
images: fix category image on server

### DIFF
--- a/src/services/images/getImageFromApi.ts
+++ b/src/services/images/getImageFromApi.ts
@@ -49,7 +49,7 @@ const fetchCommonsCategory = async (k: string, v: string): ImagePromise => {
   const thumbs = imageInfos
     .filter(({ url }) => !isAudioUrl(url))
     .map(({ thumburl }) => thumburl);
-  const imageUrl = await makeCategoryImage(thumbs.slice(0, 10)); // TODO compute the masonry based on the request and only fetch the fitting images
+  const imageUrl = await makeCategoryImage(thumbs.slice(0, 10)); // TODO compute the masonry from image sizes in response -> only fetch the fitting images
   if (!imageUrl) {
     return null;
   }

--- a/src/services/images/makeCategoryImage.ts
+++ b/src/services/images/makeCategoryImage.ts
@@ -1,3 +1,5 @@
+import { isServer } from '../../components/helpers';
+
 const retina = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
 const WIDTH = 300 * retina;
 const HEIGHT = 238 * retina;
@@ -114,6 +116,10 @@ export const placeImageToCanvas = (
 export const makeCategoryImage = async (
   thumbsUrls: string[],
 ): Promise<string> => {
+  if (isServer()) {
+    return thumbsUrls[0];
+  }
+
   const canvas = document.createElement('canvas');
   canvas.width = WIDTH;
   canvas.height = HEIGHT;


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

The canvas with collage should be created only in browser. On server (while requesting og:image) we return only the first thumb.

### Example links

http://localhost:3000/api/og-image?id=r1151274

```
# only in case, where Category would be the first image

op:relation["wikimedia_commons"~"Category"][!"wikipedia"][!"wikidata"]
```

