### PR TITLE
FilterPopover: unify look with LayerSwitcherButton

### DIFF
--- a/src/components/LayerSwitcher/LayerSwitcherButton.tsx
+++ b/src/components/LayerSwitcher/LayerSwitcherButton.tsx
@@ -60,7 +60,8 @@ export const LayerSwitcherButton = ({
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   isOpened?: boolean;
 }) => {
-  const isMobileMode = useMobileMode();
+  const isMobileMode = useMobileMode(); // TODO this could be done with media queries, is there a reason why it is not?
+
   return (
     <Tooltip title={isMobileMode ? t('layerswitcher.button') : null} arrow>
       <StyledLayerSwitcher

--- a/src/components/Map/MapFilter/MapFilter.tsx
+++ b/src/components/Map/MapFilter/MapFilter.tsx
@@ -13,12 +13,16 @@ const StyledIconButton = styled(IconButton, {
   shouldForwardProp: (prop) => !prop.startsWith('$'),
 })<{ $isOpened: boolean }>`
   pointer-events: all;
-  &,
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1); // same as LayerSwitcherButton
+  backdrop-filter: blur(15px);
+
+  background-color: ${({ theme, $isOpened }) =>
+    $isOpened
+      ? theme.palette.background.paper
+      : convertHexToRgba(theme.palette.background.paper, 0.8)};
+
   &:hover {
-    background-color: ${({ theme, $isOpened }) =>
-      $isOpened
-        ? theme.palette.background.paper
-        : convertHexToRgba(theme.palette.background.paper, 0.8)};
+    background-color: ${({ theme }) => theme.palette.background.paper};
   }
 `;
 


### PR DESCRIPTION
If the different look was done for a reason, it is probably ok to revert it.