### PR TITLE
locales: static build to use LANGUAGES

### DIFF
--- a/.github/workflows/publish-gh-pages-hack.yml
+++ b/.github/workflows/publish-gh-pages-hack.yml
@@ -47,7 +47,7 @@ jobs:
 
           curl --cookie "hideHomepage=yes" http://localhost:3000 > public/index.html
           curl --cookie "hideHomepage=yes" http://localhost:3000 > public/404.html
-          for lang in de cs en es fr it pl am ja zh zh-CN zh-TW zh-HK; do
+          for lang in $(node --input-type=module <<'EOF'import { LANGUAGES } from './src/config.mjs';process.stdout.write(`${Object.keys(LANGUAGES).join('\n')}\n`);EOF); do
             mkdir public/$lang
             curl --cookie "hideHomepage=yes; lang=$lang" http://localhost:3000 > public/$lang/index.html
           done;

--- a/src/locales/README.md
+++ b/src/locales/README.md
@@ -2,6 +2,8 @@
 
 To add a new translation, copy `vocabulary.js` to a new file and change the texts. Some javascript knowledge is needed.
 
-Then add the language to the options menu: `/next.config.js`. Restart your dev server for the changes to take effect. Or wait for deployment on a pull request.
+Then add the language in `/src/config.mjs`.
+
+Restart your dev server for the changes to take effect. Or wait for deployment on a pull request.
 
 Example: [PR #89](https://github.com/zbycz/osmapp/pull/77/files)


### PR DESCRIPTION
We use publish OsmAPP to github pages with this hacky script which turns next.js app to static SPA.

The language system needed to load languages dynamically to enable #1482.