### PR TITLE
climbingTiles: add dev user-setting to show all outlines

### DIFF
--- a/src/components/HomepagePanel/UserSettingsDialog.tsx
+++ b/src/components/HomepagePanel/UserSettingsDialog.tsx
@@ -53,6 +53,27 @@ const StoreRequests = () => {
   );
 };
 
+const ShowAllClimbingOutlines = () => {
+  const [value, setValue] = usePersistedState(
+    'show_all_climbing_outlines',
+    false,
+  );
+
+  return (
+    <ListItem>
+      <ListItemText>
+        Develop: show all outlines on climbing layer (reload needed)
+      </ListItemText>
+      <Switch
+        color="primary"
+        edge="end"
+        onChange={() => setValue((prev) => !prev)}
+        checked={!!value}
+      />
+    </ListItem>
+  );
+};
+
 // TODO refactor this - extract member functions
 
 // eslint-disable-next-line max-lines-per-function
@@ -204,6 +225,7 @@ export const UserSettingsDialog = ({ onClose, isOpened }: Props) => {
           </ListItem>
 
           <StoreRequests />
+          <ShowAllClimbingOutlines />
         </List>
       </DialogContent>
     </Dialog>

--- a/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
@@ -1,4 +1,5 @@
 import {
+  ExpressionInputType,
   ExpressionSpecification,
   LayerSpecification,
 } from '@maplibre/maplibre-gl-style-spec';
@@ -11,10 +12,15 @@ const HOVER: ExpressionSpecification = [
   0,
 ];
 
+const SHOULD_SHOW: ExpressionInputType | ExpressionSpecification =
+  global.window?.localStorage.getItem('show_all_climbing_outlines') === 'true'
+    ? 1
+    : HOVER;
+
 const BY_ZOOM = (z: number): ExpressionSpecification => [
   'case',
   ['>', z, ['get', 'minZoom']],
-  HOVER,
+  SHOULD_SHOW,
   0,
 ];
 


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a68d5b46-70df-40c5-9726-5286fa07ef1e" />
<img width="627" height="126" alt="image" src="https://github.com/user-attachments/assets/cc69a11d-e55c-4219-b242-296b36235e79" />

Also screenshot in #1346 

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
