### PR TITLE
climbingTiles: area default to # of crags + fix points

### DIFF
--- a/src/components/Map/climbingTiles/climbingLayers/groupsLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/groupsLayer.ts
@@ -55,7 +55,7 @@ export const groupsLayer: LayerSpecification = {
   type: 'symbol',
   source: CLIMBING_TILES_SOURCE,
   maxzoom: 20,
-  filter: ['all', ['in', 'type', 'area', 'crag']],
+  filter: ['in', 'type', 'area', 'crag'],
   layout: GROUPS_LAYOUT,
   paint: {
     'icon-opacity': hover(1, 0.6),
@@ -72,7 +72,7 @@ export const groupsLayer: LayerSpecification = {
 export const gymsLayer: LayerSpecification = {
   ...groupsLayer,
   id: 'climbing gym',
-  filter: ['all', ['==', 'type', 'gym']],
+  filter: ['==', 'type', 'gym'],
   minzoom: 9,
   maxzoom: 24,
   layout: {
@@ -84,7 +84,7 @@ export const gymsLayer: LayerSpecification = {
 export const ferrataLayer: LayerSpecification = {
   ...groupsLayer,
   id: 'climbing via_ferrata',
-  filter: ['all', ['==', 'type', 'ferrata']],
+  filter: ['==', 'type', 'ferrata'],
   layout: {
     ...groupsLayer.layout,
     'icon-image': VIA_FERRATA.IMAGE,

--- a/src/components/Map/climbingTiles/climbingLayers/routesLines.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesLines.ts
@@ -8,7 +8,7 @@ export const routesLines: LayerSpecification[] = [
     type: 'line',
     source: CLIMBING_TILES_SOURCE,
     minzoom: 13,
-    filter: ['all', ['==', 'type', 'route']],
+    filter: ['==', 'type', 'route'],
     layout: { 'line-cap': 'round' },
     paint: {
       'line-color': '#f8f4f0',
@@ -21,7 +21,7 @@ export const routesLines: LayerSpecification[] = [
     type: 'line',
     source: CLIMBING_TILES_SOURCE,
     minzoom: 13,
-    filter: ['all', ['==', 'type', 'route']],
+    filter: ['==', 'type', 'route'],
     layout: { 'line-cap': 'round' },
     paint: {
       'line-color': ['coalesce', ['get', 'color'], '#999'],
@@ -34,7 +34,7 @@ export const routesLines: LayerSpecification[] = [
     type: 'line',
     source: CLIMBING_TILES_SOURCE,
     minzoom: 13,
-    filter: ['all', ['==', 'type', 'route']],
+    filter: ['==', 'type', 'route'],
     layout: { 'line-cap': 'round' },
     paint: {
       'line-color': '#000',
@@ -52,7 +52,7 @@ export const routesLines: LayerSpecification[] = [
     metadata: { clickableWithOsmId: true },
     type: 'symbol',
     source: CLIMBING_TILES_SOURCE,
-    filter: ['all', ['==', 'type', 'route']],
+    filter: ['==', 'type', 'route'],
     layout: {
       'symbol-placement': 'line-center',
       'text-font': ['Noto Sans Regular'],

--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -9,7 +9,11 @@ export const routesPoints: LayerSpecification[] = [
     type: 'circle',
     source: CLIMBING_TILES_SOURCE,
     minzoom: 13,
-    filter: ['in', 'type', 'route', 'route_top'],
+    filter: [
+      'all',
+      ['in', 'type', 'route', 'route_top'],
+      ['==', '$type', 'Point'],
+    ],
     paint: {
       'circle-color': [
         'case',


### PR DESCRIPTION
Was 0 - now shows num of crags, which also gives priority to display:
<img width="497" height="438" alt="image" src="https://github.com/user-attachments/assets/c1e5e0fb-462a-4cc9-8c20-4edd7b979890" />


Was
<img width="476" height="242" alt="image" src="https://github.com/user-attachments/assets/da942d4e-13f7-4fe4-b8d3-2614859b06ff" />

now without points:
<img width="504" height="276" alt="image" src="https://github.com/user-attachments/assets/5a0773d0-7c75-4530-9eb2-ec405a58ba2d" />
