### PR TITLE
EditDialog: Update helper texts for desc and photos

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MajorKeysEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MajorKeysEditor.tsx
@@ -88,6 +88,13 @@ export const MajorKeysEditor: React.FC = () => {
     }
   }, [activeMajorKeys, focusTag]);
 
+  const getHelperText = (k: string) => {
+    if (k === 'description') {
+      return t('editdialog.description_helper_text');
+    }
+    return undefined;
+  };
+
   const getInputElement = (k: string) => {
     if (!data.keys?.includes(k)) return null;
 
@@ -120,6 +127,7 @@ export const MajorKeysEditor: React.FC = () => {
           setTag(e.target.name, e.target.value);
         }}
         value={tags[k] ?? ''}
+        helperText={getHelperText(k)}
       />
     );
   };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsEditor.tsx
@@ -5,6 +5,7 @@ import { t } from '../../../../../services/intl';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import React from 'react';
 import { useEditDialogContext } from '../../../helpers/EditDialogContext';
+import { isClimbingRoute } from '../../../../../utils';
 
 const UploadButton = () => (
   <div>
@@ -47,7 +48,8 @@ export const WikimediaCommonsEditor = ({ k }: { k: string }) => {
   const error = isWikimediaCommonsFileNameInvalid(tags[k]);
   const index = getIndexFromWikimediaCommonsKey(k);
   const label = `${t('tags.wikimedia_commons_photo')}${index ? ` (${index})` : ''}`;
-
+  const isClimbingRouteOrCrag =
+    isClimbingRoute(tags) || tags.climbing === 'crag';
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTag(
       e.target.name,
@@ -64,8 +66,13 @@ export const WikimediaCommonsEditor = ({ k }: { k: string }) => {
       <Box flex={1}>
         <TextFieldWithCharacterCount
           label={label}
-          helperText={
+          errorText={
             error ? t('editdialog.upload_photo_filename_error') : undefined
+          }
+          helperText={
+            isClimbingRouteOrCrag
+              ? t('editdialog.wikimedia_commons_climbing_helper_text')
+              : undefined
           }
           error={error}
           k={k}

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/helpers.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/helpers.tsx
@@ -17,12 +17,14 @@ type TextFieldProps = {
   autoFocus?: boolean;
   error?: boolean;
   helperText?: string;
+  errorText?: string;
 };
 
 export const TextFieldWithCharacterCount = ({
   k,
   error,
   helperText,
+  errorText,
   label,
   autoFocus,
   onChange,
@@ -59,7 +61,11 @@ export const TextFieldWithCharacterCount = ({
         slotProps={{ formHelperText: { component: 'div' } }}
         helperText={
           <Stack direction="row" spacing={1}>
-            {isValidationReadyToCheck && helperText}
+            {errorText
+              ? isValidationReadyToCheck
+                ? errorText
+                : helperText
+              : helperText}
             <CharacterCount
               count={value?.length}
               max={MAX_INPUT_LENGTH}

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -235,6 +235,8 @@ export default {
   'editdialog.members.climbing_crag_convert_description': 'Pro přidání lezeckých cest, prosím, změňte uzel na relaci.',
   'editdialog.members.convert_button': 'Změnit na relaci',
   'editdialog.location_change_current_item': 'Upravit',
+  'editdialog.description_helper_text': 'Zadávejte prosím vlastní popis nebo popis schválený jeho autorem',
+  'editdialog.wikimedia_commons_climbing_helper_text': 'Lezecké cesty můžete zakreslit přímo při prohlížení fotografie po uložení fotky.',
 
   'editsuccess.close_button': 'Zavřít',
   'editsuccess.note.heading': 'Děkujeme za Váš návrh!',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -275,6 +275,8 @@ export default {
   'editdialog.members.climbing_crag_convert_description': 'For adding climbing routes, you need to convert node to relation.',
   'editdialog.members.convert_button': 'Convert to relation',
   'editdialog.location_change_current_item': 'Edit',
+  'editdialog.description_helper_text': 'Please enter your own description or one approved by its author.',
+  'editdialog.wikimedia_commons_climbing_helper_text': 'You can draw climbing routes directly while viewing after saving the photo',
 
   'editsuccess.close_button': 'Done',
   'editsuccess.note.heading': 'Thank you for your suggestion!',


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots
<img width="801" height="251" alt="Screenshot 2025-08-08 at 6 56 06" src="https://github.com/user-attachments/assets/6a6b7374-608c-4fdc-bec4-70ab78097b2d" />


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
