### PR TITLE
HamburgerMenu: fix forwardRef warning

### DIFF
--- a/src/components/Map/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/Map/HamburgerMenu/HamburgerMenu.tsx
@@ -30,7 +30,7 @@ import { PROJECT_ID } from '../../../services/project';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import Link from 'next/link';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
-import { UserHeader } from './UserMenu';
+import { UserHeader } from './UserHeader';
 import { MyTicksMenuItem } from './MyTicksMenuItem';
 import ContrastIcon from '@mui/icons-material/Contrast';
 

--- a/src/components/Map/HamburgerMenu/UserHeader.tsx
+++ b/src/components/Map/HamburgerMenu/UserHeader.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import {
   Avatar,
   IconButton,
@@ -112,14 +112,12 @@ const LoggedOutUserHeader = ({ onClose }: { onClose: () => void }) => {
   );
 };
 
-export const UserHeader = forwardRef<SVGSVGElement, UserLoginProps>(
-  ({ closeMenu }) => {
-    const { osmUser } = useOsmAuthContext();
-    if (!osmUser) {
-      return <LoggedOutUserHeader onClose={closeMenu} />;
-    }
-
+export const UserHeader = ({ closeMenu }) => {
+  const { osmUser } = useOsmAuthContext();
+  if (osmUser) {
     return <LoggedUserHeader onClose={closeMenu} />;
-  },
-);
-UserHeader.displayName = 'UserLogin';
+  }
+
+  return <LoggedOutUserHeader onClose={closeMenu} />;
+};
+UserHeader.displayName = 'UserHeader';


### PR DESCRIPTION
Warning in console:

`forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?`