### PR TITLE
Climbing: Fix autocomplete issues

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AutocompleteSelect.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AutocompleteSelect.tsx
@@ -1,34 +1,57 @@
 import { Autocomplete, TextField } from '@mui/material';
 import React from 'react';
 
-type AutocompleteSelectProps = {
-  values: string[];
+export type Option = {
   label: string;
-  defaultValue: string;
-  renderOption?: any;
-  onChange: (event: React.SyntheticEvent, value: string | null) => void;
+  value: string;
+};
+
+type AutocompleteSelectProps = {
+  values: (string | Option)[];
+  label: string;
+  value: string | Option | null;
+  renderOption?: (
+    props: React.HTMLAttributes<HTMLLIElement>,
+    option: string | Option,
+  ) => React.ReactNode;
+  onChange: (
+    event: React.SyntheticEvent,
+    value: string | Option | null,
+  ) => void;
   freeSolo?: boolean;
+};
+
+const getLabel = (option: string | Option): string =>
+  typeof option === 'string' ? option : option.label;
+
+const isEqual = (opt: string | Option, val: string | Option): boolean => {
+  if (typeof opt === 'string' && typeof val === 'string') {
+    return opt === val;
+  }
+  if (typeof opt !== 'string' && typeof val !== 'string') {
+    return opt.value === val.value;
+  }
+  return false;
 };
 
 export const AutocompleteSelect = ({
   values,
   label,
-  defaultValue,
+  value,
   renderOption,
   onChange,
   freeSolo,
-}: AutocompleteSelectProps) => {
-  return (
-    <Autocomplete
-      freeSolo={freeSolo}
-      options={values}
-      defaultValue={defaultValue}
-      onChange={onChange}
-      onInputChange={onChange}
-      renderInput={(params) => (
-        <TextField {...params} margin="dense" label={label} />
-      )}
-      renderOption={renderOption}
-    />
-  );
-};
+}: AutocompleteSelectProps) => (
+  <Autocomplete
+    freeSolo={freeSolo}
+    options={values}
+    getOptionLabel={getLabel}
+    isOptionEqualToValue={isEqual}
+    value={value}
+    onChange={onChange}
+    renderInput={(params) => (
+      <TextField {...params} margin="dense" label={label} />
+    )}
+    renderOption={renderOption}
+  />
+);

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingRockSelect.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingRockSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AutocompleteSelect } from './AutocompleteSelect';
+import { AutocompleteSelect, Option } from './AutocompleteSelect';
 import { useCurrentItem } from '../../context/EditContext';
 import { t } from '../../../../../services/intl';
 import { CLIMBING_ROCK_OPTIONS } from '../../../../../services/tagging/climbing/climbingRockData';
@@ -8,25 +8,27 @@ const KEY = 'climbing:rock';
 
 export const ClimbingRockSelect = () => {
   const { tags } = useCurrentItem();
-  const value = tags[KEY] ?? '';
   const { setTag } = useCurrentItem();
   const isRoute = isClimbingRoute(tags);
 
   if (isRoute) return null;
 
-  const onChange = (_e, option) => {
-    setTag(KEY, option);
-  };
+  const options = CLIMBING_ROCK_OPTIONS.map((opt) => ({
+    label: t(opt.translationKey),
+    value: opt.value,
+  }));
 
-  const translatedOptions = CLIMBING_ROCK_OPTIONS.map((opt) =>
-    t(opt.translationKey),
-  );
+  const value = options.find((opt) => opt.value === tags[KEY]) ?? null;
+
+  const onChange = (_e, option: Option | null) => {
+    setTag(KEY, option?.value ?? '');
+  };
 
   return (
     <AutocompleteSelect
-      values={translatedOptions}
+      values={options}
       label={t('climbing_rock.label')}
-      defaultValue={value}
+      value={value}
       onChange={onChange}
       freeSolo
     />

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/GradeSelect.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/GradeSelect.tsx
@@ -12,6 +12,7 @@ type GradeSelectProps = {
   climbingGradeSystem: string;
   tags: FeatureTags;
 };
+
 export const GradeSelect = ({
   k,
   climbingGradeSystem,
@@ -19,33 +20,30 @@ export const GradeSelect = ({
 }: GradeSelectProps) => {
   const values = GRADE_TABLE[climbingGradeSystem];
   const uniqueValues = [...new Set(values)];
-  const value = tags[k] ?? '';
+  const currentValue = tags[k] ?? '';
   const { setTag } = useCurrentItem();
 
-  const onChange = (_e, option) => {
-    setTag(k, option);
+  const onChange = (_e: React.SyntheticEvent, option: string | null) => {
+    setTag(k, option ?? '');
   };
 
   return (
     <AutocompleteSelect
       values={uniqueValues}
       label={getGradeSystemName(climbingGradeSystem)}
-      defaultValue={value}
+      value={currentValue || null}
       onChange={onChange}
       freeSolo
-      renderOption={(props, option, _state, ownerState) => {
-        const { key, ...optionProps } = props;
-        return (
-          <Box key={key} {...optionProps}>
-            <RouteDifficultyBadge
-              routeDifficulty={{
-                gradeSystem: climbingGradeSystem,
-                grade: ownerState.getOptionLabel(option),
-              }}
-            />
-          </Box>
-        );
-      }}
+      renderOption={(props, option) => (
+        <Box component="li" {...props}>
+          <RouteDifficultyBadge
+            routeDifficulty={{
+              gradeSystem: climbingGradeSystem,
+              grade: typeof option === 'string' ? option : option.label,
+            }}
+          />
+        </Box>
+      )}
     />
   );
 };


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

- autocomplete is controlled
- fix climbing rock material select
- fix grade system select

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
