### PR TITLE
climbingTiles: revert back from neon to xata

### DIFF
--- a/pages/api/climbing-ticks/index.ts
+++ b/pages/api/climbing-ticks/index.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getPool } from '../../../src/server/climbing-tiles/db';
+import { xataRestQuery } from '../../../src/server/climbing-tiles/db';
 import { serverFetchOsmUser } from '../../../src/server/osmApiAuthServer';
 import { OSM_TOKEN_COOKIE } from '../../../src/services/osm/consts';
 import format from 'pg-format';
@@ -20,7 +20,7 @@ const addTickToDB = async (req: NextApiRequest) => {
     pairing,
   };
 
-  await getPool().query(
+  return await xataRestQuery(
     format(
       'INSERT INTO climbing_ticks (%I) VALUES (%L)',
       Object.keys(newTick),
@@ -31,7 +31,7 @@ const addTickToDB = async (req: NextApiRequest) => {
 
 const getAllTicks = async (req: NextApiRequest) => {
   const user = await serverFetchOsmUser(req.cookies[OSM_TOKEN_COOKIE]);
-  const result = await getPool().query<ClimbingTickDb>(
+  const result = await xataRestQuery<ClimbingTickDb>(
     'SELECT * FROM climbing_ticks WHERE "osmUserId" = $1',
     [user.id],
   );

--- a/pages/api/climbing-tiles/refresh.ts
+++ b/pages/api/climbing-tiles/refresh.ts
@@ -3,10 +3,6 @@ import { refreshClimbingTiles } from '../../../src/server/climbing-tiles/refresh
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
-    if (!process.env.NEON_DB_URL) {
-      throw new Error('NEON_DB_URL must be set');
-    }
-
     const log = await refreshClimbingTiles();
 
     res.status(200).send(log);

--- a/src/server/climbing-tiles/db.ts
+++ b/src/server/climbing-tiles/db.ts
@@ -1,4 +1,5 @@
 import { Pool, types } from 'pg';
+import { fetchJson } from '../../services/fetch';
 import { OsmType } from '../../services/types';
 
 export type ClimbingFeaturesRecord = {
@@ -24,14 +25,21 @@ if (!global.db) {
 types.setTypeParser(20, (val) => parseInt(val, 10));
 types.setTypeParser(1700, (val) => parseFloat(val));
 
+const XATA_DATABASE = `osmapp_db:${process.env.NEXT_PUBLIC_CLIMBING_TILES_LOCAL_BRANCH ?? 'main'}`;
+const XATA_REST_URL = `https://osmapp-tvgiad.us-east-1.xata.sh/db/${XATA_DATABASE}/sql`;
+
 export function getPool(): Pool {
-  if (!process.env.NEON_DB_URL) {
-    throw new Error('NEON_DB_URL must be set');
+  if (!process.env.XATA_PASSWORD) {
+    throw new Error('XATA_PASSWORD must be set');
   }
 
   if (!global.db.pool) {
     global.db.pool = new Pool({
-      connectionString: process.env.NEON_DB_URL,
+      user: 'tvgiad',
+      password: process.env.XATA_PASSWORD,
+      host: 'us-east-1.sql.xata.sh',
+      port: 5432,
+      database: XATA_DATABASE,
       ssl: { rejectUnauthorized: false },
       max: 5,
     });
@@ -39,3 +47,83 @@ export function getPool(): Pool {
 
   return global.db.pool;
 }
+
+type XataSQLResponse<T> = {
+  columns: { name: string; type: string }[];
+  //total: number; // present in some queries, but usually 0
+  warning?: string;
+  records: T[];
+};
+type SQLResponse<T> = Omit<XataSQLResponse<T>, 'records'> & {
+  rows: T[];
+};
+
+export const xataRestQuery = async <T = Record<string, any>>(
+  statement: string,
+  params?: any[],
+): Promise<SQLResponse<T>> => {
+  const headers = {
+    Authorization: `Bearer ${process.env.XATA_PASSWORD}`,
+    'Content-Type': 'application/json',
+  };
+  const result = await fetchJson<XataSQLResponse<T>>(XATA_REST_URL, {
+    nocache: true,
+    headers,
+    method: 'POST',
+    body: JSON.stringify({
+      statement: statement,
+      params: params,
+    }),
+  });
+
+  const { records, ...rest } = result;
+  return {
+    ...rest,
+    rows: records,
+  };
+};
+
+export const xataRestQueryPaginated = async <T = Record<string, any>>(
+  statement: string,
+  params?: any[],
+) => {
+  const LIMIT = 1000;
+
+  let offset = 0;
+  let allRecords: T[] = [];
+  let hasMore = true;
+
+  while (hasMore) {
+    const paginatedStatement = `${statement} LIMIT ${LIMIT} OFFSET ${offset}`;
+    console.log(`Executing paginated query: ${paginatedStatement}`); //eslint-disable-line no-console
+    const result = await xataRestQuery<T>(paginatedStatement, params);
+
+    allRecords = allRecords.concat(result.rows);
+    if (result.rows.length >= LIMIT) {
+      offset += LIMIT;
+    } else {
+      hasMore = false;
+    }
+  }
+
+  return allRecords;
+};
+
+export const xataRestUpdate = async (
+  sql: string,
+  params: any[],
+  allowedFields: string[],
+  data: Record<string, any>, // unsafe user input
+) => {
+  const offset = params.length + 1;
+  const setClause = allowedFields
+    .filter((field) => data[field])
+    .map((field, index) => `"${field}"=$${index + offset}`)
+    .join(', ');
+  const setParams = allowedFields
+    .filter((field) => data[field])
+    .map((field) => data[field]);
+
+  const statement = sql.replace('...', setClause);
+  return xataRestQuery(statement, [...params, ...setParams]);
+};

--- a/src/server/climbing-tiles/getClimbingSearch.ts
+++ b/src/server/climbing-tiles/getClimbingSearch.ts
@@ -1,6 +1,6 @@
 import { ClimbingSearchRecord } from '../../types';
 import { removeDiacritics } from './utils';
-import { getPool } from './db';
+import { xataRestQuery } from './db';
 
 export const getClimbingSearch = async (
   q: string,
@@ -19,7 +19,7 @@ export const getClimbingSearch = async (
       ORDER BY distance_km
       LIMIT 30`;
 
-  const result = await getPool().query<ClimbingSearchRecord>(query, [
+  const result = await xataRestQuery<ClimbingSearchRecord>(query, [
     lat,
     lon,
     `%${removeDiacritics(q)}%`,

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -2,7 +2,7 @@ import { ClimbingStatsResponse } from '../../types';
 import { xataRestQuery } from './db';
 
 export const getClimbingStats = async (): Promise<ClimbingStatsResponse> => {
-  const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
+  const query = `SELECT * FROM climbing_tiles_stats ORDER BY timestamp DESC LIMIT 1`;
   const result = await xataRestQuery(query);
 
   if (result.rows.length === 0) {

--- a/src/server/climbing-tiles/getClimbingStats.ts
+++ b/src/server/climbing-tiles/getClimbingStats.ts
@@ -1,9 +1,9 @@
 import { ClimbingStatsResponse } from '../../types';
-import { getPool } from './db';
+import { xataRestQuery } from './db';
 
 export const getClimbingStats = async (): Promise<ClimbingStatsResponse> => {
   const query = `SELECT * FROM climbing_tiles_stats ORDER BY id DESC LIMIT 1`;
-  const result = await getPool().query(query);
+  const result = await xataRestQuery(query);
 
   if (result.rows.length === 0) {
     throw new Error('No row found in climbing_tiles_stats');

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -218,13 +218,13 @@ const refreshInner = async (client: PoolClient) => {
 export const refreshClimbingTiles = async () => {
   const client = await getPool().connect();
   try {
-    await client.query('BEGIN');
+    // await client.query('BEGIN'); // xata is out of memory for transaction
     const result = await refreshInner(client);
-    await client.query('COMMIT');
+    // await client.query('COMMIT');
 
     return result;
   } catch (error) {
-    await client.query('ROLLBACK');
+    // await client.query('ROLLBACK');
     throw error;
   } finally {
     client.release(); // this is important - in finally

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -181,7 +181,7 @@ const refreshInner = async (client: PoolClient) => {
   log(`Records: ${records.length}`);
 
   const columns = Object.keys(records[0]);
-  const chunks = chunk(records, 10000); // This produces queries about 2 MB big
+  const chunks = chunk(records, 1000); // XATA max size is probably 4 MB, but it was out of memory on 1.8MB as well. This produces queries about 0.4 MB big
 
   await client.query('TRUNCATE TABLE climbing_features');
   for (const [index, chunk] of chunks.entries()) {


### PR DESCRIPTION
Unfortunately, i havent noticed, that NeonDB free plan comes only with 50 hours of compute time per month. And each time DB is woke up, it stays 5 minutes up (usually idling).

It is 14th day of month, and we have already spent 42hours. 

XATA is very slow and accessibile only with restQueries (there is no connection pooler like pgBouncer), but we were happy with it since February.

