### PR TITLE
EditDialog: fix convertToRelation to use clicked position

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSelect/useOptions.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSelect/useOptions.tsx
@@ -55,7 +55,7 @@ const getEmptyOptions = (options: TranslatedPreset[], osmType: OsmType) => {
   const EMPTY_OPTIONS =
     PROJECT_ID === 'openclimbing'
       ? [
-          'climbing/area',
+          'type/site/climbing/area',
           'climbing/crag',
           'climbing/route_bottom',
           ...(osmType === 'way' ? ['climbing/route'] : []), // this preset has both geometris (node,way) we need it offered only for `way`

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -130,11 +130,13 @@ const convertToRelationFactory = (
       const newRelation: DataItem = {
         shortId: newShortId,
         version: undefined,
-        tagsEntries: [
-          ['type', 'site'],
-          ['site', 'climbing'],
-          ...node.tagsEntries,
-        ],
+        tagsEntries: Object.entries(
+          Object.fromEntries([
+            ['type', 'site'],
+            ['site', 'climbing'],
+            ...node.tagsEntries,
+          ]),
+        ),
         toBeDeleted: false,
         nodeLonLat: node.nodeLonLat, // will be used later for first node
         nodes: undefined,

--- a/src/components/FeaturePanel/EditDialog/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/useEditItems.tsx
@@ -25,7 +25,7 @@ export type DataItem = {
   version: number | undefined; // undefined for new item
   tagsEntries: TagsEntries;
   toBeDeleted: boolean;
-  nodeLonLat: LonLat | undefined; // only for nodes
+  nodeLonLat: LonLat | undefined; // only for nodes & for relation converted from node
   nodes: number[] | undefined; // only for ways
   members: Members | undefined; // only for relations
 };
@@ -125,14 +125,18 @@ const convertToRelationFactory = (
       const newData = prevData.map((item) =>
         item.shortId === shortId ? { ...item, toBeDeleted: true } : item,
       );
-      const currentItem = newData.find((item) => item.shortId === shortId);
+      const node = newData.find((item) => item.shortId === shortId);
 
       const newRelation: DataItem = {
         shortId: newShortId,
         version: undefined,
-        tagsEntries: [['type', 'site'], ...currentItem.tagsEntries],
+        tagsEntries: [
+          ['type', 'site'],
+          ['site', 'climbing'],
+          ...node.tagsEntries,
+        ],
         toBeDeleted: false,
-        nodeLonLat: undefined,
+        nodeLonLat: node.nodeLonLat, // will be used later for first node
         nodes: undefined,
         members: [],
       };
@@ -144,7 +148,7 @@ const convertToRelationFactory = (
       );
       newData.push(...newParentItems);
 
-      // update member id everywhere
+      // update member id in every "members" field
       return newData.map((item) => ({
         ...item,
         members: item.members?.map((member) =>

--- a/src/services/tagging/ourPresets.ts
+++ b/src/services/tagging/ourPresets.ts
@@ -56,6 +56,7 @@ export const modifyPresets = (presets: Presets) => {
   presets['climbing/route'].moreFields.push(...routeFields);
   presets['climbing/route_bottom'].moreFields.push(...routeFields);
   presets['climbing/crag'].geometry.push('line'); // line is not intended use, but we need to match way+climbing=crag
+  presets['type/site/climbing/area'].geometry.push('point'); // to be able to create it from node
 
   return presets;
 };


### PR DESCRIPTION
When creating new crag (as a node) and converting it to relation - it was losing the node clicked location. Fixed.

Also added `type/site/climbing/area` to default presets.