### PR TITLE
general: fix hydration errors for usePersistedState

### DIFF
--- a/src/components/FeaturePanel/FeatureImages/FeatureImages.tsx
+++ b/src/components/FeaturePanel/FeatureImages/FeatureImages.tsx
@@ -30,7 +30,7 @@ const StyledScrollbars = styled(Scrollbars)`
   -webkit-overflow-scrolling: touch;
 `;
 export const Slider = ({ children }) => (
-  <StyledScrollbars universal autoHide>
+  <StyledScrollbars universal autoHide suppressHydrationWarning={true}>
     {children}
   </StyledScrollbars>
 );

--- a/src/components/utils/usePersistedState.ts
+++ b/src/components/utils/usePersistedState.ts
@@ -1,26 +1,34 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+const getStoredValue = (storageKey: string) =>
+  JSON.parse(global?.window?.localStorage.getItem(storageKey) ?? 'null');
+
+const storeValue = <T>(storageKey: string, value: T) =>
+  window?.localStorage.setItem(storageKey, JSON.stringify(value));
 
 export const usePersistedState = <T>(
   storageKey: string,
   init: T,
 ): [T, Dispatch<SetStateAction<T>>] => {
-  const persist = (value: T) =>
-    window?.localStorage.setItem(storageKey, JSON.stringify(value));
+  const [value, setStateValue] = useState<T>(init);
 
-  const initialState = () =>
-    JSON.parse(global?.window?.localStorage.getItem(storageKey) ?? 'null') ??
-    init;
-  const [value, setStateValue] = useState<T>(initialState);
+  useEffect(() => {
+    // we must set the localStorage value in useEffect to prevent hydration error
+    const storedValue = getStoredValue(storageKey);
+    if (storedValue) {
+      setStateValue(storedValue);
+    }
+  }, [storageKey]);
 
   const setValue = (param: (prev: T) => T | T) => {
     if (typeof param === 'function') {
       setStateValue((current) => {
         const newValue = param(current);
-        persist(newValue);
+        storeValue(storageKey, newValue);
         return newValue;
       });
     } else {
-      persist(param);
+      storeValue(storageKey, param);
       setStateValue(param);
     }
   };


### PR DESCRIPTION
We must set the localStorage value in useEffect to prevent hydration error.