### PR TITLE
climbing: refactor - make RouteNumber consume only 'routeIndex'

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RouteWithLabel.tsx
@@ -3,62 +3,27 @@ import React from 'react';
 import { RouteNumber } from './RouteNumber';
 import { useClimbingContext } from '../contexts/ClimbingContext';
 import { StartPoint } from './StartPoint';
-import { getShiftForStartPoint } from '../utils/startPoint';
 import { RoutePath } from './RoutePath';
-import { getShortId } from '../../../../services/helpers';
-import { RouteDifficulty } from './RouteDifficulty';
-import { useUserSettingsContext } from '../../../utils/userSettings/UserSettingsContext';
 
 type Props = {
   routeIndex: number;
 };
 
 export const RouteWithLabel = ({ routeIndex }: Props) => {
-  const { getPixelPosition, getPathForRoute, routes, photoPath, photoZoom } =
-    useClimbingContext();
-  const { userSettings } = useUserSettingsContext();
+  const { getPathForRoute, routes } = useClimbingContext();
 
   const route = routes[routeIndex];
   const path = getPathForRoute(route);
   if (!route || !path || path?.length === 0) return null;
 
-  const shift =
-    getShiftForStartPoint({
-      currentRouteSelectedIndex: routeIndex,
-      currentPosition: path[0],
-      checkedRoutes: routes,
-      photoPath,
-    }) / photoZoom.scale;
-
-  const { x, y } = getPixelPosition({
-    ...path[0],
-    units: 'percentage',
-  });
-  const osmId = route.feature?.osmMeta
-    ? getShortId(route.feature.osmMeta)
-    : null;
-
   if (path.length === 1) {
-    return (
-      <StartPoint
-        x={x}
-        y={y}
-        routeNumberXShift={shift}
-        routeNumber={routeIndex}
-        osmId={osmId}
-      />
-    );
+    return <StartPoint routeIndex={routeIndex} />; // TODO move the <NonEditablePoint> to RoutePath later
   }
 
   return (
     <>
       <RoutePath routeIndex={routeIndex} />
-      <RouteNumber x={x + shift} y={y} osmId={osmId}>
-        {routeIndex}
-      </RouteNumber>
-      {userSettings['climbing.isGradesOnPhotosVisible'] && (
-        <RouteDifficulty x={x + shift} y={y + 40} route={route} />
-      )}
+      <RouteNumber routeIndex={routeIndex} />
     </>
   );
 };

--- a/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/StartPoint.tsx
@@ -5,14 +5,6 @@ import { Point } from './Points/Point';
 import { MouseTrackingLine } from './MouseTrackingLine';
 import { useConfig } from '../config';
 
-type Props = {
-  x: number;
-  y: number;
-  routeNumberXShift: number;
-  routeNumber: number;
-  osmId: string;
-};
-
 const NonEditablePoint = ({ x, y, isSelected }) => {
   const config = useConfig();
   return (
@@ -39,35 +31,42 @@ const NonEditablePoint = ({ x, y, isSelected }) => {
   );
 };
 
-export const StartPoint = ({
-  x,
-  y,
-  routeNumber,
-  routeNumberXShift = 0,
-  osmId,
-}: Props) => {
-  const { isRouteSelected, getMachine } = useClimbingContext();
-  const isSelected = isRouteSelected(routeNumber);
+type Props = {
+  routeIndex: number;
+};
+
+export const StartPoint = ({ routeIndex }: Props) => {
+  const {
+    isRouteSelected,
+    getMachine,
+    getPixelPosition,
+    getPathForRoute,
+    routes,
+  } = useClimbingContext();
+
+  const route = routes[routeIndex];
+  const path = getPathForRoute(route);
+  if (!route || !path || path?.length === 0) return null;
+
+  const { x, y } = getPixelPosition({
+    ...path[0],
+    units: 'percentage',
+  });
+
+  const isSelected = isRouteSelected(routeIndex);
   const machine = getMachine();
+
   return (
     <>
       {isSelected &&
       (machine.currentStateName === 'editRoute' ||
         machine.currentStateName === 'extendRoute') ? (
-        <Point
-          x={x}
-          y={y}
-          index={0}
-          routeIndex={routeNumber}
-          type={undefined}
-        />
+        <Point x={x} y={y} index={0} routeIndex={routeIndex} type={undefined} />
       ) : (
         <NonEditablePoint isSelected={isSelected} x={x} y={y} />
       )}
-      <MouseTrackingLine routeIndex={routeNumber} />
-      <RouteNumber x={x + routeNumberXShift} y={y} osmId={osmId}>
-        {routeNumber}
-      </RouteNumber>
+      <MouseTrackingLine routeIndex={routeIndex} />
+      <RouteNumber routeIndex={routeIndex} />
     </>
   );
 };

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -150,7 +150,7 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
   const svgRef = useRef(null);
   const isPanningActiveRef = useRef(false);
   const [photoPaths, setPhotoPaths] = useState<Array<string>>(null);
-  const [photoPath, setPhotoPath] = useState<string>(null); // photo, should be null
+  const [photoPath, setPhotoPath] = useState<string>(null); // photo URL (pathname), should be null
   const [showDebugMenu, setShowDebugMenu] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });


### PR DESCRIPTION
This code was doubled for StartPoint and RouteWithLabel. Now it lives only in `<RouteNumber/>`