### PR TITLE
climbingTiles: show area of areas + refactor&test

### DIFF
--- a/src/helpers/eslint-local-rules/ruleMaxLinesPerFunction.js
+++ b/src/helpers/eslint-local-rules/ruleMaxLinesPerFunction.js
@@ -4,6 +4,8 @@ const path = require('path');
 const MAX_LINES = 50;
 
 const IGNORED = [
+  '.test.ts',
+  '.test.tsx',
   'GlobalStyle.tsx',
   'FaviconsOsmapp.tsx',
   'FaviconsOpenClimbing.tsx',

--- a/src/server/climbing-tiles/overpass/__tests__/basic.test.ts
+++ b/src/server/climbing-tiles/overpass/__tests__/basic.test.ts
@@ -1,137 +1,213 @@
-const elements = [
-  // OsmElement[]
-  // {
-  //     "type": "node",
-  //     "id": 313822575,
-  //     "lat": 50.0547464,
-  //     "lon": 14.4056821,
-  //     "tags": {
-  //         "climbing:boulder": "yes",
-  //         "climbing:toprope": "yes",
-  //         "leisure": "sports_centre",
-  //         "name": "SmíchOFF",
-  //         "opening_hours": "Mo 07:00-23:00; Tu-Th 07:00-23:30; Fr 07:00-23:00; Sa,Su 08:00-23:00",
-  //         "sport": "climbing",
-  //         "website": "https://www.lezeckecentrum.cz/"
-  //     }
-  // },
-  {
-    type: 'node',
-    id: 11580052710,
-    lat: 49.6600391,
-    lon: 14.2573987,
-    tags: {
-      climbing: 'route_bottom',
-      'climbing:grade:uiaa': '9-',
-      name: 'Lída',
-      sport: 'climbing',
-      wikimedia_commons: 'File:Roviště - Hafty2.jpg',
-      'wikimedia_commons:2': 'File:Roviště - Hafty3.jpg',
-      'wikimedia_commons:2:path':
-        '0.273,0.904|0.229,0.566B|0.317,0.427B|0.433,0.329B|0.515,0.21B|0.526,0.126B|0.495,0.075A',
-      'wikimedia_commons:path':
-        '0.67,0.601|0.66,0.442B|0.682,0.336B|0.739,0.236B|0.733,0.16B|0.72,0.1B|0.688,0.054A',
-    },
+import { OsmItem, OsmResponse } from '../types';
+import { overpassToGeojsons } from '../overpassToGeojsons';
+
+const otherCrag: OsmItem = {
+  type: 'node',
+  id: 111,
+  lat: 49.6601234,
+  lon: 14.2571299,
+  tags: {
+    climbing: 'crag',
+    'climbing:sport': '50',
+    name: 'Other crag in Roviště',
   },
-  {
-    type: 'relation',
-    id: 17130663,
-    members: [
-      {
-        type: 'node',
-        ref: 11580052710,
-        role: '',
+};
+
+const response: OsmResponse = {
+  osm3s: { timestamp_osm_base: 'string' }, // overpass only
+  elements: [
+    otherCrag,
+    {
+      type: 'node',
+      id: 11580052710,
+      lat: 49.6600391,
+      lon: 14.2573987,
+      tags: {
+        climbing: 'route_bottom',
+        'climbing:grade:uiaa': '1+', // so the histogram is shorter
+        name: 'Lída',
+        wikimedia_commons: 'File:Roviště - Hafty2.jpg',
+        'wikimedia_commons:path': '0.67,0.601|0.66,0.442A',
       },
-    ],
-    tags: {
-      climbing: 'crag',
-      name: 'Yosemite (Hafty)',
-      site: 'climbing',
-      sport: 'climbing',
-      type: 'site',
-      wikimedia_commons: 'File:Roviště - Hafty.jpg',
-      'wikimedia_commons:10': 'File:Roviště - Hafty10.jpg',
-      'wikimedia_commons:2': 'File:Roviště - Hafty2.jpg',
-      'wikimedia_commons:3': 'File:Roviště - Hafty3.jpg',
-      'wikimedia_commons:4': 'File:Roviště - Hafty4.jpg',
-      'wikimedia_commons:5': 'File:Roviště - Hafty5.jpg',
-      'wikimedia_commons:6': 'File:Roviště - Hafty6.jpg',
-      'wikimedia_commons:7': 'File:Roviště - Hafty7.jpg',
-      'wikimedia_commons:8': 'File:Roviště - Hafty8.jpg',
-      'wikimedia_commons:9': 'File:Roviště - Hafty9.jpg',
     },
-  },
-  {
-    type: 'relation',
-    id: 17130099,
-    members: [
-      {
-        type: 'relation',
-        ref: 17130663,
-        role: '',
+    {
+      type: 'node',
+      id: 12361011879,
+      lat: 49.6601234,
+      lon: 14.2571299,
+      tags: {
+        climbing: 'route',
+        'climbing:grade:uiaa': '1-',
+        name: 'Bílé ticho',
       },
-    ],
-    tags: {
-      climbing: 'area',
-      description:
-        'Roviště je klasická vltavská žula. Jedná se o velmi vyhlášenou oblast. Nabízí cesty prakticky všech obtížností, zpravidla dobře odjištěné.',
-      name: 'Roviště',
-      site: 'climbing',
-      type: 'site',
-      website: 'https://www.horosvaz.cz/skaly-sektor-289/',
-      'website:2': 'https://www.lezec.cz/pruvodcx.php?key=5',
     },
-  },
-
-  // two nodes and a climbing=route way
-  {
-    type: 'node',
-    id: 1,
-    lat: 50,
-    lon: 14,
-    tags: {},
-  },
-  {
-    type: 'node',
-    id: 2,
-    lat: 51,
-    lon: 15,
-    tags: {},
-  },
-  {
-    type: 'way',
-    id: 3,
-    nodes: [1, 2],
-    tags: {
-      climbing: 'route',
-      name: 'Route of type way starting on 14,50',
+    {
+      type: 'relation',
+      id: 17130663,
+      members: [
+        { type: 'node', ref: 12361011879, role: '' },
+        { type: 'node', ref: 11580052710, role: '' },
+      ],
+      tags: {
+        climbing: 'crag',
+        name: 'Yosemite (Hafty)',
+        wikimedia_commons: 'File:Roviště - Hafty.jpg',
+      },
     },
-  },
-
-  // two nodes and natural=cliff way ("crag")
-  {
-    type: 'node',
-    id: 4,
-    lat: 52,
-    lon: 16,
-    tags: {},
-  },
-  {
-    type: 'node',
-    id: 5,
-    lat: 53,
-    lon: 17,
-    tags: {},
-  },
-  {
-    type: 'way',
-    id: 6,
-    nodes: [4, 5],
-    tags: {
-      natural: 'cliff',
-      name: 'Cliff of type way at 16.5,52.5',
+    {
+      type: 'relation',
+      id: 17130099,
+      members: [
+        { type: 'relation', ref: 17130663, role: '' },
+        { type: 'node', ref: 111, role: '' },
+      ],
+      tags: { climbing: 'area', name: 'Roviště' },
     },
-  },
-];
+    {
+      type: 'relation',
+      id: 999,
+      members: [{ type: 'relation', ref: 17130099, role: '' }],
+      tags: { climbing: 'area', name: 'Area of areas' },
+    },
+  ],
+};
 
-test('noop', () => {});
+test('climbingTiles overpassToGeojson basic', () => {
+  const result = overpassToGeojsons(response, () => {});
+
+  expect(result.node).toEqual([
+    {
+      center: [14.2571299, 49.6601234],
+      geometry: { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+      id: 1110,
+      osmMeta: { id: 111, type: 'node' },
+      properties: { hasImages: false, routeCount: 50, parentId: 17130099 },
+      tags: {
+        climbing: 'crag',
+        'climbing:sport': '50',
+        name: 'Other crag in Roviště',
+      },
+      type: 'Feature',
+    },
+    {
+      center: [14.2573987, 49.6600391],
+      geometry: { coordinates: [14.2573987, 49.6600391], type: 'Point' },
+      id: 115800527100,
+      osmMeta: { id: 11580052710, type: 'node' },
+      properties: { hasImages: true, parentId: 17130663 },
+      tags: {
+        climbing: 'route_bottom',
+        'climbing:grade:uiaa': '1+',
+        name: 'Lída',
+        wikimedia_commons: 'File:Roviště - Hafty2.jpg',
+        'wikimedia_commons:path': '0.67,0.601|0.66,0.442A',
+      },
+      type: 'Feature',
+    },
+    {
+      center: [14.2571299, 49.6601234],
+      geometry: { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+      id: 123610118790,
+      osmMeta: { id: 12361011879, type: 'node' },
+      properties: { hasImages: false, parentId: 17130663 },
+      tags: {
+        climbing: 'route',
+        'climbing:grade:uiaa': '1-',
+        name: 'Bílé ticho',
+      },
+      type: 'Feature',
+    },
+  ]);
+
+  expect(result.relation).toEqual([
+    {
+      center: [14.2572643, 49.660081250000005],
+      geometry: {
+        geometries: [
+          {
+            geometries: [
+              {
+                geometries: [
+                  { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+                  { coordinates: [14.2573987, 49.6600391], type: 'Point' },
+                ],
+                type: 'GeometryCollection',
+              },
+              { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+            ],
+            type: 'GeometryCollection',
+          },
+        ],
+        type: 'GeometryCollection',
+      },
+      id: 9994,
+      members: [{ ref: 17130099, role: '', type: 'relation' }],
+      osmMeta: { id: 999, type: 'relation' },
+      properties: {
+        hasImages: true,
+        histogram: [1, undefined, 1],
+        routeCount: 52,
+      },
+      tags: { climbing: 'area', name: 'Area of areas' },
+      type: 'Feature',
+    },
+    {
+      center: [14.2572643, 49.660081250000005],
+      geometry: {
+        geometries: [
+          {
+            geometries: [
+              { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+              { coordinates: [14.2573987, 49.6600391], type: 'Point' },
+            ],
+            type: 'GeometryCollection',
+          },
+          { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+        ],
+        type: 'GeometryCollection',
+      },
+      id: 171300994,
+      members: [
+        { ref: 17130663, role: '', type: 'relation' },
+        { ref: 111, role: '', type: 'node' },
+      ],
+      osmMeta: { id: 17130099, type: 'relation' },
+      properties: {
+        hasImages: true,
+        histogram: [1, undefined, 1],
+        parentId: 999,
+        routeCount: 52,
+      },
+      tags: { climbing: 'area', name: 'Roviště' },
+      type: 'Feature',
+    },
+    {
+      center: [14.2572643, 49.660081250000005],
+      geometry: {
+        geometries: [
+          { coordinates: [14.2571299, 49.6601234], type: 'Point' },
+          { coordinates: [14.2573987, 49.6600391], type: 'Point' },
+        ],
+        type: 'GeometryCollection',
+      },
+      id: 171306634,
+      members: [
+        { ref: 12361011879, role: '', type: 'node' },
+        { ref: 11580052710, role: '', type: 'node' },
+      ],
+      osmMeta: { id: 17130663, type: 'relation' },
+      properties: {
+        hasImages: true,
+        histogram: [1, undefined, 1],
+        parentId: 17130099,
+        routeCount: 2,
+      },
+      tags: {
+        climbing: 'crag',
+        name: 'Yosemite (Hafty)',
+        wikimedia_commons: 'File:Roviště - Hafty.jpg',
+      },
+      type: 'Feature',
+    },
+  ]);
+});

--- a/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
+++ b/src/server/climbing-tiles/overpass/overpassToGeojsons.ts
@@ -1,9 +1,4 @@
-import {
-  FeatureGeometry,
-  LineString,
-  OsmId,
-  Point,
-} from '../../../services/types';
+import { FeatureGeometry, OsmId } from '../../../services/types';
 import { getCenter } from '../../../services/getCenter';
 import { getHistogram, sumMemberHistograms } from './histogram';
 import {
@@ -25,7 +20,7 @@ const getItems = (elements: OsmItem[], log: (message: string) => void) => {
   const nodes: OsmNode[] = [];
   const ways: OsmWay[] = [];
   const relations: OsmRelation[] = [];
-  elements.forEach((element) => {
+  for (const element of elements) {
     if (element.type === 'node') {
       nodes.push(element);
     } else if (element.type === 'way') {
@@ -37,134 +32,163 @@ const getItems = (elements: OsmItem[], log: (message: string) => void) => {
         log(`Skipping relation without members: relation/${element.id}`);
       }
     }
-  });
+  }
   return { nodes, ways, relations };
 };
 
-const getRouteNumberFromTags = (element: OsmItem) => {
-  const sport = parseFloat(element.tags['climbing:sport'] ?? '0');
-  const trad = parseFloat(element.tags['climbing:trad'] ?? '0');
-  const ice = parseFloat(element.tags['climbing:ice'] ?? '0');
-  const multipitch = parseFloat(element.tags['climbing:multipitch'] ?? '0');
-  const sum = sport + trad + ice + multipitch;
-
-  return Number.isNaN(sum) ? 1 : sum; // can be eg. "yes" .. eg. relation/15056469
+const safeParseFloat = (value: string | undefined): number => {
+  const num = parseFloat(value ?? '0');
+  return Number.isNaN(num) ? 0 : num;
 };
 
-const getRouteCount = <T extends OsmItem>(element: T) => {
-  if (element.tags?.climbing === 'crag') {
-    return Math.max(
-      element.type === 'relation'
-        ? element.members.filter((member) => member.role === '').length // TODO filter by member element having climbing=route/route_bottom
-        : 0,
-      getRouteNumberFromTags(element),
-    );
-  }
-  return undefined;
+const getRouteNumberFromTags = ({ tags }: OsmItem) => {
+  const sum =
+    safeParseFloat(tags['climbing:sport']) +
+    safeParseFloat(tags['climbing:trad']) +
+    safeParseFloat(tags['climbing:ice']) +
+    safeParseFloat(tags['climbing:multipitch']);
+
+  return sum > 0 ? sum : 1; // default 1 for crag with unknown count (needed for proper z-index in map)
 };
 
-const convert = <T extends OsmItem, TGeometry extends FeatureGeometry>(
-  element: T,
-  geometryFn: (element: T) => TGeometry,
-  lookup: Lookup,
-): GeojsonFeature<TGeometry> => {
+const isRoute = (member: GeojsonFeature) =>
+  ['route', 'route_bottom'].includes(member.tags.climbing);
+
+const hasOwnImages = (element: OsmItem) =>
+  Object.keys(element.tags ?? {}).some((key) =>
+    key.startsWith('wikimedia_commons'),
+  );
+
+const hasMemberImages = (member: GeojsonFeature) =>
+  member?.properties.hasImages;
+
+const getCommonFields = (
+  element: OsmItem,
+  geometry: FeatureGeometry,
+): GeojsonFeature => {
   const { type, id, tags = {} } = element;
-  const geometry = geometryFn(element);
   const center = getCenter(geometry) ?? undefined;
-  const histogram = getHistogram(element, lookup);
-
-  const properties: GeojsonFeature['properties'] = {
-    routeCount: getRouteCount(element),
-    hasImages: Object.keys(tags).some((key) =>
-      key.startsWith('wikimedia_commons'),
-    ),
-    histogram,
-  };
 
   return {
     type: 'Feature',
     id: convertOsmIdToMapId({ type, id }),
     osmMeta: { type, id },
     tags,
-    properties,
     geometry,
     center,
     members: element.type === 'relation' ? element.members : undefined,
+    properties: {},
   };
 };
 
-const getNodeGeomFn =
-  () =>
-  (node: any): Point => ({
-    type: 'Point',
+const getNodeWayProperties = (element: OsmNode | OsmWay) => {
+  const { tags = {} } = element;
+
+  if (
+    tags.climbing === 'crag' ||
+    tags.climbing === 'area' ||
+    tags.natural === 'cliff' ||
+    tags.natural === 'peak'
+  ) {
+    return {
+      hasImages: hasOwnImages(element),
+      routeCount: getRouteNumberFromTags(element),
+    };
+  }
+
+  return {
+    hasImages: hasOwnImages(element),
+  };
+};
+
+const convertNode = (node: OsmNode): GeojsonFeature => {
+  const geometry = {
+    type: 'Point' as const,
     coordinates: [node.lon, node.lat],
-  });
-
-const getWayGeomFn =
-  (lookup: Lookup) =>
-  ({ nodes }: OsmWay): LineString => ({
-    type: 'LineString' as const,
-    coordinates: nodes
-      .map((ref) => lookup.node[ref]?.geometry?.coordinates)
-      .filter(Boolean), // some nodes may be missing
-  });
-
-const getRelationGeomFn =
-  (lookup: Lookup) =>
-  ({ members, center }: OsmRelation): FeatureGeometry => {
-    const geometries = members
-      .map(({ type, ref }) => lookup[type][ref]?.geometry)
-      .filter(Boolean); // some members may be undefined in first pass
-
-    return geometries.length
-      ? {
-          type: 'GeometryCollection',
-          geometries,
-        }
-      : center
-        ? { type: 'Point', coordinates: [center.lon, center.lat] }
-        : undefined;
   };
 
-const addToLookup = <T extends FeatureGeometry>(
-  items: GeojsonFeature<T>[],
+  return {
+    ...getCommonFields(node, geometry),
+    properties: getNodeWayProperties(node),
+  };
+};
+
+const convertWay = (way: OsmWay, lookup: Lookup): GeojsonFeature => {
+  const geometry = {
+    type: 'LineString' as const,
+    coordinates: way.nodes
+      .map((ref) => lookup.node[ref]?.geometry?.coordinates)
+      .filter(Boolean),
+  };
+
+  return {
+    ...getCommonFields(way, geometry),
+    properties: getNodeWayProperties(way),
+  };
+};
+
+const getRelationProperties = (
+  relation: OsmRelation,
+  members: GeojsonFeature[],
+) => {
+  const { tags = {} } = relation;
+
+  if (tags.climbing === 'crag') {
+    return {
+      hasImages: hasOwnImages(relation) || members.some(hasMemberImages),
+      histogram: getHistogram(members),
+      routeCount: Math.max(
+        members.filter(isRoute).length,
+        getRouteNumberFromTags(relation),
+      ),
+    };
+  }
+
+  if (tags.climbing === 'area') {
+    return {
+      hasImages: hasOwnImages(relation) || members.some(hasMemberImages),
+      histogram: sumMemberHistograms(members),
+      routeCount: members
+        .map((member) => member?.properties.routeCount ?? 1)
+        .reduce((acc, count) => acc + count, 0),
+    };
+  }
+
+  return {};
+};
+
+const lookupRelationMembers = (element: OsmItem, lookup: Lookup) =>
+  element.type === 'relation'
+    ? element.members.map(({ type, ref }) => lookup[type][ref]).filter(Boolean) // some members may be undefined in first pass
+    : [];
+
+const convertRelation = (
+  relation: OsmRelation,
   lookup: Lookup,
+): GeojsonFeature => {
+  const members = lookupRelationMembers(relation, lookup); // TODO lookup-members + common-fields are repeated in each pass (unneccesary)
+  const geometry = members.length
+    ? {
+        type: 'GeometryCollection' as const,
+        geometries: members.map(({ geometry }) => geometry),
+      }
+    : undefined;
+
+  return {
+    ...getCommonFields(relation, geometry),
+    properties: getRelationProperties(relation, members),
+  };
+};
+
+const addToLookup = <T extends FeatureGeometry>(
+  lookup: Lookup,
+  items: GeojsonFeature<T>[],
 ) => {
   items.forEach((item) => {
     // @ts-ignore
     lookup[item.osmMeta.type][item.osmMeta.id] = item; // eslint-disable-line no-param-reassign
   });
 };
-
-const getRelationsWithAreaCount = (
-  relations: GeojsonFeature[],
-  lookup: Record<string, Record<string, GeojsonFeature>>,
-): GeojsonFeature[] =>
-  relations.map((relation) => {
-    if (relation.tags?.climbing === 'area') {
-      const members = relation.members.map(
-        ({ type, ref }) => lookup[type][ref]?.properties,
-      );
-      const routeCount = members
-        .map((member) => member?.routeCount ?? 1)
-        .reduce((acc, count) => acc + count);
-      const hasImages = members.some((member) => member?.hasImages);
-
-      const histogram = sumMemberHistograms(members);
-
-      return {
-        ...relation,
-        properties: {
-          ...relation.properties,
-          routeCount,
-          hasImages,
-          histogram,
-        },
-      };
-    }
-
-    return relation;
-  });
 
 const addParentIds = (lookup: Lookup) => {
   for (const relation of Object.values(lookup.relation)) {
@@ -183,38 +207,22 @@ export const overpassToGeojsons = (
   response: OsmResponse,
   log: (message: string) => void,
 ) => {
+  const lookup = { node: {}, way: {}, relation: {} } as Lookup;
   const { nodes, ways, relations } = getItems(response.elements, log);
 
-  const lookup = { node: {}, way: {}, relation: {} } as Lookup;
+  addToLookup(lookup, nodes.map(convertNode));
 
-  const NODE_GEOM = getNodeGeomFn();
-  const nodesOut = nodes.map((node) => convert(node, NODE_GEOM, lookup));
-  addToLookup(nodesOut, lookup);
-
-  const WAY_GEOM = getWayGeomFn(lookup);
-  const waysOut = ways.map((way) => convert(way, WAY_GEOM, lookup));
-  addToLookup(waysOut, lookup);
-
-  // first pass
-  const RELATION_GEOM1 = getRelationGeomFn(lookup);
-  const relationsOut1 = relations.map((relation) =>
-    convert(relation, RELATION_GEOM1, lookup),
+  addToLookup(
+    lookup,
+    ways.map((way) => convertWay(way, lookup)),
   );
-  addToLookup(relationsOut1, lookup);
 
-  // second pass for climbing=area geometries
-  // TODO: loop while number of geometries changes
-  // TODO: update only geometries (?)
-  const RELATION_GEOM2 = getRelationGeomFn(lookup);
-  const relationsOut2 = relations.map((relation) =>
-    convert(relation, RELATION_GEOM2, lookup),
-  );
-  lookup.relation = {};
-  addToLookup(relationsOut2, lookup);
-
-  const relationsOut3 = getRelationsWithAreaCount(relationsOut2, lookup);
-  lookup.relation = {};
-  addToLookup(relationsOut3, lookup);
+  for (let i = 0; i < 3; i++) {
+    addToLookup(
+      lookup,
+      relations.map((relation) => convertRelation(relation, lookup)),
+    );
+  }
 
   addParentIds(lookup);
 


### PR DESCRIPTION
We resolve the relation members 3 times now - each pass computes routeCount + routesHistogram + hasImages from its members:
- the 1. pass - resolves crag members
- the 2. pass - resolves crags in areas
- the 3. pass - resolves areas in areas = superareas

Examples:
- Bolton area: https://openclimbing.org/relation/14600025#7.07/43.8741/-73.9597
- Rabštejn: https://openclimbing.org/relation/19587288#15.76/49.9477/17.1514

.

From the logs we see all of them:
- All super-areas: 19302418, 19339487, 19339855, 19377156, 19513589, 19587288
- All super-super-areas: 19339856


Fixes #1368