### PR TITLE
climbing: fix click in canvas to deselect route

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/InteractivePath.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/InteractivePath.tsx
@@ -86,7 +86,10 @@ export const InteractivePath = ({ routeIndex }: Props) => {
         hoveredPosition: getPositionInImageFromMouse(svgRef, e, photoZoom),
         hoveredSegmentIndex: segmentIndex,
       });
-    } else if (isEditMode) {
+      return;
+    }
+
+    if (isEditMode) {
       machine.execute('editRoute', { routeNumber: routeIndex });
     } else {
       machine.execute('routeSelect', { routeNumber: routeIndex });

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -72,7 +72,10 @@ export const RoutesLayer = ({ isVisible }: Props) => {
 
     if (machine.currentStateName === 'pointMenu') {
       machine.execute('cancelPointMenu');
-    } else if (!isPanningActiveRef) {
+      return;
+    }
+
+    if (!isPanningActiveRef.current) {
       machine.execute('cancelRouteSelection');
     }
   };
@@ -108,7 +111,7 @@ export const RoutesLayer = ({ isVisible }: Props) => {
     }
   };
 
-  const handleOnMovingPointDropOnCanvas = () => {
+  const handleOnMovingPointDropped = () => {
     if (isPointMoving) {
       setPointSelectedIndex(null);
       setIsPointMoving(false);
@@ -121,7 +124,7 @@ export const RoutesLayer = ({ isVisible }: Props) => {
     <Svg
       $hasEditableCursor={machine.currentStateName === 'extendRoute'}
       onClick={onClick}
-      onMouseUp={handleOnMovingPointDropOnCanvas}
+      onMouseUp={handleOnMovingPointDropped}
       onPointerMove={onPointerMove}
       $imageSize={imageSize}
       $isVisible={isVisible}


### PR DESCRIPTION
There was missing `.current` in:

```
if (!isPanningActiveRef.current) {
      machine.execute('cancelRouteSelection');
    }
    ```