### PR TITLE
climbing: remove hovered route in mobile

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/PathWithBorder.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/PathWithBorder.tsx
@@ -8,6 +8,7 @@ import {
   getDifficultyColor,
 } from '../../../../services/tagging/climbing/routeGrade';
 import { ClimbingRoute } from '../types';
+import { useMobileMode } from '../../../helpers';
 
 const RouteLine = styled.path`
   pointer-events: none;
@@ -23,6 +24,7 @@ type Props = {
 };
 
 export const PathWithBorder = ({ d, routeIndex, opacity }: Props) => {
+  const isMobileMode = useMobileMode();
   const config = useConfig();
   const theme = useTheme();
   const {
@@ -68,7 +70,7 @@ export const PathWithBorder = ({ d, routeIndex, opacity }: Props) => {
           opacity ? opacity : isOtherSelected ? (isEditMode ? 1 : 0.6) : 1
         }
       />
-      {routeIndexHovered === routeIndex && (
+      {!isMobileMode && routeIndexHovered === routeIndex && (
         <RouteLine
           d={d}
           strokeWidth={config.pathStrokeWidth}

--- a/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/RoutesLayer.tsx
@@ -6,6 +6,7 @@ import { RouteMarks } from './RouteMarks';
 import { InteractivePath } from './InteractivePath';
 import { updateElementOnIndex } from '../utils/array';
 import { getPositionInImageFromMouse } from '../utils/mousePositionUtils';
+import { useMobileMode } from '../../../helpers';
 
 const Svg = styled.svg<{
   $hasEditableCursor: boolean;
@@ -38,6 +39,7 @@ type Props = {
 };
 
 export const RoutesLayer = ({ isVisible }: Props) => {
+  const isMobileMode = useMobileMode();
   const {
     imageSize,
     getMachine,
@@ -145,7 +147,7 @@ export const RoutesLayer = ({ isVisible }: Props) => {
         </>
       ) : null}
 
-      {routeIndexHovered != null ? (
+      {routeIndexHovered != null && !isMobileMode ? (
         <>
           <RouteWithLabel routeIndex={routeIndexHovered} />
           <InteractivePath routeIndex={routeIndexHovered} />


### PR DESCRIPTION
It was leaving hoveredIndex active for a different route then selecting - thus it was darker (not white).