### PR TITLE
EditDialog: revert automatic closing of MajorKeysEditor fields

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemEditSection.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemEditSection.tsx
@@ -27,7 +27,7 @@ export const ItemEditSection = () => {
     <>
       <ItemHeading />
       <PresetSelect />
-      <MajorKeysEditor key={shortId} />
+      <MajorKeysEditor />
       <ClimbingEditor />
       <TagsEditor />
       <LocationEditor />


### PR DESCRIPTION
Introduced in #1362