### PR TITLE
EditDialog: remove helper text for `wikimedia_commons`

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsEditor.tsx
@@ -5,7 +5,6 @@ import { t } from '../../../../../services/intl';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import React from 'react';
 import { useEditDialogContext } from '../../../helpers/EditDialogContext';
-import { isClimbingRoute } from '../../../../../utils';
 
 const UploadButton = () => (
   <div>
@@ -48,8 +47,6 @@ export const WikimediaCommonsEditor = ({ k }: { k: string }) => {
   const error = isWikimediaCommonsFileNameInvalid(tags[k]);
   const index = getIndexFromWikimediaCommonsKey(k);
   const label = `${t('tags.wikimedia_commons_photo')}${index ? ` (${index})` : ''}`;
-  const isClimbingRouteOrCrag =
-    isClimbingRoute(tags) || tags.climbing === 'crag';
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTag(
       e.target.name,
@@ -68,11 +65,6 @@ export const WikimediaCommonsEditor = ({ k }: { k: string }) => {
           label={label}
           errorText={
             error ? t('editdialog.upload_photo_filename_error') : undefined
-          }
-          helperText={
-            isClimbingRouteOrCrag
-              ? t('editdialog.wikimedia_commons_climbing_helper_text')
-              : undefined
           }
           error={error}
           k={k}

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -241,7 +241,6 @@ export default {
   'editdialog.members.convert_button': 'Změnit na relaci',
   'editdialog.location_change_current_item': 'Upravit',
   'editdialog.description_helper_text': 'Zadávejte prosím vlastní popis nebo s písemným souhlasem autora.',
-  'editdialog.wikimedia_commons_climbing_helper_text': 'Lezecké cesty můžete zakreslit přímo při prohlížení fotografie po uložení fotky.',
   'editdialog.download_osc': 'Stáhnout osmChange',
   'editdialog.members_climbing_info':
     'Do relace lze přidat i jiné relevantní objekty, jako třeba parkoviště nebo referenci na konkrétní vrchol či sráz (natural=cliff).',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -279,7 +279,6 @@ export default {
   'editdialog.members.convert_button': 'Convert to relation',
   'editdialog.location_change_current_item': 'Edit',
   'editdialog.description_helper_text': 'Please enter your own description or with written approval of its author.',
-  'editdialog.wikimedia_commons_climbing_helper_text': 'You can draw climbing routes directly while viewing after saving the photo',
   'editdialog.download_osc': 'Download osmChange',
   'editdialog.members_climbing_info':
     'Members of climbing crag can also be other relevant objects, like parking or reference to specific peak or cliff (natural=cliff).',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -277,7 +277,6 @@ export default {
   'editdialog.members.convert_button': '转换为关系',
   'editdialog.location_change_current_item': '编辑',
   'editdialog.description_helper_text': '请输入您自己的描述或经作者批准的描述。',
-  'editdialog.wikimedia_commons_climbing_helper_text': '保存照片后，您可以在查看照片时直接绘制攀岩路线',
 
   'editsuccess.close_button': '完成',
   'editsuccess.note.heading': '感谢您的建议！',

--- a/src/locales/zh-HK.js
+++ b/src/locales/zh-HK.js
@@ -277,7 +277,6 @@ export default {
   'editdialog.members.convert_button': '轉換為關係',
   'editdialog.location_change_current_item': '編輯',
   'editdialog.description_helper_text': '請輸入你嘅描述，或者經作者同意嘅描述。',
-  'editdialog.wikimedia_commons_climbing_helper_text': '上載相片後，你喺睇相嗰陣就可以直接繪製攀石路線',
 
   'editsuccess.close_button': '完成',
   'editsuccess.note.heading': '多謝你嘅建議！',

--- a/src/locales/zh-TW.js
+++ b/src/locales/zh-TW.js
@@ -275,7 +275,6 @@ export default {
   'editdialog.members.convert_button': '轉換為關係',
   'editdialog.location_change_current_item': '編輯',
   'editdialog.description_helper_text': '請輸入您自己的描述或經作者批准的描述。',
-  'editdialog.wikimedia_commons_climbing_helper_text': '存取照片後，您可以在瀏覽時直接繪製攀岩路線喔',
 
   'editsuccess.close_button': '完成',
   'editsuccess.note.heading': '感謝您的建議！',


### PR DESCRIPTION
It is already written in the climbing section - with action button - #1340.