### PR TITLE
climbing: round openclimbing logo

### DIFF
--- a/public/openclimbing/logo/openclimbing.svg
+++ b/public/openclimbing/logo/openclimbing.svg
@@ -1,5 +1,5 @@
 <svg width="609" height="609" viewBox="0 0 609 609" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="609" height="609" fill="#EB5757"/>
+<path d="M 60,0 L 549,0 A 60,60 0 0 1 609,60 L 609,549 A 60,60 0 0 1 549,609 L 60,609 A 60,60 0 0 1 0,549 L 0,60 A 60,60 0 0 1 60,0 " fill="#EB5757" />
 <mask id="mask0_1702_220" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="609" height="609">
 <rect width="609" height="609" fill="white"/>
 </mask>

--- a/src/assets/LogoOpenClimbing.tsx
+++ b/src/assets/LogoOpenClimbing.tsx
@@ -13,7 +13,10 @@ export const LogoOpenClimbing = ({ width, style }: LogoOpenClimbingProps) => (
     xmlns="http://www.w3.org/2000/svg"
     style={style}
   >
-    <rect width="609" height="609" fill="#EB5757" />
+    <path
+      d="M 60,0 L 549,0 A 60,60 0 0 1 609,60 L 609,549 A 60,60 0 0 1 549,609 L 60,609 A 60,60 0 0 1 0,549 L 0,60 A 60,60 0 0 1 60,0 "
+      fill="#EB5757"
+    />
     <mask
       id="mask0_1702_220"
       style={{ maskType: 'alpha' }}


### PR DESCRIPTION
I wanted to test the new `A` (arc)  command I learned here: https://www.joshwcomeau.com/svg/interactive-guide-to-paths/?utm_source=hackernewsletter :-) feel free to revert.

10% round = 60px radius, manually written


| 1 | 2 |
|--|--|
| <img width="411" height="427" alt="image" src="https://github.com/user-attachments/assets/763b2c95-4023-4597-bda9-49f2cfb87dcf" /> | <img width="411" height="426" alt="image" src="https://github.com/user-attachments/assets/498f8fba-6021-4ffc-b179-68119ac70162" />
