### PR TITLE
EditDialog: show OpenAll only if items not already opened

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -129,7 +129,7 @@ export const MembersEditor = () => {
 
         <Box sx={{ flex: '1' }} />
 
-        {members?.length > 1 && <OpenAllButton onClick={handleOpenAll} />}
+        {handleOpenAll && <OpenAllButton onClick={handleOpenAll} />}
       </Stack>
     </AccordionComponent>
   );

--- a/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
@@ -61,6 +61,14 @@ export const useHandleOpenAllMembers = () => {
   const { addItem, items } = useEditContext();
   const shortIds = members?.map(({ shortId }) => shortId);
 
+  if (!members || members.length < 2) {
+    return undefined;
+  }
+
+  if (members.every((member) => isInItems(items, member.shortId))) {
+    return undefined;
+  }
+
   return async (e: React.MouseEvent) => {
     e.stopPropagation();
     await addAllItems(shortIds, addItem, items);

--- a/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
+++ b/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
@@ -63,7 +63,7 @@ const convert = <T extends OsmItem, TGeometry extends FeatureGeometry>(
     element.tags?.climbing === 'crag'
       ? Math.max(
           element.type === 'relation'
-            ? element.members.filter((member) => member.role === '').length
+            ? element.members.filter((member) => member.role === '').length // TODO filter by member element having climbing=route/route_bottom
             : 0,
           getRouteNumberFromTags(element),
         )


### PR DESCRIPTION
OpenAll button is hidden when:
- only one item
- all items already opened