### PR TITLE
EditDialog: show icon for members in `items`

### DIFF
--- a/src/components/FeaturePanel/EditDialog/context/utils.ts
+++ b/src/components/FeaturePanel/EditDialog/context/utils.ts
@@ -2,10 +2,10 @@ import { DataItem } from './types';
 import { getApiId } from '../../../../services/helpers';
 import { findPreset } from '../../../../services/tagging/presets';
 
-export const isInItems = (items: DataItem[], shortId: string) =>
+export const isInItems = <T extends DataItem>(items: T[], shortId: string) =>
   items.some((item) => item.shortId === shortId);
 
-export const findInItems = (items: DataItem[], shortId: string) =>
+export const findInItems = <T extends DataItem>(items: T[], shortId: string) =>
   items.find((item) => item.shortId === shortId);
 
 export const getName = (d: DataItem): string | undefined =>

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -240,7 +240,7 @@ export default {
   'editdialog.members.climbing_crag_convert_description': 'Pro přidání lezeckých cest, prosím, změňte uzel na relaci.',
   'editdialog.members.convert_button': 'Změnit na relaci',
   'editdialog.location_change_current_item': 'Upravit',
-  'editdialog.description_helper_text': 'Zadávejte prosím vlastní popis nebo popis schválený jeho autorem',
+  'editdialog.description_helper_text': 'Zadávejte prosím vlastní popis nebo s písemným souhlasem autora.',
   'editdialog.wikimedia_commons_climbing_helper_text': 'Lezecké cesty můžete zakreslit přímo při prohlížení fotografie po uložení fotky.',
   'editdialog.download_osc': 'Stáhnout osmChange',
   'editdialog.members_climbing_info':

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -278,7 +278,7 @@ export default {
   'editdialog.members.climbing_crag_convert_description': 'For adding climbing routes, you need to convert node to relation.',
   'editdialog.members.convert_button': 'Convert to relation',
   'editdialog.location_change_current_item': 'Edit',
-  'editdialog.description_helper_text': 'Please enter your own description or one approved by its author.',
+  'editdialog.description_helper_text': 'Please enter your own description or with written approval of its author.',
   'editdialog.wikimedia_commons_climbing_helper_text': 'You can draw climbing routes directly while viewing after saving the photo',
   'editdialog.download_osc': 'Download osmChange',
   'editdialog.members_climbing_info':


### PR DESCRIPTION
The preset is already computed for opened `items`, lets use it as an icon.