### PR TITLE
EditDialog: node location can be undefined

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/EditFeatureMap.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/EditFeatureMap.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import { Chip, CircularProgress, Stack, TextField } from '@mui/material';
+import React, { useEffect } from 'react';
+import { Alert, Chip, CircularProgress } from '@mui/material';
 
 import styled from '@emotion/styled';
-import { t } from '../../../../../../services/intl';
 import { useInitEditFeatureMap } from './useInitEditFeatureMap';
-import { LngLat } from 'maplibre-gl';
 import LayersIcon from '@mui/icons-material/Layers';
 import { getMapStyle } from './getMapStyle';
 import { useCurrentItem } from '../../../context/EditContext';
+import { LocationInputs } from './LocationInputs';
+import { t } from '../../../../../../services/intl';
 
 const Container = styled.div`
   width: 100%;
@@ -36,17 +36,25 @@ const MapStyle = styled.div`
   right: 4px;
 `;
 
+const StyledAlert = styled(Alert)`
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+const NoLocationAlert = () => (
+  <StyledAlert severity="info">{t('editdialog.no_location_alert')}</StyledAlert>
+);
+
 const EditFeatureMap = ({ mapStyle, setMapStyle }) => {
-  const [isFirstMapLoad, setIsFirstMapLoad] = useState(true);
-  const { containerRef, isMapLoaded, currentItem, onMarkerChange, mapRef } =
-    useInitEditFeatureMap(isFirstMapLoad, setIsFirstMapLoad);
+  const { containerRef, isMapLoaded, mapRef } = useInitEditFeatureMap();
 
   useEffect(() => {
     const style = getMapStyle(mapStyle);
     mapRef.current.setStyle(style);
   }, [mapStyle, mapRef]);
 
-  const { shortId } = useCurrentItem();
+  const { shortId, nodeLonLat } = useCurrentItem();
   const isNode = shortId[0] === 'n';
   if (!isNode) return null;
 
@@ -76,36 +84,11 @@ const EditFeatureMap = ({ mapStyle, setMapStyle }) => {
             color="secondary"
           />
         </MapStyle>
+
+        {nodeLonLat === undefined && <NoLocationAlert />}
       </Container>
 
-      <Stack direction="row" mt={2} gap={1}>
-        <TextField
-          label={t('editdialog.location_latitude')}
-          variant="outlined"
-          value={currentItem?.nodeLonLat[1] || ''}
-          onChange={(e) => {
-            onMarkerChange({
-              lng: currentItem?.nodeLonLat[0],
-              lat: parseFloat(e.target.value),
-            } as LngLat);
-            setIsFirstMapLoad(true);
-          }}
-          size="small"
-        />
-        <TextField
-          label={t('editdialog.location_longitude')}
-          variant="outlined"
-          value={currentItem?.nodeLonLat[0] || ''}
-          onChange={(e) => {
-            onMarkerChange({
-              lng: parseFloat(e.target.value),
-              lat: currentItem?.nodeLonLat[1],
-            } as LngLat);
-            setIsFirstMapLoad(true);
-          }}
-          size="small"
-        />
-      </Stack>
+      <LocationInputs key={shortId} />
     </>
   );
 };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationInputs.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationInputs.tsx
@@ -1,0 +1,92 @@
+import { useCurrentItem } from '../../../context/EditContext';
+import React, { useEffect, useRef, useState } from 'react';
+import { LonLat } from '../../../../../../services/types';
+import { Stack, TextField } from '@mui/material';
+import { t } from '../../../../../../services/intl';
+
+const isNumeric = (val: string) => {
+  const str = val
+    .replace(/(\.\d*?)0*$/, '$1')
+    .replace(/\.$/, '')
+    .replace(/^0*(\d)/, '$1');
+  const num = `${parseFloat(val)}`;
+  return str === num;
+};
+
+const LonInput = (props: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  lonError: boolean;
+}) => (
+  <TextField
+    label={t('editdialog.location_longitude')}
+    variant="outlined"
+    value={props.value}
+    onChange={props.onChange}
+    size="small"
+    error={props.value && props.lonError}
+  />
+);
+
+const LatInput = (props: {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  latError: boolean;
+}) => (
+  <TextField
+    label={t('editdialog.location_latitude')}
+    variant="outlined"
+    value={props.value}
+    onChange={props.onChange}
+    size="small"
+    error={props.value && props.latError}
+  />
+);
+
+export const LocationInputs = () => {
+  const { nodeLonLat, setNodeLonLat } = useCurrentItem();
+  const [latError, setLatError] = useState(false);
+  const [lat, setLat] = useState<string>(`${nodeLonLat?.[0] || ''}`);
+  const [lonError, setLonError] = useState(false);
+  const [lon, setLon] = useState<string>(`${nodeLonLat?.[1] || ''}`);
+
+  const updatedFromHere = useRef<LonLat>();
+
+  useEffect(() => {
+    if (nodeLonLat && updatedFromHere.current !== nodeLonLat) {
+      setLat(`${nodeLonLat[1] || ''}`);
+      setLon(`${nodeLonLat[0] || ''}`);
+    }
+  }, [nodeLonLat]);
+
+  const onChange = (lon: string, lat: string) => {
+    const pos = [lon, lat];
+
+    if (pos.every(isNumeric)) {
+      const toBeSet = pos.map(parseFloat);
+      setNodeLonLat(toBeSet);
+      updatedFromHere.current = toBeSet;
+      setLonError(false);
+      setLatError(false);
+    } else {
+      if (!isNumeric(lon)) setLonError(true);
+      if (!isNumeric(lat)) setLatError(true);
+    }
+  };
+
+  const changeLon = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLon(e.target.value);
+    onChange(e.target.value, lat);
+  };
+  const changeLat = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLat(e.target.value);
+    onChange(lon, e.target.value);
+  };
+
+  return (
+    <Stack direction="row" mt={2} gap={1}>
+      <LatInput value={lat} onChange={changeLat} latError={latError} />
+      <LonInput value={lon} onChange={changeLon} lonError={lonError} />
+    </Stack>
+  );
+};

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/getTmpNodePosition.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/getTmpNodePosition.ts
@@ -1,0 +1,68 @@
+import { DataItem } from '../../../context/types';
+import { findInItems } from '../../../context/utils';
+import { getOsmElement } from '../../../../../../services/osm/quickFetchFeature';
+import { getApiId } from '../../../../../../services/helpers';
+import { LonLat } from '../../../../../../services/types';
+import { getGlobalMap } from '../../../../../../services/mapStorage';
+
+const getParent = (items: DataItem[], shortId: string) =>
+  items
+    .filter((item) => item.shortId[0] === 'r')
+    .find((item) => item.members?.some((member) => member.shortId === shortId));
+
+const isNodeOrWay = ({ shortId }) => ['n', 'w'].includes(shortId[0]);
+
+const getMapCenter = (): LonLat => getGlobalMap().getCenter().toArray();
+
+const isExisting = (shortId: string) => !shortId.includes('-');
+
+const getNodeOrWayPoint = async (shortId: string) => {
+  const element = await getOsmElement(getApiId(shortId));
+  if (shortId[0] === 'n') {
+    return [element.lon, element.lat];
+  }
+
+  if (shortId[0] === 'w') {
+    if (element.nodes?.length > 0) {
+      const firstNode = await getOsmElement({
+        type: 'node',
+        id: element.nodes[0],
+      });
+      return [firstNode.lon, firstNode.lat];
+    }
+  }
+
+  return undefined;
+};
+
+const getPositionFromMembers = async (items: DataItem[], parent: DataItem) => {
+  const membersBackwards = parent.members.filter(isNodeOrWay).toReversed();
+  if (!membersBackwards.length) {
+    return undefined;
+  }
+
+  for (const member of membersBackwards) {
+    const item = findInItems(items, member.shortId);
+    if (item?.nodeLonLat) {
+      return item.nodeLonLat;
+    }
+    if (isExisting(member.shortId)) {
+      return await getNodeOrWayPoint(member.shortId);
+    }
+  }
+};
+
+const getNextNodePosition = async (items: DataItem[], shortId: string) => {
+  const parent = getParent(items, shortId);
+  if (!parent) {
+    return undefined;
+  }
+
+  const location = await getPositionFromMembers(items, parent);
+  const moved = location?.map((x) => x + 0.00005); // +- 5m
+
+  return moved ?? parent.relationClickedLonLat; // may be also undefined
+};
+
+export const getTmpNodePosition = async (items: DataItem[], shortId: string) =>
+  (await getNextNodePosition(items, shortId)) ?? getMapCenter();

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useDraggableMarker.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useDraggableMarker.ts
@@ -1,60 +1,75 @@
-import React, { useRef } from 'react';
-import maplibregl, { LngLat } from 'maplibre-gl';
-import { createMapEffectHook } from '../../../../../helpers';
-import { LonLat } from '../../../../../../services/types';
-import { isGpsValid } from './isGpsValid';
-import { useCurrentItem } from '../../../context/EditContext';
+import React, { useEffect, useRef } from 'react';
+import maplibregl, { LngLat, MarkerOptions } from 'maplibre-gl';
+import { useCurrentItem, useEditContext } from '../../../context/EditContext';
+import { getTmpNodePosition } from './getTmpNodePosition';
 
-const MAIN_MARKER = {
-  color: 'salmon',
+const svgHtml = `
+<svg xmlns="http://www.w3.org/2000/svg" width="27" height="41" display="block">
+    <g transform="translate(3 29)">
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="10.5" ry="5.25"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="10.5" ry="5.25"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="9.5" ry="4.773"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="8.5" ry="4.295"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="7.5" ry="3.818"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="6.5" ry="3.341"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="5.5" ry="2.864"/>
+        <ellipse cx="10.5" cy="5.8" opacity=".04" rx="4.5" ry="2.386"/>
+    </g>
+    <path fill="salmon"
+          d="M27 13.5c0 5.575-6.75 13.5-12.25 21-.733 1-1.767 1-2.5 0C6.75 27 0 19.223 0 13.5 0 6.044 6.044 0 13.5 0S27 6.044 27 13.5Z"/>
+    <path d="M13.5 0C6.044 0 0 6.044 0 13.5c0 5.723 6.75 13.5 12.25 21 .75 1.023 1.767 1 2.5 0C20.25 27 27 19.075 27 13.5 27 6.044 20.956 0 13.5 0Zm0 1C20.415 1 26 6.585 26 13.5c0 2.399-1.504 5.681-3.78 9.238-2.274 3.557-5.515 7.404-8.277 11.17-.2.273-.33.415-.443.533a4.934 4.934 0 0 1-.443-.533c-2.773-3.78-5.642-7.594-8.041-11.135C2.616 19.233 1 15.953 1 13.5 1 6.585 6.585 1 13.5 1Z"
+          opacity=".25"/>
+    <path d="m13.825 4.872 3.44 3.561-1.147 1.187-1.482-1.534v4.573h4.573l-1.535-1.482 1.187-1.147 3.561 3.44-3.56 3.438-1.188-1.146 1.535-1.482h-4.573v4.573l1.482-1.535 1.146 1.187-3.439 3.561-3.439-3.56 1.147-1.188 1.482 1.535V14.28H8.44l1.535 1.482-1.187 1.146-3.561-3.439 3.561-3.439 1.187 1.147-1.535 1.482h4.574V8.086L11.533 9.62l-1.147-1.187Z"
+          fill="#fff"/>
+</svg>`;
+
+const markerWithArrows = document.createElement('div');
+markerWithArrows.style.width = '27px';
+markerWithArrows.style.height = '41px';
+markerWithArrows.style.zIndex = '999';
+markerWithArrows.innerHTML = svgHtml;
+
+const MAIN_MARKER: MarkerOptions = {
   draggable: true,
+  element: markerWithArrows,
+  offset: [0, -14],
 };
-
-const useUpdateDraggableFeatureMarker = createMapEffectHook<
-  [
-    {
-      onMarkerChange: (lngLat: LngLat) => void;
-      nodeLonLat: LonLat;
-      markerRef: React.MutableRefObject<maplibregl.Marker>;
-    },
-  ]
->((map, props) => {
-  const { markerRef, nodeLonLat, onMarkerChange } = props;
-
-  const onDragEnd = () => {
-    const lngLat = markerRef.current?.getLngLat();
-    if (lngLat) {
-      onMarkerChange(lngLat);
-    }
-  };
-
-  markerRef.current?.remove();
-  markerRef.current = undefined;
-
-  if (nodeLonLat && isGpsValid(nodeLonLat)) {
-    markerRef.current = new maplibregl.Marker(MAIN_MARKER)
-      .setLngLat(nodeLonLat as [number, number])
-      .addTo(map);
-
-    markerRef.current?.on('dragend', onDragEnd);
-  }
-});
 
 export function useDraggableFeatureMarker(
   mapRef: React.MutableRefObject<maplibregl.Map>,
 ) {
-  const currentItem = useCurrentItem();
+  const map = mapRef.current;
+  const { items } = useEditContext();
+  const { nodeLonLat, setNodeLonLat, shortId } = useCurrentItem();
   const markerRef = useRef<maplibregl.Marker>();
+
+  useEffect(() => {
+    (async () => {
+      if (!map) {
+        return;
+      }
+
+      markerRef.current?.remove();
+      markerRef.current = undefined;
+
+      const tmpPos = nodeLonLat ?? (await getTmpNodePosition(items, shortId));
+      if (tmpPos) {
+        markerRef.current = new maplibregl.Marker(MAIN_MARKER)
+          .setLngLat(tmpPos as [number, number])
+          .addTo(map);
+        map.easeTo({ center: tmpPos as [number, number] });
+
+        markerRef.current.on('dragend', () => {
+          setNodeLonLat(markerRef.current?.getLngLat().toArray());
+        });
+      }
+    })();
+  }, [items, map, nodeLonLat, setNodeLonLat, shortId]);
 
   const onMarkerChange = ({ lng, lat }: LngLat) => {
     const newLonLat = [lng, lat];
-    currentItem.setNodeLonLat(newLonLat);
+    setNodeLonLat(newLonLat);
   };
 
-  useUpdateDraggableFeatureMarker(mapRef.current, {
-    onMarkerChange,
-    nodeLonLat: currentItem?.nodeLonLat,
-    markerRef,
-  });
   return { onMarkerChange };
 }

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useStaticMarkers.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/useStaticMarkers.tsx
@@ -38,10 +38,7 @@ const useUpdateFeatureMarkers = createMapEffectHook<
     const [lng, lat] = item.nodeLonLat;
 
     const marker = new maplibregl.Marker(GRAY_MARKER)
-      .setLngLat({
-        lng: parseFloat(lng.toFixed(6)),
-        lat: parseFloat(lat.toFixed(6)),
-      })
+      .setLngLat({ lng, lat })
       .addTo(map);
 
     const popupContainer = document.createElement('div');

--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemEditSection.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemEditSection.tsx
@@ -13,6 +13,7 @@ import { Box } from '@mui/material';
 
 export const ItemEditSection = () => {
   const { toBeDeleted } = useCurrentItem();
+  const { shortId } = useCurrentItem();
   if (toBeDeleted) {
     return (
       <>
@@ -26,7 +27,7 @@ export const ItemEditSection = () => {
     <>
       <ItemHeading />
       <PresetSelect />
-      <MajorKeysEditor />
+      <MajorKeysEditor key={shortId} />
       <ClimbingEditor />
       <TagsEditor />
       <LocationEditor />

--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
@@ -11,6 +11,7 @@ import { useEditContext } from '../context/EditContext';
 import React from 'react';
 import { NwrIcon } from '../../NwrIcon';
 import { EditDataItem } from '../context/types';
+import WarningIcon from '@mui/icons-material/Warning';
 
 const StyledTypography = styled(Typography, {
   shouldForwardProp: (prop) => !prop.startsWith('$'),
@@ -55,41 +56,51 @@ const ModifiedBadge = styled.div(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
 }));
 
+const StyledWarningIcon = styled(WarningIcon)`
+  font-size: 15px;
+`;
+
+const WarningBadge = ({ item }: { item: EditDataItem }) => {
+  const { validate } = useEditContext();
+  return validate &&
+    item.shortId[0] === 'n' &&
+    item.nodeLonLat === undefined ? (
+    <StyledWarningIcon color="warning" />
+  ) : null;
+};
+
 type TabLabelProps = {
   item: EditDataItem;
 };
 
-const TabLabel = ({
-  item: { shortId, tags, presetLabel, toBeDeleted, modified },
-}: TabLabelProps) => (
-  <>
-    {modified && <ModifiedBadge />}
-    <Stack direction="column" alignItems="flex-start" width="100%">
-      <Stack
-        direction="row"
-        gap={1}
-        alignItems="center"
-        justifyContent="space-between"
-        width="100%"
-      >
-        <StyledTypography
-          variant="button"
+const TabLabel = ({ item }: TabLabelProps) => {
+  const { shortId, tags, presetLabel, toBeDeleted, modified } = item;
+
+  return (
+    <>
+      {modified && <ModifiedBadge />}
+      <Stack direction="column" alignItems="flex-start" width="100%">
+        <Stack direction="row" gap={1} alignItems="center" width="100%">
+          <WarningBadge item={item} />
+          <StyledTypography
+            variant="button"
+            whiteSpace="nowrap"
+            $deleted={toBeDeleted}
+          >
+            {tags.name || shortId}
+          </StyledTypography>
+        </Stack>
+        <Typography
+          variant="caption"
+          textTransform="lowercase"
           whiteSpace="nowrap"
-          $deleted={toBeDeleted}
         >
-          {tags.name || shortId}
-        </StyledTypography>
+          {presetLabel} <NwrIcon shortId={shortId} hideNode />
+        </Typography>
       </Stack>
-      <Typography
-        variant="caption"
-        textTransform="lowercase"
-        whiteSpace="nowrap"
-      >
-        {presetLabel} <NwrIcon shortId={shortId} hideNode />
-      </Typography>
-    </Stack>
-  </>
-);
+    </>
+  );
+};
 
 export const ItemsTabs = () => {
   const { items, current, setCurrent } = useEditContext();

--- a/src/components/FeaturePanel/EditDialog/context/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/EditContext.tsx
@@ -20,6 +20,8 @@ type EditContextType = {
   items: EditDataItem[];
   current: string;
   setCurrent: Setter<string>;
+  validate: boolean;
+  setValidate: Setter<boolean>;
 };
 
 const EditContext = createContext<EditContextType>(undefined);
@@ -29,6 +31,7 @@ export const EditContextProvider: React.FC = ({ children }) => {
   const [isSaving, setIsSaving] = useState(false);
   const [location, setLocation] = useState(''); // only for note
   const [comment, setComment] = useState('');
+  const [validate, setValidate] = useState(false);
   const { items, addItem, removeItem } = useEditItems();
   const [current, setCurrent] = useState<ShortId>(''); // to get currentItem - use `useCurrentItem()`
 
@@ -46,6 +49,8 @@ export const EditContextProvider: React.FC = ({ children }) => {
     items,
     current,
     setCurrent,
+    validate,
+    setValidate,
   };
 
   return <EditContext.Provider value={value}>{children}</EditContext.Provider>;

--- a/src/components/FeaturePanel/EditDialog/context/itemsHelpers.ts
+++ b/src/components/FeaturePanel/EditDialog/context/itemsHelpers.ts
@@ -30,7 +30,7 @@ export const addEmptyOriginalState = (dataItem: DataItemRaw): DataItem => ({
 });
 
 export const getNewNodeItem = (
-  [lon, lat]: LonLat,
+  nodeLonLat: LonLat | undefined,
   tags: FeatureTags = {},
 ): DataItem =>
   addEmptyOriginalState({
@@ -38,7 +38,7 @@ export const getNewNodeItem = (
     version: undefined,
     tagsEntries: Object.entries(tags),
     toBeDeleted: false,
-    nodeLonLat: [lon, lat],
+    nodeLonLat,
   });
 
 const getLabel = (itemsMap: ItemsMap, member: RelationMember) => {

--- a/src/components/FeaturePanel/EditDialog/context/types.ts
+++ b/src/components/FeaturePanel/EditDialog/context/types.ts
@@ -22,7 +22,7 @@ export type DataItem = {
     nodes: number[] | undefined;
     members: Members;
   };
-  nodeLonLat?: LonLat; // only for nodes
+  nodeLonLat?: LonLat; // only for nodes (may be undefined until user selects the location)
   nodes?: number[]; // only for ways
   members?: Members; // only for relations
   relationClickedLonLat?: LonLat; // only for relations (converted from clicked node)

--- a/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
+++ b/src/components/FeaturePanel/EditDialog/useGetHandleSave.tsx
@@ -42,11 +42,22 @@ export const useGetHandleSave = () => {
   const { loggedIn, handleLogout } = useOsmAuthContext();
   const { feature } = useEditDialogFeature();
   const { setRedirectOnClose } = useEditDialogContext();
-  const { setSuccessInfo, setIsSaving, comment, items } = useEditContext();
+  const { setSuccessInfo, setIsSaving, comment, items, setValidate } =
+    useEditContext();
   const saveNote = useGetSaveNote();
 
   return async () => {
     try {
+      if (
+        items
+          .filter(({ shortId }) => shortId[0] === 'n')
+          .some(({ nodeLonLat }) => nodeLonLat === undefined)
+      ) {
+        showToast(t('editdialog.set_location_for_all_items'), 'warning');
+        setValidate(true);
+        return;
+      }
+
       setIsSaving(true);
 
       const changes = items.filter((item) => item.modified);

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -245,6 +245,8 @@ export default {
   'editdialog.download_osc': 'Stáhnout osmChange',
   'editdialog.members_climbing_info':
     'Do relace lze přidat i jiné relevantní objekty, jako třeba parkoviště nebo referenci na konkrétní vrchol či sráz (natural=cliff).',
+  'editdialog.no_location_alert': 'Nastavte, prosím, polohu tažením bodu.',
+  'editdialog.set_location_for_all_items': 'Nastave, prosím, polohu všem prvkům.',
 
   'editsuccess.close_button': 'Zavřít',
   'editsuccess.note.heading': 'Děkujeme za Váš návrh!',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -283,6 +283,8 @@ export default {
   'editdialog.download_osc': 'Download osmChange',
   'editdialog.members_climbing_info':
     'Members of climbing crag can also be other relevant objects, like parking or reference to specific peak or cliff (natural=cliff).',
+  'editdialog.no_location_alert': 'Please set a location by dragging the marker.',
+  'editdialog.set_location_for_all_items': 'Please set a location for all items.',
 
   'editsuccess.close_button': 'Done',
   'editsuccess.note.heading': 'Thank you for your suggestion!',


### PR DESCRIPTION
After conversion of node (climbing crag) to relation, user can add nodes in bulk and forget to set location.

This PR enables nodes to have nodeLonLat=undefined, and forbids user to save it. 

<img width="712" height="657" alt="image" src="https://github.com/user-attachments/assets/aa60dfd2-ddbc-4df2-83cf-b3b7795042f7" />
