### PR TITLE
climbing: refactor - extract onPointClick() to utils

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/Points/Anchor.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Anchor.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { useConfig } from '../../config';
 import { PointProps } from './pointTypes';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
+import { usePointClickHandler } from '../utils';
 
 export const Anchor = ({
   x,
   y,
   isPointSelected,
-  onClick,
+  pointIndex,
   pointerEvents,
 }: PointProps) => {
   const config = useConfig();
   const { photoZoom } = useClimbingContext();
+  const onClick = usePointClickHandler(pointIndex);
   const size = 5;
 
   const foregroundColor = isPointSelected

--- a/src/components/FeaturePanel/Climbing/Editor/Points/Bolt.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Bolt.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
 import { useConfig } from '../../config';
 import { PointProps } from './pointTypes';
+import { usePointClickHandler } from '../utils';
 
 export const Bolt = ({
   x,
   y,
   isPointSelected,
-  onClick,
   pointerEvents,
+  pointIndex,
 }: PointProps) => {
   const { isEditMode, photoZoom } = useClimbingContext();
+  const onClick = usePointClickHandler(pointIndex);
+
   const config = useConfig();
   const size = 14;
   const strokeWidth = 2.5;

--- a/src/components/FeaturePanel/Climbing/Editor/Points/Piton.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Piton.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { useConfig } from '../../config';
 import { PointProps } from './pointTypes';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
+import { usePointClickHandler } from '../utils';
 
 export const Piton = ({
   x,
   y,
   isPointSelected,
-  onClick,
   pointerEvents,
+  pointIndex,
 }: PointProps) => {
   const config = useConfig();
   const { photoZoom } = useClimbingContext();
+  const onClick = usePointClickHandler(pointIndex);
 
   const foregroundColor = isPointSelected
     ? config.anchorColorSelected

--- a/src/components/FeaturePanel/Climbing/Editor/Points/Point.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Point.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
 import { useConfig } from '../../config';
 import { useMobileMode } from '../../../../helpers';
+import { usePointClickHandler } from '../utils';
 
 const ClickableArea = styled.circle``;
 
@@ -41,22 +41,11 @@ const usePointColor = (type, isHovered) => {
   };
 };
 
-export const Point = ({
-  x,
-  y,
-  onPointInSelectedRouteClick,
-  type,
-  index,
-  routeNumber,
-}) => {
+export const Point = ({ x, y, type, index, routeNumber }) => {
   const [isHovered, setIsHovered] = useState(false);
   const {
     setPointSelectedIndex,
-    setIsPointMoving,
     setIsPointClicked,
-    isPointMoving,
-    pointElement,
-    setPointElement,
     setRouteIndexHovered,
     photoZoom,
     getCurrentPath,
@@ -97,19 +86,7 @@ export const Point = ({
     e.stopPropagation();
   };
 
-  const onPointMouseUp = (e) => {
-    // @TODO unify with RouteMarks.tsx
-    if (!isPointMoving) {
-      onPointInSelectedRouteClick(e);
-      setPointElement(pointElement !== null ? null : e.currentTarget);
-      setPointSelectedIndex(index);
-      setIsPointMoving(false);
-      setIsPointClicked(false);
-      e.stopPropagation();
-      e.preventDefault();
-    }
-  };
-
+  const onPointMouseUp = usePointClickHandler(index);
   const isTouchDevice = 'ontouchstart' in window;
 
   const commonProps = {
@@ -143,6 +120,7 @@ export const Point = ({
       <ClickableArea
         fill="transparent"
         r={isTouchDevice ? 20 : 10}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonProps}
       >
         {title}
@@ -154,6 +132,7 @@ export const Point = ({
         r={isTouchDevice ? 7 : 4}
         $isHovered={isHovered}
         $isPointSelected={isPointOnRouteSelected}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...commonProps}
       >
         {title}

--- a/src/components/FeaturePanel/Climbing/Editor/Points/Sling.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Sling.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { useConfig } from '../../config';
 import { PointProps } from './pointTypes';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
+import { usePointClickHandler } from '../utils';
 
 export const Sling = ({
   x,
   y,
   isPointSelected,
-  onClick,
+  pointIndex,
   pointerEvents,
 }: PointProps) => {
   const config = useConfig();
   const { photoZoom } = useClimbingContext();
+  const onClick = usePointClickHandler(pointIndex);
 
   const foregroundColor = isPointSelected
     ? config.anchorColorSelected

--- a/src/components/FeaturePanel/Climbing/Editor/Points/UnfinishedPoint.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/UnfinishedPoint.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import { useClimbingContext } from '../../contexts/ClimbingContext';
 import { useConfig } from '../../config';
 import { PointProps } from './pointTypes';
+import { usePointClickHandler } from '../utils';
 
 export const UnfinishedPoint = ({
   x,
   y,
   isPointSelected,
-  onClick,
+  pointIndex,
   pointerEvents,
 }: PointProps) => {
   const { isEditMode, photoZoom } = useClimbingContext();
+  const onClick = usePointClickHandler(pointIndex);
   const config = useConfig();
+
   const strokeWidth = 1;
   const size = 12;
   const dx = x - size / 2 - strokeWidth / 2;

--- a/src/components/FeaturePanel/Climbing/Editor/Points/pointTypes.ts
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/pointTypes.ts
@@ -4,4 +4,5 @@ export type PointProps = {
   isPointSelected: boolean;
   onClick?: (e: any) => void;
   pointerEvents?: string;
+  pointIndex: number;
 };

--- a/src/components/FeaturePanel/Climbing/Editor/RouteMarks.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RouteMarks.tsx
@@ -12,26 +12,15 @@ import { UnfinishedPoint } from './Points/UnfinishedPoint';
 type Props = {
   route: ClimbingRoute;
   routeNumber: number;
-  onPointInSelectedRouteClick: (event: React.MouseEvent<any>) => void;
 };
 
-export const RouteMarks = ({
-  route,
-  routeNumber,
-  onPointInSelectedRouteClick,
-}: Props) => {
+export const RouteMarks = ({ route, routeNumber }: Props) => {
   const {
     getPixelPosition,
     isPointSelected,
     getMachine,
     getPathForRoute,
     isRouteSelected,
-    pointElement,
-    isPointMoving,
-    setPointElement,
-    setPointSelectedIndex,
-    setIsPointMoving,
-    setIsPointClicked,
     isOtherRouteSelected,
     isEditMode,
   } = useClimbingContext();
@@ -40,19 +29,6 @@ export const RouteMarks = ({
   return (
     <>
       {getPathForRoute(route).map(({ x, y, type }, index) => {
-        const onMarkedPointClick = (e: any) => {
-          // @TODO unify with Point.tsx
-          if (!isPointMoving) {
-            onPointInSelectedRouteClick(e);
-            setPointElement(pointElement !== null ? null : e.currentTarget);
-            setPointSelectedIndex(index);
-            setIsPointMoving(false);
-            setIsPointClicked(false);
-            e.stopPropagation();
-            e.preventDefault();
-          }
-        };
-
         const isBoltVisible = !isOtherSelected && type === 'bolt';
         const isAnchorVisible = !isOtherSelected && type === 'anchor';
         const isSlingVisible = !isOtherSelected && type === 'sling';
@@ -82,7 +58,7 @@ export const RouteMarks = ({
                 y={position.y}
                 isPointSelected={isActualPointSelected}
                 pointerEvents={pointerEvents}
-                onClick={onMarkedPointClick}
+                pointIndex={index}
               />
             )}
             {isPitonVisible && (
@@ -91,7 +67,7 @@ export const RouteMarks = ({
                 y={position.y}
                 isPointSelected={isActualPointSelected}
                 pointerEvents={pointerEvents}
-                onClick={onMarkedPointClick}
+                pointIndex={index}
               />
             )}
             {isSlingVisible && (
@@ -100,7 +76,7 @@ export const RouteMarks = ({
                 y={position.y}
                 isPointSelected={isActualPointSelected}
                 pointerEvents={pointerEvents}
-                onClick={onMarkedPointClick}
+                pointIndex={index}
               />
             )}
             {isAnchorVisible && (
@@ -109,7 +85,7 @@ export const RouteMarks = ({
                 y={position.y}
                 isPointSelected={isActualPointSelected}
                 pointerEvents={pointerEvents}
-                onClick={onMarkedPointClick}
+                pointIndex={index}
               />
             )}
             {isUnfinishedPointVisible && (
@@ -118,14 +94,13 @@ export const RouteMarks = ({
                 y={position.y}
                 isPointSelected={isActualPointSelected}
                 pointerEvents={pointerEvents}
-                onClick={onMarkedPointClick}
+                pointIndex={index}
               />
             )}
             <Point
               x={position.x}
               y={position.y}
               type={type}
-              onPointInSelectedRouteClick={onPointInSelectedRouteClick}
               index={index}
               routeNumber={routeNumber}
             />

--- a/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
@@ -13,14 +13,9 @@ import { useUserSettingsContext } from '../../../utils/UserSettingsContext';
 type Props = {
   route: ClimbingRoute;
   routeNumber: number;
-  onPointInSelectedRouteClick: (event: React.MouseEvent<any>) => void;
 };
 
-export const RouteWithLabel = ({
-  route,
-  routeNumber,
-  onPointInSelectedRouteClick,
-}: Props) => {
+export const RouteWithLabel = ({ route, routeNumber }: Props) => {
   const { getPixelPosition, getPathForRoute, routes, photoPath, photoZoom } =
     useClimbingContext();
   const { userSettings } = useUserSettingsContext();
@@ -46,7 +41,6 @@ export const RouteWithLabel = ({
   if (path.length === 1) {
     return (
       <StartPoint
-        onPointInSelectedRouteClick={onPointInSelectedRouteClick}
         x={x}
         y={y}
         routeNumberXShift={shift}

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -3,10 +3,7 @@ import styled from '@emotion/styled';
 
 import { useClimbingContext } from '../contexts/ClimbingContext';
 import { RouteWithLabel } from './RouteWithLabel';
-import { RouteFloatingMenu } from './RouteFloatingMenu';
 import { RouteMarks } from './RouteMarks';
-import { getMouseFromPositionInImage } from '../utils/mousePositionUtils';
-import { DIALOG_TOP_BAR_HEIGHT } from '../config';
 
 const Svg = styled.svg<{
   $hasEditableCursor: boolean;
@@ -52,7 +49,6 @@ export const RoutesLayer = ({
 }: Props) => {
   const {
     imageSize,
-    pointSelectedIndex,
     getMachine,
     isRouteSelected,
     isRouteHovered,
@@ -69,18 +65,6 @@ export const RoutesLayer = ({
   const machine = getMachine();
   const path = getCurrentPath();
   if (!path) return null;
-
-  const onPointInSelectedRouteClick = (
-    event: React.MouseEvent<HTMLElement>,
-  ) => {
-    machine.execute('showPointMenu');
-    const isDoubleClick = event.detail === 2;
-    const lastPointIndex = path.length - 1;
-
-    if (isDoubleClick && pointSelectedIndex === lastPointIndex) {
-      machine.execute('finishRoute');
-    }
-  };
 
   const handleOnMovingPointDropOnCanvas = () => {
     if (isPointMoving) {
@@ -124,16 +108,10 @@ export const RoutesLayer = ({
           key={routeNumber}
           routeNumber={routeNumber}
           route={route}
-          onPointInSelectedRouteClick={onPointInSelectedRouteClick}
         />
       ))}
       {routesWithNumbers.map(({ route, routeNumber }) => (
-        <RouteMarks
-          key={routeNumber}
-          routeNumber={routeNumber}
-          route={route}
-          onPointInSelectedRouteClick={onPointInSelectedRouteClick}
-        />
+        <RouteMarks key={routeNumber} routeNumber={routeNumber} route={route} />
       ))}
 
       {selectedRoute ? (
@@ -141,12 +119,10 @@ export const RoutesLayer = ({
           <RouteWithLabel
             routeNumber={selectedRoute.routeNumber}
             route={selectedRoute.route}
-            onPointInSelectedRouteClick={onPointInSelectedRouteClick}
           />
           <RouteMarks
             routeNumber={selectedRoute.routeNumber}
             route={selectedRoute.route}
-            onPointInSelectedRouteClick={onPointInSelectedRouteClick}
           />
         </>
       ) : null}
@@ -156,12 +132,10 @@ export const RoutesLayer = ({
           <RouteWithLabel
             routeNumber={hoveredRoute.routeNumber}
             route={hoveredRoute.route}
-            onPointInSelectedRouteClick={onPointInSelectedRouteClick}
           />
           <RouteMarks
             routeNumber={hoveredRoute.routeNumber}
             route={hoveredRoute.route}
-            onPointInSelectedRouteClick={onPointInSelectedRouteClick}
           />
         </>
       ) : null}

--- a/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
@@ -10,7 +10,6 @@ type Props = {
   y: number;
   routeNumberXShift: number;
   routeNumber: number;
-  onPointInSelectedRouteClick: (event: React.MouseEvent<any>) => void;
   osmId: string;
 };
 
@@ -46,7 +45,6 @@ export const StartPoint = ({
   routeNumber,
   routeNumberXShift = 0,
   osmId,
-  onPointInSelectedRouteClick,
 }: Props) => {
   const { isRouteSelected, getMachine } = useClimbingContext();
   const isSelected = isRouteSelected(routeNumber);
@@ -59,7 +57,6 @@ export const StartPoint = ({
         <Point
           x={x}
           y={y}
-          onPointInSelectedRouteClick={onPointInSelectedRouteClick}
           index={0}
           routeNumber={routeNumber}
           type={undefined}

--- a/src/components/FeaturePanel/Climbing/Editor/utils.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/utils.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useClimbingContext } from '../contexts/ClimbingContext';
 
 export const addShortcutUnderline = (message: string, shortcut: string) => {
   const firstLetter = message.substring(0, 1);
@@ -14,4 +15,40 @@ export const addShortcutUnderline = (message: string, shortcut: string) => {
   }
 
   return message;
+};
+
+export const usePointClickHandler = (index: number) => {
+  const {
+    pointElement,
+    isPointMoving,
+    setPointElement,
+    setPointSelectedIndex,
+    setIsPointMoving,
+    setIsPointClicked,
+    pointSelectedIndex,
+    getMachine,
+    getCurrentPath,
+  } = useClimbingContext();
+  const machine = getMachine();
+  const path = getCurrentPath();
+
+  return (e: any) => {
+    if (isPointMoving) {
+      return;
+    }
+
+    machine.execute('showPointMenu');
+    const isDoubleClick = e.detail === 2;
+    const lastPointIndex = path.length - 1;
+    if (isDoubleClick && pointSelectedIndex === lastPointIndex) {
+      machine.execute('finishRoute');
+    }
+
+    setPointElement(pointElement !== null ? null : e.currentTarget);
+    setPointSelectedIndex(index);
+    setIsPointMoving(false);
+    setIsPointClicked(false);
+    e.stopPropagation();
+    e.preventDefault();
+  };
 };


### PR DESCRIPTION
I moved the handler to the most bottom component, which had some useClimbingContext connection.

That allowed to remove of passing the onclick prop through many layers.