### PR TITLE
climbingTiles: fix skeleton to show name - part 2

### DIFF
--- a/src/components/Map/climbingTiles/climbingTilesSource.ts
+++ b/src/components/Map/climbingTiles/climbingTilesSource.ts
@@ -53,7 +53,7 @@ const processFeature = (
     ...feature,
     properties: {
       ...properties,
-      label: getLabel(properties.label, properties.routeCount),
+      name: getLabel(properties.name, properties.routeCount),
       color,
     },
   };

--- a/src/server/climbing-tiles/buildTileGeojson.ts
+++ b/src/server/climbing-tiles/buildTileGeojson.ts
@@ -55,21 +55,14 @@ const buildGeojson = (record: ClimbingFeaturesRecord): ClimbingTilesFeature => {
     : { type: 'Point', coordinates: [lon, lat] };
 
   const { routeCount, hasImages, gradeId, histogramCode } = record;
-  const name = record.name ? record.name : record.nameRaw;
+  const name = record.name || record.nameRaw;
   const properties: ClimbingTilesProperties =
     type === 'area' || type === 'crag'
-      ? {
-          type,
-          name,
-          label: name,
-          routeCount: routeCount ?? 0,
-          hasImages,
-          histogramCode,
-        }
+      ? { type, name, routeCount: routeCount ?? 0, hasImages, histogramCode }
       : type === 'gym' || type === 'ferrata'
-        ? { type, name, label: name }
+        ? { type, name }
         : type === 'route'
-          ? { type, name, label: name, gradeId }
+          ? { type, name, gradeId }
           : undefined;
 
   return { type: 'Feature', id, geometry, properties };

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export type ClimbingStatsResponse = {
 export type ClimbingTilesProperties = {
   type: 'area' | 'crag' | 'route' | 'gym' | 'ferrata';
   name: string;
-  label: string; // TODO remove 24/8 - only for migration
   // group only:
   routeCount?: number;
   hasImages?: boolean;


### PR DESCRIPTION
use the `name` - it should be cached everywhere now, via #1309 