### PR TITLE
CragsInArea: hide FilterRow for 1 unfiltered crag

### DIFF
--- a/src/components/FeaturePanel/Climbing/Filter/CragsInAreaFilter.tsx
+++ b/src/components/FeaturePanel/Climbing/Filter/CragsInAreaFilter.tsx
@@ -6,8 +6,7 @@ import { FilterPopover } from './FilterPopover';
 import { useMobileMode } from '../../../helpers';
 
 export const CragsInAreaFilter = () => {
-  const { climbingFilter } = useUserSettingsContext();
-  const { isDefaultFilter, reset } = climbingFilter;
+  const { isDefaultFilter } = useUserSettingsContext().climbingFilter;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [open, setOpen] = useState(false);
   const isMobileMode = useMobileMode();

--- a/src/components/FeaturePanel/CragsInArea.tsx
+++ b/src/components/FeaturePanel/CragsInArea.tsx
@@ -142,7 +142,7 @@ const AreaInfo = ({ crags }: { crags: Feature[] }) => {
   return (
     <PanelLabel
       addition={
-        crags.length > 1 ? (
+        crags.length >= 2 ? (
           <NumberOfVisible crags={crags.length} routes={numberOfRoutes} />
         ) : null
       }
@@ -173,31 +173,6 @@ const Gallery = ({ images, feature }) => {
         ))}
       </Slider>
     </Wrapper>
-  );
-};
-
-const CragList = ({ crags }: { crags: Feature[] }) => {
-  const { feature } = useFeatureContext();
-  const otherFeatures = feature.memberFeatures.filter(
-    ({ tags }) => tags.climbing !== 'crag',
-  );
-
-  return (
-    <Box mt={2} mb={4}>
-      <CragListContainer>
-        {crags.map((item) => (
-          <CragItem key={getOsmappLink(item)} feature={item} />
-        ))}
-      </CragListContainer>
-
-      {otherFeatures.length > 0 && (
-        <Ul>
-          {otherFeatures.map((item) => (
-            <MemberItem key={getReactKey(item)} feature={item} />
-          ))}
-        </Ul>
-      )}
-    </Box>
   );
 };
 
@@ -244,6 +219,31 @@ const CragItem = ({ feature }: { feature: Feature }) => {
   );
 };
 
+const CragList = ({ crags }: { crags: Feature[] }) => {
+  const { feature } = useFeatureContext();
+  const otherFeatures = feature.memberFeatures.filter(
+    ({ tags }) => tags.climbing !== 'crag',
+  );
+
+  return (
+    <Box mt={2} mb={4}>
+      <CragListContainer>
+        {crags.map((item) => (
+          <CragItem key={getOsmappLink(item)} feature={item} />
+        ))}
+      </CragListContainer>
+
+      {otherFeatures.length > 0 && (
+        <Ul>
+          {otherFeatures.map((item) => (
+            <MemberItem key={getReactKey(item)} feature={item} />
+          ))}
+        </Ul>
+      )}
+    </Box>
+  );
+};
+
 const NumberOfVisible = (props: { crags: any; routes: any }) => (
   <Chip
     size="small"
@@ -279,10 +279,10 @@ const AllCragsDistribution = ({ crags }: { crags: Feature[] }) => {
     return [...acc, ...memberFeatures];
   }, []);
 
-  if (crags.length <= 1) {
-    return null;
+  if (crags.length >= 2) {
+    return <RouteDistribution features={allCragRoutes} />;
   }
-  return <RouteDistribution features={allCragRoutes} />;
+  return null;
 };
 
 const FilterRow: React.FC = ({ children }) => (
@@ -306,7 +306,7 @@ const CragsInAreaInner = () => {
 
   return (
     <>
-      {unfilteredCrags.length > 0 && (
+      {unfilteredCrags.length >= 2 && (
         <FilterRow>
           <NumberOfHiddenCrags crags={crags} />
           <CragsInAreaSort setSortBy={setSortBy} sortBy={sortBy} />


### PR DESCRIPTION
This was kinda hard to get right:

- FilterRow depends only on number of unfilteredCrags (it cannot be influenced by number of filtered crags - bug #1428)
- AllCragsDistribution in the meantime must show only for 2+ **filtered** results

FUN! 😅