### PR TITLE
EditDialog: skip changes-not-saved dialog on success screen

### DIFF
--- a/src/components/FeaturePanel/EditDialog/utils.ts
+++ b/src/components/FeaturePanel/EditDialog/utils.ts
@@ -12,13 +12,15 @@ export const useEditDialogFeature = () => {
 };
 
 export const useEditDialogClose = () => {
-  const { items } = useEditContext();
+  const { items, successInfo } = useEditContext();
   const isModified = items.some(({ modified }) => modified);
   const { close } = useEditDialogContext();
 
+  // TODO remove this window.confirm, once the edit-dialog state is saved in localStorage
   return () => {
     if (
       isModified &&
+      !successInfo &&
       window.confirm(
         'Your changes are not saved. Are you sure you want to close this dialog?',
       ) === false


### PR DESCRIPTION
### Description

Fixes #1458

### Example links

Save a new node in test api - observe success screen - click outside of the window.

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
