### PR TITLE
EditDialog: Fix preset select styling on mobile

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSelect/PresetSelect.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/PresetSelect/PresetSelect.tsx
@@ -36,7 +36,7 @@ const QuasiSelectBox = styled(Box)`
   padding: 10px 14px;
   border: 1px solid ${({ theme }) => theme.palette.action.disabled};
   border-radius: ${({ theme }) => theme.shape.borderRadius}px;
-  min-width: 300px;
+  flex: 1;
   cursor: pointer;
   background-color: ${({ theme }) => theme.palette.background.paper};
   min-height: 40px;


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
