### PR TITLE
images: don't request og-image for climbing=*

### DIFF
--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -123,7 +123,7 @@ const getImagesFromTags = (tags: FeatureTags) => {
     ...entries.filter(commonsCategory),
     ...entries.filter(mapillary),
     ...entries.filter(panoramax),
-    ...entries.filter(website),
+    ...(tags.climbing ? [] : entries.filter(website)), // don't request og-image for climbing=* ... TODO maybe other tags as well??
   ];
 
   return imageTags


### PR DESCRIPTION
We were requesting a lot of og-images for website tag in climbing=* items. 

This doesn't make much sense. The website usually links to a online guidebook which doesnt really add relevant image - rather a logo of the service.

TODO is the issue similar in othe presets/tags?