### PR TITLE
climbing: refactor - make PathWithBorder consume only routeIndex+d

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/MouseTrackingLine.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/MouseTrackingLine.tsx
@@ -36,9 +36,7 @@ export const MouseTrackingLine = ({ routeIndex }: Props) => {
     isSelected && (
       <PathWithBorder
         d={`M ${lastPointPositionInPx.x} ${lastPointPositionInPx.y} L ${mousePositionSticked.x} ${mousePositionSticked.y}`}
-        routeNumber={routeIndex}
-        isSelected={isSelected}
-        route={route}
+        routeIndex={routeIndex}
         opacity={0.7}
       />
     )

--- a/src/components/FeaturePanel/Climbing/Editor/PathWithBorder.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/PathWithBorder.tsx
@@ -17,24 +17,24 @@ const RouteBorder = styled.path`
 `;
 
 type Props = {
-  d: string;
-  routeNumber: number;
-  isSelected: boolean;
-  route: ClimbingRoute;
+  d: string; // TODO this should be moved inside this components
+  routeIndex: number;
   opacity?: number;
 };
 
-export const PathWithBorder = ({
-  d,
-  routeNumber,
-  isSelected,
-  route,
-  opacity,
-}: Props) => {
+export const PathWithBorder = ({ d, routeIndex, opacity }: Props) => {
   const config = useConfig();
   const theme = useTheme();
-  const { routeIndexHovered, isOtherRouteSelected, isEditMode } =
-    useClimbingContext();
+  const {
+    routeIndexHovered,
+    isOtherRouteSelected,
+    isEditMode,
+    routes,
+    isRouteSelected,
+  } = useClimbingContext();
+
+  const route = routes[routeIndex];
+  const isSelected = isRouteSelected(routeIndex);
 
   const strokeColor = getDifficultyColor(
     getDifficulty(route.feature.tags),
@@ -44,7 +44,7 @@ export const PathWithBorder = ({
   const contrastColor = theme.palette.getContrastText(
     isSelected ? config.pathStrokeColorSelected : strokeColor,
   );
-  const isOtherSelected = isOtherRouteSelected(routeNumber);
+  const isOtherSelected = isOtherRouteSelected(routeIndex);
 
   return (
     <>
@@ -68,7 +68,7 @@ export const PathWithBorder = ({
           opacity ? opacity : isOtherSelected ? (isEditMode ? 1 : 0.6) : 1
         }
       />
-      {routeIndexHovered === routeNumber && (
+      {routeIndexHovered === routeIndex && (
         <RouteLine
           d={d}
           strokeWidth={config.pathStrokeWidth}

--- a/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
@@ -53,9 +53,9 @@ export const RoutePath = ({ routeIndex }: Props) => {
     .map(({ x, y }, index) => {
       const position = getPixelPosition({ x, y, units: 'percentage' });
 
-      return `${index === 0 ? 'M' : 'L'}${position.x} ${position.y} `;
+      return `${index === 0 ? 'M' : 'L'}${position.x} ${position.y}`;
     })
-    .join('');
+    .join(' ');
 
   const onMouseMove = (e, segmentIndex: number) => {
     if (
@@ -116,12 +116,7 @@ export const RoutePath = ({ routeIndex }: Props) => {
 
   return (
     <>
-      <PathWithBorder
-        d={`M0 0 ${pointsInString}`}
-        isSelected={isSelected}
-        route={route}
-        routeNumber={routeIndex}
-      />
+      <PathWithBorder d={`${pointsInString}`} routeIndex={routeIndex} />
 
       {!isExtendingDifferentRoute &&
         path.length >= 2 &&

--- a/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutePath.tsx
@@ -116,7 +116,7 @@ export const RoutePath = ({ routeIndex }: Props) => {
 
   return (
     <>
-      <PathWithBorder d={`${pointsInString}`} routeIndex={routeIndex} />
+      <PathWithBorder d={pointsInString} routeIndex={routeIndex} />
 
       {!isExtendingDifferentRoute &&
         path.length >= 2 &&


### PR DESCRIPTION
`d` is left for later

Reducing unneeded props - increasing readabilty.