### PR TITLE
CragsInArea: don't ever hide the filtering button

### DIFF
--- a/src/components/FeaturePanel/CragsInArea.tsx
+++ b/src/components/FeaturePanel/CragsInArea.tsx
@@ -277,7 +277,7 @@ const CragsInAreaInner = () => {
 
   return (
     <>
-      {crags.length > 1 ? (
+      {unfilteredCrags.length > 0 ? (
         <>
           <StyledPaper elevation={0} square>
             <Stack
@@ -294,7 +294,7 @@ const CragsInAreaInner = () => {
               <CragsInAreaFilter />
             </Stack>
           </StyledPaper>
-          <RouteDistribution features={allCragRoutes} />
+          {crags.length > 1 && <RouteDistribution features={allCragRoutes} />}
         </>
       ) : null}
 


### PR DESCRIPTION
The filtering button was hiding when filter got 0 or 1 results. Preventing the user to "unfilter" again.

Fixed.