### PR TITLE
EditDialog: store expanded sections

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -63,7 +63,7 @@ const parseGradeFromLine = (line: string, gradeSystem?: string) => {
 const convertLine = async (
   line: string,
   parentTags: FeatureTags,
-  gradeSystem: string,
+  gradeSystem: string | undefined,
 ) => {
   let newItem: DataItem;
   if (line.match(/^[nwr]\d+$/)) {

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingEditor/ClimbingEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingEditor/ClimbingEditor.tsx
@@ -8,10 +8,13 @@ import {
   Typography,
 } from '@mui/material';
 import { MultiValueKeyEditor } from './MultiValueKeyEditor';
-import React, { useState } from 'react';
+import React from 'react';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { t } from '../../../../../../services/intl';
-import { useCurrentItem } from '../../../context/EditContext';
+import {
+  useCurrentItem,
+  useExpandedSections,
+} from '../../../context/EditContext';
 import { Maki } from '../../../../../utils/icons/Maki';
 import styled from '@emotion/styled';
 import { ClimbingGradesEditor } from './ClimbingGradesEditor';
@@ -85,7 +88,7 @@ const ClimbingMultiValuesInner = () => {
 
 export const ClimbingEditor = () => {
   const { tags } = useCurrentItem();
-  const [expanded, setExpanded] = useState(!!tags.climbing);
+  const { expanded, toggleExpanded } = useExpandedSections('climbing');
 
   if (!tags.climbing) {
     return null;
@@ -94,12 +97,13 @@ export const ClimbingEditor = () => {
   return (
     <>
       <Divider />
-      <Accordion
+      <Accordion // TODO replace Accordion with custom collapse component, it is not accordion anymore :)
         disableGutters
         elevation={0}
         square
         expanded={expanded}
-        onChange={() => setExpanded(!expanded)}
+        onChange={toggleExpanded}
+        slotProps={{ transition: { timeout: 0 } }}
         sx={{
           '&.MuiAccordion-root:before': {
             opacity: 0,

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
@@ -14,7 +14,10 @@ import { getApiId } from '../../../../../../services/helpers';
 import { fetchWays } from '../../../../../../services/osm/fetchWays';
 import { OsmId } from '../../../../../../services/types';
 import PlaceIcon from '@mui/icons-material/Place';
-import { useCurrentItem } from '../../../context/EditContext';
+import {
+  useCurrentItem,
+  useExpandedSections,
+} from '../../../context/EditContext';
 
 const EditFeatureMapDynamic = dynamic(() => import('./EditFeatureMap'), {
   ssr: false,
@@ -71,7 +74,7 @@ const Content = () => {
 };
 
 export const LocationEditor = () => {
-  const [expanded, setExpanded] = useState(false);
+  const { expanded, toggleExpanded } = useExpandedSections('location');
   const { shortId } = useCurrentItem();
   const osmId = getApiId(shortId);
 
@@ -82,12 +85,13 @@ export const LocationEditor = () => {
   return (
     <>
       <Divider />
-      <Accordion
+      <Accordion // TODO replace Accordion with custom collapse component, it is not accordion anymore :)
         disableGutters
         elevation={0}
         square
         expanded={expanded}
-        onChange={() => setExpanded(!expanded)}
+        onChange={toggleExpanded}
+        slotProps={{ transition: { timeout: 0 } }}
         sx={{
           '&.MuiAccordion-root:before': {
             opacity: 0,

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/MembersEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -17,13 +17,12 @@ import { t, Translation } from '../../../../../services/intl';
 import { AddMemberForm } from './AddMemberForm';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import { CragIcon } from '../../../Climbing/CragIcon';
-import { Setter } from '../../../../../types';
 import {
   useHandleItemClick,
   useHandleOpenAllMembers,
 } from '../useHandleItemClick';
 import { ConvertNodeToRelation, isConvertible } from './ConvertNodeToRelation';
-import { useCurrentItem } from '../../context/EditContext';
+import { useCurrentItem, useExpandedSections } from '../../context/EditContext';
 import { OpenAllButton } from './helpers';
 
 const SectionName = () => {
@@ -68,49 +67,48 @@ const SectionName = () => {
 const CustomAccordion = ({
   children,
   membersLength,
-  isExpanded,
-  setIsExpanded,
 }: {
   children: React.ReactNode;
-  membersLength?: number;
-  isExpanded?: boolean;
-  setIsExpanded?: Setter<boolean>;
-}) => (
-  <>
-    <Divider />
-    <Accordion
-      disableGutters
-      elevation={0}
-      square
-      expanded={isExpanded}
-      sx={{
-        '&.MuiAccordion-root:before': {
-          opacity: 1,
-        },
-      }}
-    >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
-        onClick={() => setIsExpanded(!isExpanded)}
+  membersLength: number | undefined;
+}) => {
+  const { expanded, toggleExpanded } = useExpandedSections('members');
+  return (
+    <>
+      <Divider />
+      <Accordion // TODO replace Accordion with custom collapse component, it is not accordion anymore :)
+        disableGutters
+        elevation={0}
+        square
+        expanded={expanded}
+        slotProps={{ transition: { timeout: 0 } }}
+        sx={{
+          '&.MuiAccordion-root:before': {
+            opacity: 1,
+          },
+        }}
       >
-        <Stack direction="row" spacing={2} alignItems="center">
-          <SectionName />
-          {membersLength ? (
-            <Chip size="small" label={membersLength} variant="outlined" />
-          ) : null}
-        </Stack>
-      </AccordionSummary>
-      <AccordionDetails sx={{ pt: 0 }}>
-        <List disablePadding>{children}</List>
-      </AccordionDetails>
-    </Accordion>
-  </>
-);
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          onClick={toggleExpanded}
+        >
+          <Stack direction="row" spacing={2} alignItems="center">
+            <SectionName />
+            {membersLength ? (
+              <Chip size="small" label={membersLength} variant="outlined" />
+            ) : null}
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 0 }}>
+          <List disablePadding>{children}</List>
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+};
 
 export const MembersEditor = () => {
   const { shortId, members, tags } = useCurrentItem();
-  const [isExpanded, setIsExpanded] = useState(false);
-  const handleClick = useHandleItemClick(setIsExpanded);
+  const handleClick = useHandleItemClick();
   const convertible = isConvertible(shortId, tags);
   const handleOpenAll = useHandleOpenAllMembers();
 
@@ -119,11 +117,7 @@ export const MembersEditor = () => {
   }
 
   return (
-    <CustomAccordion
-      membersLength={members?.length}
-      isExpanded={isExpanded}
-      setIsExpanded={setIsExpanded}
-    >
+    <CustomAccordion membersLength={members?.length}>
       {members?.map((member) => (
         <FeatureRow
           key={member.shortId}

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ParentsEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -14,7 +14,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { getShortId } from '../../../../../services/helpers';
 import { FeatureRow } from '../FeatureRow';
 import { t } from '../../../../../services/intl';
-import { useCurrentItem } from '../../context/EditContext';
+import { useCurrentItem, useExpandedSections } from '../../context/EditContext';
 import { isClimbingRoute as getIsClimbingRoute } from '../../../../../utils';
 import { AreaIcon } from '../../../Climbing/AreaIcon';
 import { CragIcon } from '../../../Climbing/CragIcon';
@@ -24,7 +24,6 @@ import {
 } from '../useHandleItemClick';
 import { Feature } from '../../../../../services/types';
 import { OpenAllButton } from './helpers';
-import { Setter } from '../../../../../types';
 import { useGetParents } from './useGetParents';
 
 const SectionName = () => {
@@ -81,50 +80,49 @@ const getLabel = (parent: Feature) => {
 const CustomAccordion = ({
   children,
   parentsLength,
-  isExpanded,
-  setIsExpanded,
 }: {
   children: React.ReactNode;
-  parentsLength?: number;
-  isExpanded?: boolean;
-  setIsExpanded?: Setter<boolean>;
-}) => (
-  <>
-    <Divider />
-    <Accordion
-      disableGutters
-      elevation={0}
-      square
-      expanded={isExpanded}
-      sx={{
-        '&.MuiAccordion-root:before': {
-          opacity: 0,
-        },
-      }}
-    >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
-        aria-controls="panel1-content"
-        id="panel1-header"
-        onClick={() => setIsExpanded(!isExpanded)}
+  parentsLength: number | undefined;
+}) => {
+  const { expanded, toggleExpanded } = useExpandedSections('parents');
+  return (
+    <>
+      <Divider />
+      <Accordion // TODO replace Accordion with custom collapse component, it is not accordion anymore :)
+        disableGutters
+        elevation={0}
+        square
+        expanded={expanded}
+        slotProps={{ transition: { timeout: 0 } }}
+        sx={{
+          '&.MuiAccordion-root:before': {
+            opacity: 0,
+          },
+        }}
       >
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Typography variant="button">
-            <SectionName />
-          </Typography>
-          <Chip size="small" label={parentsLength} variant="outlined" />
-        </Stack>
-      </AccordionSummary>
-      <AccordionDetails sx={{ pt: 0 }}>
-        <List disablePadding>{children}</List>
-      </AccordionDetails>
-    </Accordion>
-  </>
-);
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1-content"
+          id="panel1-parents-header"
+          onClick={toggleExpanded}
+        >
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Typography variant="button">
+              <SectionName />
+            </Typography>
+            <Chip size="small" label={parentsLength} variant="outlined" />
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pt: 0 }}>
+          <List disablePadding>{children}</List>
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+};
 
 export const ParentsEditor = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const handleClick = useHandleItemClick(setIsExpanded);
+  const handleClick = useHandleItemClick();
   const parents = useGetParents();
   const handleOpenAll = useHandleOpenAllParents(parents);
 
@@ -133,11 +131,7 @@ export const ParentsEditor = () => {
   }
 
   return (
-    <CustomAccordion
-      parentsLength={parents?.length}
-      isExpanded={isExpanded}
-      setIsExpanded={setIsExpanded}
-    >
+    <CustomAccordion parentsLength={parents?.length}>
       {parents.map((parent) => {
         const shortId = getShortId(parent.osmMeta);
         return (

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/TagsEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/TagsEditor/TagsEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import {
   Accordion,
@@ -19,7 +19,10 @@ import { useEditDialogContext } from '../../../../helpers/EditDialogContext';
 import { KeyInput } from './KeyInput';
 import { ValueInput } from './ValueInput';
 import { OptionsEditor } from '../OptionsEditor';
-import { useCurrentItem } from '../../../context/EditContext';
+import {
+  useCurrentItem,
+  useExpandedSections,
+} from '../../../context/EditContext';
 
 const Table = styled.table`
   width: calc(100% - 8px);
@@ -57,7 +60,7 @@ const TagsEditorInfo = () => (
 );
 
 const AddButton = () => {
-  const { tagsEntries, setTagsEntries } = useCurrentItem();
+  const { setTagsEntries } = useCurrentItem();
   return (
     <tr>
       <td colSpan={2}>
@@ -114,23 +117,22 @@ const TagsCount = () => {
 export const TagsEditor = () => {
   const { focusTag } = useEditDialogContext();
   const focusThisEditor = isString(focusTag) && !majorKeys.includes(focusTag);
-  const [expanded, setExpanded] = useState(focusThisEditor);
+  const { expanded, expand, toggleExpanded } = useExpandedSections('tags');
 
   useEffect(() => {
-    if (focusThisEditor) {
-      setExpanded(true);
-    }
-  }, [focusThisEditor]);
+    if (focusThisEditor) expand();
+  }, [focusThisEditor, expand]);
 
   return (
     <>
       <Divider />
-      <Accordion
+      <Accordion // TODO replace Accordion with custom collapse component, it is not accordion anymore :)
         disableGutters
         elevation={0}
         square
         expanded={expanded}
-        onChange={() => setExpanded(!expanded)}
+        onChange={toggleExpanded}
+        slotProps={{ transition: { timeout: 0 } }}
         sx={{
           '&.MuiAccordion-root:before': {
             opacity: 0,

--- a/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/useHandleItemClick.tsx
@@ -2,32 +2,23 @@ import React from 'react';
 import { useCurrentItem, useEditContext } from '../context/EditContext';
 import { getApiId, getShortId } from '../../../../services/helpers';
 import { fetchFreshItem } from '../context/itemsHelpers';
-import { Setter } from '../../../../types';
 import { Feature } from '../../../../services/types';
 import { DataItem, EditDataItem } from '../context/types';
 
 import { isInItems } from '../context/utils';
 
-export const useHandleItemClick = (setIsExpanded: Setter<boolean>) => {
+export const useHandleItemClick = () => {
   const { addItem, items, setCurrent } = useEditContext();
 
   return async (e: React.MouseEvent, shortId: string) => {
-    const isCmdClicked = e.ctrlKey || e.metaKey;
-    const switchToNewTab = !isCmdClicked;
-    const apiId = getApiId(shortId);
-
     if (!isInItems(items, shortId)) {
-      const newItem = await fetchFreshItem(apiId);
+      const newItem = await fetchFreshItem(getApiId(shortId));
       addItem(newItem);
+    }
 
-      if (switchToNewTab) {
-        setIsExpanded(false);
-        setCurrent(newItem.shortId);
-      }
-    } else {
-      if (switchToNewTab) {
-        setCurrent(shortId);
-      }
+    const switchToNewTab = !e.ctrlKey && !e.metaKey;
+    if (switchToNewTab) {
+      setCurrent(shortId);
     }
   };
 };

--- a/src/components/FeaturePanel/EditDialog/context/EditContext.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/EditContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState } from 'react';
 import { SuccessInfo } from '../../../../services/types';
 import { useEditItems } from './useEditItems';
 import { Setter } from '../../../../types';
-import { DataItem, EditDataItem } from './types';
+import { DataItem, EditDataItem, Section } from './types';
 
 type ShortId = string;
 
@@ -62,4 +62,27 @@ export const useCurrentItem = (): EditDataItem => {
   const { items, current } = useEditContext();
 
   return items.find((item) => item.shortId === current);
+};
+
+const isInSections = (sections: Section[], current: Section) =>
+  sections.some((section) => section === current);
+
+export const useExpandedSections = (current: Section) => {
+  const { sections, setSections } = useCurrentItem();
+
+  return {
+    expanded: isInSections(sections, current),
+    toggleExpanded: () => {
+      setSections((prev) =>
+        isInSections(prev, current)
+          ? prev.filter((section) => section !== current)
+          : [...prev, current],
+      );
+    },
+    expand: () => {
+      setSections((prev) =>
+        isInSections(prev, current) ? prev : [...prev, current],
+      );
+    },
+  };
 };

--- a/src/components/FeaturePanel/EditDialog/context/__tests__/useEditItems.convertToRelationFactory.test.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/__tests__/useEditItems.convertToRelationFactory.test.tsx
@@ -32,6 +32,7 @@ const initialNode: DataItem = addEmptyOriginalState({
   ],
   toBeDeleted: false,
   nodeLonLat: [14, 50],
+  sections: [],
 });
 
 const parentFeature = { osmMeta: { type: 'relation', id: 99 } };

--- a/src/components/FeaturePanel/EditDialog/context/__tests__/useEditItems.test.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/__tests__/useEditItems.test.tsx
@@ -9,6 +9,7 @@ const initialItem: DataItem = addEmptyOriginalState({
   tagsEntries: Object.entries({ amenity: 'cafe' }),
   toBeDeleted: false,
   nodeLonLat: [14, 50],
+  sections: [],
 });
 
 describe('useEditItems', () => {
@@ -31,6 +32,7 @@ describe('useEditItems', () => {
       tagsEntries: [['amenity', 'restaurant']],
       toBeDeleted: false,
       nodeLonLat: [14, 50],
+      sections: [],
     });
 
     act(() => {

--- a/src/components/FeaturePanel/EditDialog/context/convertToRelationFactory.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/convertToRelationFactory.tsx
@@ -99,6 +99,7 @@ export const convertToRelationFactory = (
         toBeDeleted: false,
         relationClickedLonLat: node.nodeLonLat,
         members: keepNode ? [{ shortId, role: '' }] : [],
+        sections: ['members'],
       });
 
       const newData = prevData.map((item) =>

--- a/src/components/FeaturePanel/EditDialog/context/itemsHelpers.ts
+++ b/src/components/FeaturePanel/EditDialog/context/itemsHelpers.ts
@@ -39,6 +39,7 @@ export const getNewNodeItem = (
     tagsEntries: Object.entries(tags),
     toBeDeleted: false,
     nodeLonLat,
+    sections: tags.climbing ? ['climbing'] : [],
   });
 
 const getLabel = (itemsMap: ItemsMap, member: RelationMember) => {
@@ -102,5 +103,6 @@ export const fetchFreshItem = async (apiId: OsmId): Promise<DataItem> => {
       nodes,
       members,
     },
+    sections: tags.climbing ? ['climbing'] : [],
   };
 };

--- a/src/components/FeaturePanel/EditDialog/context/types.ts
+++ b/src/components/FeaturePanel/EditDialog/context/types.ts
@@ -8,6 +8,8 @@ export type Members = Array<{
   originalLabel?: string; // only shown when member is not among editItems
 }>;
 
+export type Section = 'climbing' | 'location' | 'parents' | 'members' | 'tags';
+
 // internal type stored in the state
 export type DataItem = {
   shortId: string;
@@ -21,6 +23,7 @@ export type DataItem = {
     nodes: number[] | undefined;
     members: Members;
   };
+  sections: Section[];
   nodeLonLat?: LonLat; // only for nodes (may be undefined until user selects the location)
   nodes?: number[]; // only for ways
   members?: Members; // only for relations
@@ -41,6 +44,7 @@ export type EditDataItem = DataItem & {
   toggleToBeDeleted: () => void;
   convertToRelation: ConvertToRelation;
   modified: boolean;
+  setSections: SetSections;
 };
 
 export type ConvertToRelation = () => Promise<string>;
@@ -52,3 +56,5 @@ export type SetTagsEntries = (
 export type SetShortId = (shortId: string) => void;
 
 export type SetMembers = (updateFn: (prev: Members) => Members) => void;
+
+export type SetSections = (updateFn: (prev: Section[]) => Section[]) => void;

--- a/src/components/FeaturePanel/EditDialog/context/useEditItems.tsx
+++ b/src/components/FeaturePanel/EditDialog/context/useEditItems.tsx
@@ -10,6 +10,7 @@ import {
   EditDataItem,
   Members,
   SetMembers,
+  SetSections,
   SetShortId,
   SetTagsEntries,
   TagsEntries,
@@ -81,6 +82,14 @@ const toggleToBeDeletedFactory = (setDataItem: SetDataItem) => {
     }));
 };
 
+const setSectionsFactory =
+  (setDataItem: SetDataItem): SetSections =>
+  (updateFn) =>
+    setDataItem((prev) => ({
+      ...prev,
+      sections: updateFn(prev.sections),
+    }));
+
 const getModifiedFlag = (dataItem: DataItem): boolean => {
   if (dataItem.shortId.includes('-')) {
     return true;
@@ -103,13 +112,12 @@ const getModifiedFlag = (dataItem: DataItem): boolean => {
 export const useEditItems = () => {
   const [data, setData] = useState<DataItem[]>([]);
 
-  const items = useMemo<Array<EditDataItem>>(
+  const items = useMemo<EditDataItem[]>(
     () =>
       data.map((dataItem) => {
         const { shortId, tagsEntries, members } = dataItem;
         const setDataItem = setDataItemFactory(setData, shortId);
         const setTagsEntries = setTagsEntriesFactory(setDataItem, tagsEntries);
-        const setMembers = setMembersFactory(setDataItem, members);
         const presetKey = getPresetKey(dataItem);
         return {
           ...dataItem,
@@ -118,12 +126,13 @@ export const useEditItems = () => {
           tags: Object.fromEntries(tagsEntries),
           setTag: setTagFactory(setTagsEntries),
           toggleToBeDeleted: toggleToBeDeletedFactory(setDataItem),
-          setMembers,
+          setMembers: setMembersFactory(setDataItem, members),
           setNodeLonLat: setNodeLonLatFactory(setDataItem),
           presetKey,
           presetLabel: getPresetTranslation(presetKey),
           convertToRelation: convertToRelationFactory(setData, shortId),
           modified: getModifiedFlag(dataItem),
+          setSections: setSectionsFactory(setDataItem),
         };
         // TODO maybe keep reference to original EditDataItem if DataItem didnt change? #performance
       }),


### PR DESCRIPTION
The collapsible sections in EditDialog are now remembered per each item. 

Animation was removed, because it was animating while switched among the items 😅 

TODO: acordion is no longer accordion, rather use Collapse or something custom.