### PR TITLE
FeaturePanel: add iD editor link to footer + OpenInProd

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/LocationEditor/LocationEditor.tsx
@@ -18,6 +18,7 @@ import {
   useCurrentItem,
   useExpandedSections,
 } from '../../../context/EditContext';
+import { OSM_WEBSITE } from '../../../../../../services/osm/consts';
 
 const EditFeatureMapDynamic = dynamic(() => import('./EditFeatureMap'), {
   ssr: false,
@@ -27,7 +28,7 @@ const EditFeatureMapDynamic = dynamic(() => import('./EditFeatureMap'), {
 const NotYetEditableWarning = () => {
   const { shortId } = useCurrentItem();
   const osmId = getApiId(shortId);
-  const link = `https://www.openstreetmap.org/edit?${osmId.type}=${osmId.id}`;
+  const link = `${OSM_WEBSITE}/edit?${osmId.type}=${osmId.id}`;
 
   return (
     <Translation

--- a/src/components/FeaturePanel/FeaturePanelFooter.tsx
+++ b/src/components/FeaturePanel/FeaturePanelFooter.tsx
@@ -1,7 +1,11 @@
 import { useToggleState } from '../helpers';
 import { useFeatureContext } from '../utils/FeatureContext';
 import { PanelFooterWrapper, PanelSidePadding } from '../utils/PanelHelpers';
-import { FeatureDescription, FromOsm } from './FeatureDescription';
+import {
+  FeatureDescription,
+  FromOsm,
+  OpenInProduction,
+} from './FeatureDescription';
 import Coordinates from './Coordinates';
 import { t } from '../../services/intl';
 import { ObjectsAround } from './ObjectsAround';
@@ -76,6 +80,7 @@ export const FeaturePanelFooter = ({
               </Typography>
             </Box>
             <Coordinates />
+            <OpenInProduction />
           </PanelSidePadding>
         </PanelFooterWrapper>
       </AccordionDetails>

--- a/src/components/FeaturePanel/QuickActions/ShareDialog/LinkSection.tsx
+++ b/src/components/FeaturePanel/QuickActions/ShareDialog/LinkSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import React from 'react';
 import { getFullOsmappLink, getShortLink } from '../../../../services/helpers';
 import { useFeatureContext } from '../../../utils/FeatureContext';
@@ -25,17 +25,9 @@ const getProjectLogo = () => {
   return '/osmapp/logo/osmapp_64.png';
 };
 
-const useLink = (short: boolean) => {
+const useProjectLink = (short: boolean) => {
   const { feature } = useFeatureContext();
-  const [link, setLink] = useState(
-    short ? getShortLink(feature) : getFullOsmappLink(feature),
-  );
-
-  useEffect(() => {
-    const url = short ? getShortLink(feature) : getFullOsmappLink(feature);
-    setLink(url);
-  }, [short, feature]);
-  return link;
+  return short ? getShortLink(feature) : getFullOsmappLink(feature);
 };
 
 const StyledTextField = styled(TextField)`
@@ -70,7 +62,7 @@ export const LinkSection = () => {
   const { feature } = useFeatureContext();
   const supportsShortUrl = !feature.point;
   const [short, setShort] = useState(false);
-  const link = useLink(short);
+  const link = useProjectLink(short);
 
   return (
     <>


### PR DESCRIPTION
This section is meant only for powerusers.

iD editor link was missing - now it is "hidden" under the "v1" link.


<img width="300" height="" alt="image" src="https://github.com/user-attachments/assets/da26e0d7-d957-49a6-a5fb-e5f53c305a6e" />
