### PR TITLE
climbing: refactor - move RouteMarks to the bottom of RoutesLayer

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/PointTypeButtons.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/PointTypeButtons.tsx
@@ -61,7 +61,11 @@ export const PointTypeButtons = ({ setShowRouteMarksMenu }: Props) => {
   return (
     <>
       {pointTypes.map(({ message, type, shortcut }) => (
-        <Button key={type} onClick={() => onPointTypeChange(type)}>
+        <Button
+          key={type}
+          title={t('shortcut', { shortcut })}
+          onClick={() => onPointTypeChange(type)}
+        >
           {addShortcutUnderline(message, shortcut)}
         </Button>
       ))}

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -110,35 +110,24 @@ export const RoutesLayer = ({
           route={route}
         />
       ))}
-      {routesWithNumbers.map(({ route, routeNumber }) => (
-        <RouteMarks key={routeNumber} routeNumber={routeNumber} route={route} />
-      ))}
 
       {selectedRoute ? (
-        <>
-          <RouteWithLabel
-            routeNumber={selectedRoute.routeNumber}
-            route={selectedRoute.route}
-          />
-          <RouteMarks
-            routeNumber={selectedRoute.routeNumber}
-            route={selectedRoute.route}
-          />
-        </>
+        <RouteWithLabel
+          routeNumber={selectedRoute.routeNumber}
+          route={selectedRoute.route}
+        />
       ) : null}
 
       {hoveredRoute ? (
-        <>
-          <RouteWithLabel
-            routeNumber={hoveredRoute.routeNumber}
-            route={hoveredRoute.route}
-          />
-          <RouteMarks
-            routeNumber={hoveredRoute.routeNumber}
-            route={hoveredRoute.route}
-          />
-        </>
+        <RouteWithLabel
+          routeNumber={hoveredRoute.routeNumber}
+          route={hoveredRoute.route}
+        />
       ) : null}
+
+      {routesWithNumbers.map(({ route, routeNumber }) => (
+        <RouteMarks key={routeNumber} routeNumber={routeNumber} route={route} />
+      ))}
     </Svg>
   );
 };

--- a/src/components/FeaturePanel/Climbing/Editor/utils.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/utils.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { useClimbingContext } from '../contexts/ClimbingContext';
 
 export const addShortcutUnderline = (message: string, shortcut: string) => {
-  const firstLetter = message.substring(0, 1);
-  const rest = message.substring(1);
+  const shortcutUp = shortcut.toUpperCase();
+  const messageUp = message.toUpperCase();
 
-  if (firstLetter.toUpperCase() === shortcut.toUpperCase()) {
+  if (messageUp.includes(shortcutUp)) {
+    const position = messageUp.indexOf(shortcutUp);
     return (
       <>
+        {message.substring(0, position)}
         <u>{shortcut}</u>
-        {rest}
+        {message.substring(position + 1)}
       </>
     );
   }

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -17,6 +17,7 @@ export default {
   show_more: 'Show more',
   show_less: 'Show less',
   url_not_found_toast: 'Requested URL not found, check your address bar.',
+  shortcut: 'Keyboard shortcut: __shortcut__',
 
   'user.login_register': 'Login / register',
   'user.logout': 'Logout',


### PR DESCRIPTION
We want Marks to be always visible at the top - moved as last item in RoutesLayers.

Hovered or selected routes doesn't have to define them again.