### PR TITLE
ClimbingTicks: hide it on non-climbing project

### DIFF
--- a/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
@@ -34,6 +34,7 @@ import { useClimbingContext } from '../contexts/ClimbingContext';
 import { useTicksContext } from '../../../utils/TicksContext';
 import { useOsmAuthContext } from '../../../utils/OsmAuthContext';
 import { useSnackbar } from '../../../utils/SnackbarContext';
+import { PROJECT_ID } from '../../../../services/project';
 
 const Container = styled.div`
   width: 100%;
@@ -107,6 +108,10 @@ const AddTickMenuItem = ({ feature, closeMenu }: AddTickMenuItemProps) => {
   const { addTick } = useTicksContext();
   const { showToast } = useSnackbar();
   const [loading, setLoading] = useState(false);
+
+  if (PROJECT_ID !== 'openclimbing') {
+    return null; // ticks are not loaded in context
+  }
 
   const handleAddTick = async (event: React.MouseEvent) => {
     event.stopPropagation();

--- a/src/components/FeaturePanel/Climbing/Ticks/MyRouteTicks.tsx
+++ b/src/components/FeaturePanel/Climbing/Ticks/MyRouteTicks.tsx
@@ -10,6 +10,7 @@ import { getShortId } from '../../../../services/helpers';
 import { RouteTickRow } from '../RouteTickRow';
 import { isFeatureClimbingRoute } from '../../../../utils';
 import { useTicksContext } from '../../../utils/TicksContext';
+import { PROJECT_ID } from '../../../../services/project';
 
 const Container = styled.div`
   margin-bottom: 20px;
@@ -84,6 +85,10 @@ export const MyRouteTicks = () => {
   const { feature } = useFeatureContext();
   if (!isFeatureClimbingRoute(feature)) {
     return null;
+  }
+
+  if (PROJECT_ID !== 'openclimbing') {
+    return null; // ticks are not loaded in context
   }
 
   return <MyRouteTicksInner />;


### PR DESCRIPTION
The initial request for /api/climbing-ticks (get all) is only enabled for PROJECT_ID===openclimbing. 

The addTick buttons should be disabled, because it never load the actual ticks.