### PR TITLE
climbingTiles: convert grades on map

### DIFF
--- a/src/components/utils/userSettings/getClimbingFilter.tsx
+++ b/src/components/utils/userSettings/getClimbingFilter.tsx
@@ -24,6 +24,7 @@ const SETTINGS_KEY = 'climbing.filter';
 const DEFAULT_MINIMUM_ROUTES = 1;
 
 export const mapClimbingFilter = {
+  gradeSystem: undefined,
   gradeInterval: undefined,
   minimumRoutes: undefined,
   isDefaultFilter: false,
@@ -32,14 +33,17 @@ export const mapClimbingFilter = {
   callback: () => {},
 };
 const updateMapFilter = (
+  gradeSystem: GradeSystem,
   gradeInterval: Interval,
   minimumRoutes: number,
   isDefaultFilter: boolean,
 ) => {
   if (
+    mapClimbingFilter.gradeSystem != gradeSystem ||
     !isEqual(mapClimbingFilter.gradeInterval, gradeInterval) ||
     mapClimbingFilter.minimumRoutes != minimumRoutes
   ) {
+    mapClimbingFilter.gradeSystem = gradeSystem;
     mapClimbingFilter.gradeInterval = gradeInterval;
     mapClimbingFilter.minimumRoutes = minimumRoutes;
     mapClimbingFilter.isDefaultFilter = isDefaultFilter;
@@ -66,8 +70,9 @@ export const getClimbingFilter = (
   userSettings: UserSettingsType,
   setUserSetting: UserSettingsContextType['setUserSetting'],
 ): ClimbingFilter => {
-  const currentSystem = userSettings['climbing.gradeSystem'] || 'uiaa';
-  const grades = GRADE_TABLE[currentSystem];
+  const userSystem = userSettings['climbing.gradeSystem'];
+
+  const grades = GRADE_TABLE[userSystem || 'uiaa'];
   const data = (userSettings[SETTINGS_KEY] ?? {}) as ClimbingFilterSettings;
 
   const setFilter: SetFilter = (name, value) => {
@@ -90,7 +95,7 @@ export const getClimbingFilter = (
 
   const isDefaultFilter = isGradeIntervalDefault && isMinimumRoutesDefault;
 
-  updateMapFilter(gradeInterval, minimumRoutes, isDefaultFilter);
+  updateMapFilter(userSystem, gradeInterval, minimumRoutes, isDefaultFilter);
 
   return {
     grades,

--- a/src/server/climbing-tiles/db.sql
+++ b/src/server/climbing-tiles/db.sql
@@ -1,6 +1,12 @@
 -- Right click on "public" schema, SQL Scripts/Generate DDL to clipboard
 -- + Reformat in WebStorm
 
+create sequence climbing_tiles_stats_id_seq
+  as integer
+  start with 209;
+
+alter sequence climbing_tiles_stats_id_seq owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
+
 create table climbing_features
 (
   id              serial
@@ -15,13 +21,14 @@ create table climbing_features
   "nameRaw"       text,
   "hasImages"     boolean,
   line            json,
+  "gradeTxt"      text,
   "gradeId"       integer,
   "histogramCode" text,
   "parentId"      bigint
 );
 
 alter table climbing_features
-  owner to zbytovsky;
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 
 create table climbing_tiles_cache
 (
@@ -33,11 +40,11 @@ create table climbing_tiles_cache
 );
 
 alter table climbing_tiles_cache
-  owner to zbytovsky;
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 
 create table climbing_tiles_stats
 (
-  id                     serial
+  id                     integer default nextval('climbing_tiles_stats_id_seq'::regclass) not null
     primary key,
   timestamp              text,
   osm_data_timestamp     text,
@@ -53,7 +60,9 @@ create table climbing_tiles_stats
 );
 
 alter table climbing_tiles_stats
-  owner to zbytovsky;
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
+
+alter sequence climbing_tiles_stats_id_seq owned by climbing_tiles_stats.id;
 
 create table climbing_ticks
 (
@@ -70,5 +79,5 @@ create table climbing_ticks
 );
 
 alter table climbing_ticks
-  owner to zbytovsky;
+  owner to xata_owner_bb_3id0nfvj551arc4a8j3li4ee7s;
 

--- a/src/server/climbing-tiles/db.ts
+++ b/src/server/climbing-tiles/db.ts
@@ -14,6 +14,7 @@ export type ClimbingFeaturesRecord = {
   hasImages?: boolean;
   parentId?: number;
   gradeId?: number;
+  gradeTxt?: string;
   line?: number[][];
   histogramCode?: string;
 };

--- a/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
+++ b/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
@@ -26,16 +26,16 @@ const firstPointGeometry = (
   },
 });
 
-const getNameWithDifficulty = (tags: FeatureTags) => {
-  if (tags.climbing?.startsWith('route')) {
+const getRouteGradeTxt = (tags: FeatureTags) => {
+  if (tags?.climbing?.startsWith('route')) {
     const gradeKey = Object.keys(tags).find((key) =>
       key.match(/^climbing:grade:[^:]+$/),
     );
-    const grade = gradeKey ? tags[gradeKey] : '';
-    return `${tags.name ?? ''}${grade ? ` ${grade}` : ''}`;
+    if (gradeKey) {
+      return tags[gradeKey];
+    }
   }
-
-  return tags.name ?? null;
+  return null;
 };
 
 const getRouteGradeIndex = (tags: FeatureTags) => {
@@ -69,9 +69,10 @@ export const recordsFactory = (log: (message: string) => void) => {
     }
 
     const [lon, lat] = coordinates;
-    const name = getNameWithDifficulty(feature.tags);
+    const gradeTxt = getRouteGradeTxt(feature.tags);
     const gradeId = getRouteGradeIndex(feature.tags);
 
+    const name = feature.tags.name;
     const nameRaw = removeDiacritics(name);
     const record: ClimbingFeaturesRecord = {
       type,
@@ -83,6 +84,7 @@ export const recordsFactory = (log: (message: string) => void) => {
       hasImages: feature.properties.hasImages,
       parentId: feature.properties.parentId,
       gradeId,
+      gradeTxt,
       lon,
       lat,
       line:

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type ClimbingStatsResponse = {
   routesCount: number;
 };
 
+// @see climbingTilesSource#processFeature()
 export type ClimbingTilesProperties = {
   type: 'area' | 'crag' | 'route' | 'route_top' | 'gym' | 'ferrata';
   name: string;
@@ -29,6 +30,7 @@ export type ClimbingTilesProperties = {
 
   // route only:
   gradeId?: number;
+  gradeTxt?: string;
   color?: string; // computed on FE - processFeature()
 };
 


### PR DESCRIPTION
For route we return gradeTxt field, which is used as fallback when no gradeSystem is selected. Otherwise we use gradeId (already present for filtering).

Also refactoring of getProperties()