### PR TITLE
climbingTiles: show on styledata + fix filter condition

### DIFF
--- a/src/components/Map/climbingTiles/climbingTilesSource.ts
+++ b/src/components/Map/climbingTiles/climbingTilesSource.ts
@@ -133,6 +133,7 @@ export const addClimbingTilesSource = (style: StyleSpecification) => {
   if (!eventsAdded) {
     const map = getGlobalMap();
     map.on('load', updateData);
+    map.on('styledata', updateData);
     map.on('moveend', updateData);
     eventsAdded = true;
   }
@@ -142,6 +143,7 @@ export const removeClimbingTilesSource = () => {
   if (eventsAdded) {
     const map = getGlobalMap();
     map.off('load', updateData);
+    map.off('styledata', updateData);
     map.off('moveend', updateData);
     eventsAdded = false;
   }

--- a/src/components/utils/userSettings/getClimbingFilter.tsx
+++ b/src/components/utils/userSettings/getClimbingFilter.tsx
@@ -5,6 +5,7 @@ import {
 import { GRADE_TABLE } from '../../../services/tagging/climbing/gradeData';
 import { GradeSystem } from '../../../services/tagging/climbing/gradeSystems';
 import { Setter } from '../../../types';
+import { isEqual } from 'lodash';
 
 export type Interval = [number, number];
 
@@ -36,7 +37,7 @@ const updateMapFilter = (
   isDefaultFilter: boolean,
 ) => {
   if (
-    mapClimbingFilter.gradeInterval != gradeInterval ||
+    !isEqual(mapClimbingFilter.gradeInterval, gradeInterval) ||
     mapClimbingFilter.minimumRoutes != minimumRoutes
   ) {
     mapClimbingFilter.gradeInterval = gradeInterval;


### PR DESCRIPTION
Switching of layers is possible even without the mapdiff (#1113)

Condition was wrong - always performing the updateData even though no filter changed.