### PR TITLE
EditDialog: set default width for ItemsTabs

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/ItemsTabs.tsx
@@ -28,6 +28,7 @@ const StyledTabs = styled(Tabs)`
   ${({ theme }) => theme.breakpoints.up('sm')} {
     border-right: 1px solid ${({ theme }) => theme.palette.divider};
     resize: horizontal;
+    width: 200px;
     min-width: 120px;
     max-width: 50%;
 


### PR DESCRIPTION
Otherwise it was jumpy after opening items with longer label.

eg. relation/17424001