### PR TITLE
EditDialog: fix convertToRelation - add type=site

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -83,19 +83,11 @@ const AccordionComponent = ({
         id="panel1-header"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <Stack
-          direction="row"
-          spacing={2}
-          alignItems="center"
-          justifyContent="space-between"
-          flex="1"
-        >
-          <Stack direction="row" spacing={2} alignItems="center">
-            <SectionName />
-            {membersLength ? (
-              <Chip size="small" label={membersLength} variant="outlined" />
-            ) : null}
-          </Stack>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <SectionName />
+          {membersLength ? (
+            <Chip size="small" label={membersLength} variant="outlined" />
+          ) : null}
         </Stack>
       </AccordionSummary>
       <AccordionDetails>

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -116,19 +116,11 @@ export const ParentsEditor = () => {
         id="panel1-header"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <Stack
-          direction="row"
-          spacing={2}
-          alignItems="center"
-          justifyContent="space-between"
-          flex="1"
-        >
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Typography variant="button">
-              <SectionName />
-            </Typography>
-            <Chip size="small" label={parents.length} variant="outlined" />
-          </Stack>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Typography variant="button">
+            <SectionName />
+          </Typography>
+          <Chip size="small" label={parents.length} variant="outlined" />
         </Stack>
       </AccordionSummary>
       <AccordionDetails>

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/TagsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/TagsEditor.tsx
@@ -108,6 +108,20 @@ const TagsEditorInner = () => {
   );
 };
 
+const TagsCount = () => {
+  const { tagsEntries } = useCurrentItem();
+  if (!tagsEntries.length) {
+    return null;
+  }
+  return (
+    // This is intentionaly Typography, not a Chip. Because the number is not the same importancy level as number of Members/Parents.
+    <Typography variant="caption" color="secondary">
+      {' '}
+      ({tagsEntries.length})
+    </Typography>
+  );
+};
+
 export const TagsEditor = () => {
   const { focusTag } = useEditDialogContext();
   const focusThisEditor = isString(focusTag) && !majorKeys.includes(focusTag);
@@ -137,6 +151,7 @@ export const TagsEditor = () => {
             <AppsIcon />
             <Typography variant="button">
               {t('editdialog.tags_editor')}
+              <TagsCount />
             </Typography>
           </Stack>
         </AccordionSummary>

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -130,7 +130,7 @@ const convertToRelationFactory = (
       const newRelation: DataItem = {
         shortId: newShortId,
         version: undefined,
-        tagsEntries: currentItem.tagsEntries,
+        tagsEntries: [['type', 'site'], ...currentItem.tagsEntries],
         toBeDeleted: false,
         nodeLonLat: undefined,
         nodes: undefined,


### PR DESCRIPTION
Changing Climbing crag to relation was not matching the new preset. Because in id-tagging-schema the relation/node presets are two different: [type/site/climbing/crag.json](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/type/site/climbing/crag.json) and [climbing/crag.json](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/climbing/crag.json)

Also
- remove forgotten old code from #1265 refactoring
- add TagsCount number