### PR TITLE
EditDialog: Add open all for members/parents

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -3,6 +3,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Button,
   Chip,
   List,
   Stack,
@@ -16,9 +17,10 @@ import { AddMemberForm } from './AddMemberForm';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import { CragIcon } from '../../../Climbing/CragIcon';
 import { Setter } from '../../../../../types';
-import { useHandleItemClick } from '../useHandleItemClick';
+import { useHandleItemClick, useOpenAll } from '../useHandleItemClick';
 import { ConvertNodeToRelation, isConvertible } from './ConvertNodeToRelation';
 import { useCurrentItem } from '../../EditContext';
+import { Members } from '../../useEditItems';
 
 const SectionName = () => {
   const theme = useTheme();
@@ -64,12 +66,21 @@ const AccordionComponent = ({
   membersLength,
   isExpanded,
   setIsExpanded,
+  members,
 }: {
   children: React.ReactNode;
   membersLength?: number;
   isExpanded?: boolean;
   setIsExpanded?: Setter<boolean>;
+  members: Members;
 }) => {
+  const openAll = useOpenAll(members.map(({ shortId }) => shortId));
+
+  const handleOpenAll = (e) => {
+    openAll();
+    e.stopPropagation();
+  };
+
   return (
     <Accordion disableGutters elevation={0} square expanded={isExpanded}>
       <AccordionSummary
@@ -78,11 +89,24 @@ const AccordionComponent = ({
         id="panel1-header"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <Stack direction="row" spacing={2} alignItems="center">
-          <SectionName />
-          {membersLength ? (
-            <Chip size="small" label={membersLength} variant="outlined" />
-          ) : null}
+        <Stack
+          direction="row"
+          spacing={2}
+          alignItems="center"
+          justifyContent="space-between"
+          flex="1"
+        >
+          <Stack direction="row" spacing={2} alignItems="center">
+            <SectionName />
+            {membersLength ? (
+              <Chip size="small" label={membersLength} variant="outlined" />
+            ) : null}
+          </Stack>
+          {isExpanded && (
+            <Button size="small" color="secondary" onClick={handleOpenAll}>
+              {t('editdialog.open_all')}
+            </Button>
+          )}
         </Stack>
       </AccordionSummary>
       <AccordionDetails>
@@ -107,6 +131,7 @@ export const MembersEditor = () => {
       membersLength={members?.length}
       isExpanded={isExpanded}
       setIsExpanded={setIsExpanded}
+      members={members}
     >
       {members?.map((member) => (
         <FeatureRow

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -3,6 +3,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Button,
   Chip,
   List,
   Stack,
@@ -19,7 +20,7 @@ import { useCurrentItem, useEditContext } from '../../EditContext';
 import { isClimbingRoute as getIsClimbingRoute } from '../../../../../utils';
 import { AreaIcon } from '../../../Climbing/AreaIcon';
 import { CragIcon } from '../../../Climbing/CragIcon';
-import { useHandleItemClick } from '../useHandleItemClick';
+import { useHandleItemClick, useOpenAll } from '../useHandleItemClick';
 import { Feature } from '../../../../../services/types';
 
 const SectionName = () => {
@@ -97,6 +98,14 @@ export const ParentsEditor = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
   const handleClick = useHandleItemClick(setIsExpanded);
   const parents = useGetParents();
+  const openAll = useOpenAll(
+    parents.map((parent) => getShortId(parent.osmMeta)),
+  );
+
+  const handleOpenAll = (e) => {
+    openAll();
+    e.stopPropagation();
+  };
 
   if (!parents || parents.length === 0) {
     return null;
@@ -110,11 +119,24 @@ export const ParentsEditor = () => {
         id="panel1-header"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Typography variant="button">
-            <SectionName />
-          </Typography>
-          <Chip size="small" label={parents.length} variant="outlined" />
+        <Stack
+          direction="row"
+          spacing={2}
+          alignItems="center"
+          justifyContent="space-between"
+          flex="1"
+        >
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Typography variant="button">
+              <SectionName />
+            </Typography>
+            <Chip size="small" label={parents.length} variant="outlined" />
+          </Stack>
+          {isExpanded && (
+            <Button size="small" color="secondary" onClick={handleOpenAll}>
+              {t('editdialog.open_all')}
+            </Button>
+          )}
         </Stack>
       </AccordionSummary>
       <AccordionDetails>

--- a/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
@@ -1,5 +1,5 @@
 import { EditDataItem } from '../useEditItems';
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import { useEditContext } from '../EditContext';
 import { getApiId } from '../../../../services/helpers';
 import { fetchFreshItem } from '../itemsHelpers';
@@ -29,5 +29,18 @@ export const useHandleItemClick = (setIsExpanded: Setter<boolean>) => {
         setCurrent(shortId);
       }
     }
+  };
+};
+
+export const useOpenAll = (shortIds: string[]) => {
+  const { addItem, items } = useEditContext();
+  return () => {
+    shortIds.forEach(async (shortId) => {
+      const apiId = getApiId(shortId);
+      if (!isInItems(items, shortId)) {
+        const newItem = await fetchFreshItem(apiId);
+        addItem(newItem);
+      }
+    });
   };
 };

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -225,6 +225,7 @@ export default {
   'editdialog.climbing_areas': 'Lezecké oblasti',
   'editdialog.climbing_crags': 'Lezecké sektory',
   'editdialog.climbing_routes': 'Lezecké cesty',
+  'editdialog.open_all': 'Otevřít vše',
   'editdialog.members': 'Členové',
   'editdialog.members.name': 'Název',
   'editdialog.members.add_member': 'Přidat člena',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -265,6 +265,7 @@ export default {
   'editdialog.climbing_areas': 'Climbing areas',
   'editdialog.climbing_crags': 'Climbing crags',
   'editdialog.climbing_routes': 'Climbing routes',
+  'editdialog.open_all': 'Open all',
   'editdialog.members': 'Members',
   'editdialog.members.name': 'Name',
   'editdialog.members.add_member': 'Add member',


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<img width="902" height="995" alt="image" src="https://github.com/user-attachments/assets/538c8b9b-1508-4f9e-be7e-695708bfe27f" />

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
