### PR TITLE
climbingTiles: overlap icons in zoom 15+

### DIFF
--- a/src/components/Map/climbingTiles/climbingLayers/groupsLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/groupsLayer.ts
@@ -37,7 +37,7 @@ const GROUPS_LAYOUT: SymbolLayerSpecification['layout'] = {
   'text-offset': [0, 0.6],
   'icon-optional': false,
   'icon-ignore-placement': false,
-  'icon-allow-overlap': ['step', ['zoom'], true, 4, false],
+  'icon-allow-overlap': ['step', ['zoom'], true, 4, false, 15, true],
   'text-field': ['step', ['zoom'], '', 4, ['get', 'label']],
   'text-padding': 2,
   'text-font': ['Noto Sans Bold'],


### PR DESCRIPTION
Much better! :D

| 1 | 2 |
|--|--|
|<img width="433" height="351" alt="image" src="https://github.com/user-attachments/assets/f97b86fb-40ed-4cf8-b597-cc88ff304438" /> |<img width="436" height="351" alt="image" src="https://github.com/user-attachments/assets/4ef2c01a-0cb7-4798-b476-45d98a8ba60b" />
| <img width="634" height="905" alt="image" src="https://github.com/user-attachments/assets/53fae4c0-9cb0-494f-9b28-4b731f51b169" /> |<img width="646" height="904" alt="image" src="https://github.com/user-attachments/assets/836cd1c4-9f11-4aa7-b713-3f4799b81930" /> 
