### PR TITLE
EditDialog: Add confirm on Editdialog close

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/EditDialogActions.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/EditDialogActions.tsx
@@ -4,8 +4,8 @@ import { t } from '../../../../services/intl';
 import { useEditContext } from '../context/EditContext';
 import { useOsmAuthContext } from '../../../utils/OsmAuthContext';
 import { useGetHandleSave } from '../useGetHandleSave';
-import { useEditDialogContext } from '../../helpers/EditDialogContext';
 import { getDiffXml } from '../../../../services/osm/auth/getDIffXml';
+import { useEditDialogClose } from '../utils';
 
 const downloadFile = (content: string, filename: string) => {
   const file = new Blob([content], { type: 'text/xml' });
@@ -39,10 +39,10 @@ const SaveButton = () => {
 };
 
 const CancelButton = () => {
-  const { close } = useEditDialogContext();
+  const handleClose = useEditDialogClose();
 
   return (
-    <Button onClick={close} color="primary">
+    <Button onClick={handleClose} color="primary">
       {t('editdialog.cancel_button')}
     </Button>
   );

--- a/src/components/FeaturePanel/EditDialog/EditDialog.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditDialog.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Dialog, useMediaQuery, useTheme } from '@mui/material';
 import styled from '@emotion/styled';
 import { useEditDialogContext } from '../helpers/EditDialogContext';
-import { useEditDialogFeature } from './utils';
+import { useEditDialogClose, useEditDialogFeature } from './utils';
 import { EditContextProvider, useEditContext } from './context/EditContext';
 import { getReactKey } from '../../../services/helpers';
 import { fetchFreshItem, getNewNodeItem } from './context/itemsHelpers';
@@ -20,18 +20,22 @@ const StyledDialog = styled(Dialog)`
     align-items: start;
   }
 `;
+
 const CustomizedDialog: React.FC = ({ children }) => {
-  const { opened, close } = useEditDialogContext();
+  const handleClose = useEditDialogClose();
+  const { opened } = useEditDialogContext();
   const fullScreen = useIsFullScreen();
   const { items } = useEditContext();
   const hasMoreItems = items.length > 1;
   const { successInfo } = useEditContext();
+  const isModified = items.some(({ modified }) => modified);
+
   return (
     <StyledDialog
       fullScreen={fullScreen}
       open={opened}
-      onClose={close}
-      disableEscapeKeyDown={!successInfo}
+      onClose={handleClose}
+      disableEscapeKeyDown={isModified && !successInfo}
       aria-labelledby="edit-dialog-title"
       slotProps={{
         paper: {

--- a/src/components/FeaturePanel/EditDialog/utils.ts
+++ b/src/components/FeaturePanel/EditDialog/utils.ts
@@ -1,4 +1,6 @@
 import { useFeatureContext } from '../../utils/FeatureContext';
+import { useEditContext } from './context/EditContext';
+import { useEditDialogContext } from '../helpers/EditDialogContext';
 
 export const useEditDialogFeature = () => {
   const { feature } = useFeatureContext();
@@ -6,5 +8,23 @@ export const useEditDialogFeature = () => {
     feature,
     isAddPlace: feature.point,
     isUndelete: feature.deleted,
+  };
+};
+
+export const useEditDialogClose = () => {
+  const { items } = useEditContext();
+  const isModified = items.some(({ modified }) => modified);
+  const { close } = useEditDialogContext();
+
+  return () => {
+    if (
+      isModified &&
+      window.confirm(
+        'Your changes are not saved. Are you sure you want to close this dialog?',
+      ) === false
+    ) {
+      return;
+    }
+    close();
   };
 };


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
