### PR TITLE
climbingTiles: larger queries to speed up refresh

### DIFF
--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -181,7 +181,7 @@ const refreshInner = async (client: PoolClient) => {
   log(`Records: ${records.length}`);
 
   const columns = Object.keys(records[0]);
-  const chunks = chunk(records, 1000); // XATA max size is probably 4 MB, but it was out of memory on 1.8MB as well. This produces queries about 0.4 MB big
+  const chunks = chunk(records, 10000); // This produces queries about 2 MB big
 
   await client.query('TRUNCATE TABLE climbing_features');
   for (const [index, chunk] of chunks.entries()) {


### PR DESCRIPTION
Neon dosn't have such strange memory limits as xata lite, so we can send 2MB queries which is 1.5x faster
