### PR TITLE
Revert "EditDialog: remove helper text for `description` (#1392)"

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MajorKeysEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MajorKeysEditor.tsx
@@ -86,6 +86,13 @@ export const MajorKeysEditor: React.FC = () => {
     }
   }, [activeMajorKeys, focusTag]);
 
+  const getHelperText = (k: string) => {
+    if (k === 'description') {
+      return t('editdialog.description_helper_text');
+    }
+    return undefined;
+  };
+
   const getInputElement = (k: string) => {
     if (!data.keys?.includes(k)) return null;
 
@@ -106,6 +113,7 @@ export const MajorKeysEditor: React.FC = () => {
           setTag(e.target.name, e.target.value);
         }}
         value={tags[k] ?? ''}
+        helperText={getHelperText(k)}
       />
     );
   };


### PR DESCRIPTION
Mistake - should have been the wikimedia_commons helper.