### PR TITLE
climbing: refactor - rename to use `routeIndex`

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/MouseTrackingLine.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/MouseTrackingLine.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { PathWithBorder } from './PathWithBorder';
 import { useClimbingContext } from '../contexts/ClimbingContext';
 
-export const MouseTrackingLine = ({ routeNumber }) => {
+type Props = {
+  routeIndex: number;
+};
+
+export const MouseTrackingLine = ({ routeIndex }: Props) => {
   const {
     mousePosition,
     isRouteSelected,
@@ -13,7 +17,7 @@ export const MouseTrackingLine = ({ routeNumber }) => {
     getPathForRoute,
   } = useClimbingContext();
 
-  const route = routes[routeNumber];
+  const route = routes[routeIndex];
   const path = getPathForRoute(route);
   const lastPoint = path[path.length - 1];
   const lastPointPositionInPx = getPixelPosition(lastPoint);
@@ -25,14 +29,14 @@ export const MouseTrackingLine = ({ routeNumber }) => {
     ? getPixelPosition(closerMousePositionPoint)
     : mousePosition;
 
-  const isSelected = isRouteSelected(routeNumber);
+  const isSelected = isRouteSelected(routeIndex);
 
   return (
     mousePositionSticked &&
     isSelected && (
       <PathWithBorder
         d={`M ${lastPointPositionInPx.x} ${lastPointPositionInPx.y} L ${mousePositionSticked.x} ${mousePositionSticked.y}`}
-        routeNumber={routeNumber}
+        routeNumber={routeIndex}
         isSelected={isSelected}
         route={route}
         opacity={0.7}

--- a/src/components/FeaturePanel/Climbing/Editor/Points/Point.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/Points/Point.tsx
@@ -4,6 +4,7 @@ import { useClimbingContext } from '../../contexts/ClimbingContext';
 import { useConfig } from '../../config';
 import { useMobileMode } from '../../../../helpers';
 import { usePointClickHandler } from '../utils';
+import { PointType } from '../../types';
 
 const ClickableArea = styled.circle``;
 
@@ -41,7 +42,15 @@ const usePointColor = (type, isHovered) => {
   };
 };
 
-export const Point = ({ x, y, type, index, routeNumber }) => {
+type Props = {
+  routeIndex: number;
+  index: number;
+  type: PointType;
+  x: number;
+  y: number;
+};
+
+export const Point = ({ x, y, type, index, routeIndex }: Props) => {
   const [isHovered, setIsHovered] = useState(false);
   const {
     setPointSelectedIndex,
@@ -56,8 +65,8 @@ export const Point = ({ x, y, type, index, routeNumber }) => {
     isEditMode,
   } = useClimbingContext();
   const isMobileMode = useMobileMode();
-  const isSelected = isRouteSelected(routeNumber);
-  const isOtherSelected = isOtherRouteSelected(routeNumber);
+  const isSelected = isRouteSelected(routeIndex);
+  const isOtherSelected = isOtherRouteSelected(routeIndex);
   const { pointColor, pointStroke } = usePointColor(type, isHovered);
 
   const isPointOnRouteSelected = isSelected && isPointSelected(index);
@@ -70,7 +79,7 @@ export const Point = ({ x, y, type, index, routeNumber }) => {
     setIsHovered(true);
     const isLastPoint = getCurrentPath().length - 1 === index;
     if (!isLastPoint) {
-      setRouteIndexHovered(routeNumber);
+      setRouteIndexHovered(routeIndex);
     }
   };
 

--- a/src/components/FeaturePanel/Climbing/Editor/RouteMarks.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RouteMarks.tsx
@@ -6,15 +6,13 @@ import { PulsedPoint } from './Points/PulsedPoint';
 import { Sling } from './Points/Sling';
 import { useClimbingContext } from '../contexts/ClimbingContext';
 import { Anchor } from './Points/Anchor';
-import { ClimbingRoute } from '../types';
 import { UnfinishedPoint } from './Points/UnfinishedPoint';
 
 type Props = {
-  route: ClimbingRoute;
-  routeNumber: number;
+  routeIndex: number;
 };
 
-export const RouteMarks = ({ route, routeNumber }: Props) => {
+export const RouteMarks = ({ routeIndex }: Props) => {
   const {
     getPixelPosition,
     isPointSelected,
@@ -23,12 +21,16 @@ export const RouteMarks = ({ route, routeNumber }: Props) => {
     isRouteSelected,
     isOtherRouteSelected,
     isEditMode,
+    routes,
   } = useClimbingContext();
-  const isSelected = isRouteSelected(routeNumber);
-  const isOtherSelected = isOtherRouteSelected(routeNumber);
+  const isSelected = isRouteSelected(routeIndex);
+  const isOtherSelected = isOtherRouteSelected(routeIndex);
+  const route = routes[routeIndex];
+  const path = getPathForRoute(route);
+
   return (
     <>
-      {getPathForRoute(route).map(({ x, y, type }, index) => {
+      {path.map(({ x, y, type }, index) => {
         const isBoltVisible = !isOtherSelected && type === 'bolt';
         const isAnchorVisible = !isOtherSelected && type === 'anchor';
         const isSlingVisible = !isOtherSelected && type === 'sling';
@@ -49,7 +51,7 @@ export const RouteMarks = ({ route, routeNumber }: Props) => {
         const xOffset = isSelected && isEditMode ? 15 : 0;
         return (
           // eslint-disable-next-line react/no-array-index-key
-          <React.Fragment key={`${routeNumber}-${index}-${x}-${y}`}>
+          <React.Fragment key={`${routeIndex}-${index}-${x}-${y}`}>
             {isThisRouteEditOrExtendMode && <PulsedPoint x={x} y={y} />}
 
             {isBoltVisible && (
@@ -102,7 +104,7 @@ export const RouteMarks = ({ route, routeNumber }: Props) => {
               y={position.y}
               type={type}
               index={index}
-              routeNumber={routeNumber}
+              routeIndex={routeIndex}
             />
           </React.Fragment>
         );

--- a/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
@@ -15,7 +15,11 @@ const AddNewPoint = styled.circle`
   cursor: copy;
 `;
 
-export const RoutePath = ({ route, routeNumber }) => {
+type Props = {
+  routeIndex: number;
+};
+
+export const RoutePath = ({ routeIndex }: Props) => {
   const [tempPointPosition, setTempPointPosition] = useState<PositionPx | null>(
     null,
   );
@@ -33,9 +37,11 @@ export const RoutePath = ({ route, routeNumber }) => {
     getPathForRoute,
     svgRef,
     photoZoom,
+    routes,
   } = useClimbingContext();
-  const isSelected = isRouteSelected(routeNumber);
+  const isSelected = isRouteSelected(routeIndex);
   const machine = getMachine();
+  const route = routes[routeIndex];
   const path = getPathForRoute(route);
   const isMobileMode = useMobileMode();
 
@@ -56,7 +62,7 @@ export const RoutePath = ({ route, routeNumber }) => {
       machine.currentStateName === 'editRoute' ||
       machine.currentStateName === 'extendRoute'
     ) {
-      if (!routeIndexHovered) setRouteIndexHovered(routeNumber);
+      if (!routeIndexHovered) setRouteIndexHovered(routeIndex);
 
       const mousePosition: PositionPx = {
         x: e.clientX,
@@ -75,21 +81,11 @@ export const RoutePath = ({ route, routeNumber }) => {
   };
 
   const onMouseEnter = () => {
-    setRouteIndexHovered(routeNumber);
+    setRouteIndexHovered(routeIndex);
   };
 
   const onMouseLeave = () => {
     setRouteIndexHovered(null);
-  };
-
-  const onMidpointAdd = (e) => {
-    if (tempPointPosition) {
-      machine.execute('addPointInBetween', {
-        hoveredPosition: tempPointPosition,
-        hoveredSegmentIndex: tempPointSegmentIndex,
-      });
-      e.stopPropagation();
-    }
   };
 
   const isMidpointAddScenario =
@@ -100,19 +96,23 @@ export const RoutePath = ({ route, routeNumber }) => {
     routeIndexHovered !== null;
 
   const isExtendingDifferentRoute =
-    machine.currentStateName === 'extendRoute' && !isRouteSelected(routeNumber);
+    machine.currentStateName === 'extendRoute' && !isRouteSelected(routeIndex);
 
-  const onClick = isMidpointAddScenario
-    ? onMidpointAdd
-    : (e) => {
-        if (isExtendingDifferentRoute) return;
-        if (isEditMode) {
-          machine.execute('editRoute', { routeNumber });
-        } else {
-          machine.execute('routeSelect', { routeNumber });
-        }
-        e.stopPropagation();
-      };
+  const onClick = (e) => {
+    if (isMidpointAddScenario) {
+      if (tempPointPosition) {
+        machine.execute('addPointInBetween', {
+          hoveredPosition: tempPointPosition,
+          hoveredSegmentIndex: tempPointSegmentIndex,
+        });
+      }
+    } else if (isEditMode) {
+      machine.execute('editRoute', { routeIndex });
+    } else {
+      machine.execute('routeSelect', { routeIndex });
+    }
+    e.stopPropagation();
+  };
 
   return (
     <>
@@ -120,41 +120,38 @@ export const RoutePath = ({ route, routeNumber }) => {
         d={`M0 0 ${pointsInString}`}
         isSelected={isSelected}
         route={route}
-        routeNumber={routeNumber}
+        routeNumber={routeIndex}
       />
 
       {!isExtendingDifferentRoute &&
-        path.length > 1 &&
-        path.map(({ x, y }, index) => {
-          if (path && index < path.length - 1) {
-            const position1 = getPixelPosition({ x, y, units: 'percentage' });
-            const position2 = getPixelPosition({
-              ...path[index + 1],
-              units: 'percentage',
-            });
+        path.length > 2 &&
+        path.slice(0, -1).map(({ x, y }, index) => {
+          const position1 = getPixelPosition({ x, y, units: 'percentage' });
+          const position2 = getPixelPosition({
+            ...path[index + 1],
+            units: 'percentage',
+          });
 
-            const desktopProps = {
-              onMouseEnter: onMouseEnter,
-              onMouseLeave: onMouseLeave,
-            };
-            return (
-              <InteractiveArea
-                // eslint-disable-next-line react/no-array-index-key
-                key={`${routeNumber}-${index}-${x}-${y}`}
-                stroke="transparent"
-                strokeWidth={15}
-                x1={position1.x}
-                y1={position1.y}
-                x2={position2.x}
-                y2={position2.y}
-                {...(isMobileMode ? {} : desktopProps)}
-                onMouseMove={(e) => onMouseMove(e, index)}
-                onClick={onClick}
-                cursor={isMidpointAddScenario ? 'copy' : 'pointer'}
-              />
-            );
-          }
-          return null;
+          const desktopProps = {
+            onMouseEnter: onMouseEnter,
+            onMouseLeave: onMouseLeave,
+          };
+          return (
+            <InteractiveArea
+              // eslint-disable-next-line react/no-array-index-key
+              key={`${routeIndex}-${index}-${x}-${y}`}
+              stroke="transparent"
+              strokeWidth={15}
+              x1={position1.x}
+              y1={position1.y}
+              x2={position2.x}
+              y2={position2.y}
+              {...(isMobileMode ? {} : desktopProps)}
+              onMouseMove={(e) => onMouseMove(e, index)}
+              onClick={onClick}
+              cursor={isMidpointAddScenario ? 'copy' : 'pointer'}
+            />
+          );
         })}
       {isMidpointAddScenario && tempPointPosition && (
         <AddNewPoint
@@ -168,7 +165,7 @@ export const RoutePath = ({ route, routeNumber }) => {
       )}
       {machine.currentStateName === 'extendRoute' &&
         routeIndexHovered === null && (
-          <MouseTrackingLine routeNumber={routeNumber} />
+          <MouseTrackingLine routeIndex={routeIndex} />
         )}
     </>
   );

--- a/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
@@ -107,9 +107,9 @@ export const RoutePath = ({ routeIndex }: Props) => {
         });
       }
     } else if (isEditMode) {
-      machine.execute('editRoute', { routeIndex });
+      machine.execute('editRoute', { routeNumber: routeIndex });
     } else {
-      machine.execute('routeSelect', { routeIndex });
+      machine.execute('routeSelect', { routeNumber: routeIndex });
     }
     e.stopPropagation();
   };

--- a/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
@@ -124,7 +124,7 @@ export const RoutePath = ({ routeIndex }: Props) => {
       />
 
       {!isExtendingDifferentRoute &&
-        path.length > 2 &&
+        path.length >= 2 &&
         path.slice(0, -1).map(({ x, y }, index) => {
           const position1 = getPixelPosition({ x, y, units: 'percentage' });
           const position2 = getPixelPosition({

--- a/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { RouteNumber } from './RouteNumber';
 import { useClimbingContext } from '../contexts/ClimbingContext';
-import { ClimbingRoute } from '../types';
 import { StartPoint } from './StartPoint';
 import { getShiftForStartPoint } from '../utils/startPoint';
 import { RoutePath } from './RoutePath';
@@ -11,20 +10,21 @@ import { RouteDifficulty } from './RouteDifficulty';
 import { useUserSettingsContext } from '../../../utils/userSettings/UserSettingsContext';
 
 type Props = {
-  route: ClimbingRoute;
-  routeNumber: number;
+  routeIndex: number;
 };
 
-export const RouteWithLabel = ({ route, routeNumber }: Props) => {
+export const RouteWithLabel = ({ routeIndex }: Props) => {
   const { getPixelPosition, getPathForRoute, routes, photoPath, photoZoom } =
     useClimbingContext();
   const { userSettings } = useUserSettingsContext();
+
+  const route = routes[routeIndex];
   const path = getPathForRoute(route);
   if (!route || !path || path?.length === 0) return null;
 
   const shift =
     getShiftForStartPoint({
-      currentRouteSelectedIndex: routeNumber,
+      currentRouteSelectedIndex: routeIndex,
       currentPosition: path[0],
       checkedRoutes: routes,
       photoPath,
@@ -44,7 +44,7 @@ export const RouteWithLabel = ({ route, routeNumber }: Props) => {
         x={x}
         y={y}
         routeNumberXShift={shift}
-        routeNumber={routeNumber}
+        routeNumber={routeIndex}
         osmId={osmId}
       />
     );
@@ -52,9 +52,9 @@ export const RouteWithLabel = ({ route, routeNumber }: Props) => {
 
   return (
     <>
-      <RoutePath route={route} routeNumber={routeNumber} />
+      <RoutePath routeIndex={routeIndex} />
       <RouteNumber x={x + shift} y={y} osmId={osmId}>
-        {routeNumber}
+        {routeIndex}
       </RouteNumber>
       {userSettings['climbing.isGradesOnPhotosVisible'] && (
         <RouteDifficulty x={x + shift} y={y + 40} route={route} />

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -50,8 +50,8 @@ export const RoutesLayer = ({
   const {
     imageSize,
     getMachine,
-    isRouteSelected,
-    isRouteHovered,
+    routeSelectedIndex,
+    routeIndexHovered,
     isPointMoving,
     setIsPointClicked,
     setIsPointMoving,
@@ -75,18 +75,6 @@ export const RoutesLayer = ({
     }
   };
 
-  const routesWithNumbers = routes.map((route, routeNumber) => ({
-    routeNumber,
-    route,
-  }));
-
-  const selectedRoute = routesWithNumbers.find(({ routeNumber }) =>
-    isRouteSelected(routeNumber),
-  );
-  const hoveredRoute = routesWithNumbers.find(({ routeNumber }) =>
-    isRouteHovered(routeNumber),
-  );
-
   return (
     <Svg
       $hasEditableCursor={machine.currentStateName === 'extendRoute'}
@@ -103,30 +91,20 @@ export const RoutesLayer = ({
       xmlns="http://www.w3.org/2000/svg"
       ref={svgRef}
     >
-      {routesWithNumbers.map(({ route, routeNumber }) => (
-        <RouteWithLabel
-          key={routeNumber}
-          routeNumber={routeNumber}
-          route={route}
-        />
+      {routes.map((_, routeIndex) => (
+        <RouteWithLabel key={routeIndex} routeIndex={routeIndex} />
       ))}
 
-      {selectedRoute ? (
-        <RouteWithLabel
-          routeNumber={selectedRoute.routeNumber}
-          route={selectedRoute.route}
-        />
+      {routeSelectedIndex ? (
+        <RouteWithLabel routeIndex={routeSelectedIndex} />
       ) : null}
 
-      {hoveredRoute ? (
-        <RouteWithLabel
-          routeNumber={hoveredRoute.routeNumber}
-          route={hoveredRoute.route}
-        />
+      {routeIndexHovered ? (
+        <RouteWithLabel routeIndex={routeIndexHovered} />
       ) : null}
 
-      {routesWithNumbers.map(({ route, routeNumber }) => (
-        <RouteMarks key={routeNumber} routeNumber={routeNumber} route={route} />
+      {routes.map((_, routeIndex) => (
+        <RouteMarks key={routeIndex} routeIndex={routeIndex} />
       ))}
     </Svg>
   );

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -95,13 +95,13 @@ export const RoutesLayer = ({
         <RouteWithLabel key={routeIndex} routeIndex={routeIndex} />
       ))}
 
-      {routeSelectedIndex ? (
+      {routeSelectedIndex == null ? null : (
         <RouteWithLabel routeIndex={routeSelectedIndex} />
-      ) : null}
+      )}
 
-      {routeIndexHovered ? (
+      {routeIndexHovered == null ? null : (
         <RouteWithLabel routeIndex={routeIndexHovered} />
-      ) : null}
+      )}
 
       {routes.map((_, routeIndex) => (
         <RouteMarks key={routeIndex} routeIndex={routeIndex} />

--- a/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
@@ -58,13 +58,13 @@ export const StartPoint = ({
           x={x}
           y={y}
           index={0}
-          routeNumber={routeNumber}
+          routeIndex={routeNumber}
           type={undefined}
         />
       ) : (
         <NonEditablePoint isSelected={isSelected} x={x} y={y} />
       )}
-      <MouseTrackingLine routeNumber={routeNumber} />
+      <MouseTrackingLine routeIndex={routeNumber} />
       <RouteNumber x={x + routeNumberXShift} y={y} osmId={osmId}>
         {routeNumber}
       </RouteNumber>

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -56,7 +56,7 @@ type ClimbingContextType = {
   isPointSelected: (pointNumber: number) => boolean;
   pointSelectedIndex: number;
   routes: Array<ClimbingRoute>;
-  routeSelectedIndex: number | null;
+  routeSelectedIndex: number | null | undefined;
   isPointClicked: boolean;
   setIsPointClicked: (isPointClicked: boolean) => void;
   setEditorPosition: (position: PositionPx) => void;
@@ -104,7 +104,7 @@ type ClimbingContextType = {
   setIsEditMode: (value: boolean | ((old: boolean) => boolean)) => void;
   viewportSize: Size;
   setViewportSize: (size: Size) => void;
-  routeIndexHovered: number | null;
+  routeIndexHovered: number | null | undefined;
   setRouteIndexHovered: (routeIndexHovered: number) => void;
   routeIndexExpanded: number | null;
   setRouteIndexExpanded: (routeIndexHovered: number | null) => void;

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -56,7 +56,7 @@ type ClimbingContextType = {
   isPointSelected: (pointNumber: number) => boolean;
   pointSelectedIndex: number;
   routes: Array<ClimbingRoute>;
-  routeSelectedIndex: number;
+  routeSelectedIndex: number | null;
   isPointClicked: boolean;
   setIsPointClicked: (isPointClicked: boolean) => void;
   setEditorPosition: (position: PositionPx) => void;
@@ -104,7 +104,7 @@ type ClimbingContextType = {
   setIsEditMode: (value: boolean | ((old: boolean) => boolean)) => void;
   viewportSize: Size;
   setViewportSize: (size: Size) => void;
-  routeIndexHovered: number;
+  routeIndexHovered: number | null;
   setRouteIndexHovered: (routeIndexHovered: number) => void;
   routeIndexExpanded: number | null;
   setRouteIndexExpanded: (routeIndexHovered: number | null) => void;


### PR DESCRIPTION
routeNumber is the route index, renamed to avoid the confusion.

This enabled RoutesLayer to get much shorter, as we don't have to ask if every routeNumber isSelected() and isHovered().
