### PR TITLE
osmApi: fetchFeature loads "full" way and computes center

### DIFF
--- a/src/services/__tests__/osmApi.fixture.ts
+++ b/src/services/__tests__/osmApi.fixture.ts
@@ -56,6 +56,18 @@ export const WAY = {
       nodes: [1, 2],
       tags: { amenity: 'school' },
     },
+    {
+      type: 'node',
+      id: 1,
+      lat: 49,
+      lon: 13,
+    },
+    {
+      type: 'node',
+      id: 2,
+      lat: 51,
+      lon: 15,
+    },
   ],
 };
 export const WAY_FEATURE = {

--- a/src/services/getCenter.ts
+++ b/src/services/getCenter.ts
@@ -30,7 +30,7 @@ export const getBbox = (coordinates: LonLat[]): NamedBbox => {
   );
 };
 
-const getCenterOfBbox = (points: LonLat[]): LonLat | undefined => {
+export const getCenterOfBbox = (points: LonLat[]): LonLat | undefined => {
   if (!points.length) return undefined;
 
   const { w, s, e, n } = getBbox(points);

--- a/src/services/osm/__tests__/osmApi.test.ts
+++ b/src/services/osm/__tests__/osmApi.test.ts
@@ -52,19 +52,14 @@ describe('fetchFeature', () => {
     expect(feature).toEqual(NODE_FEATURE);
   });
 
-  const OVERPASS_CENTER_RESPONSE = {
-    elements: [{ center: { lat: 50, lon: 14 } }],
-  };
-
   it('should work for way', async () => {
-    const fetchJson = jest
-      .spyOn(fetch, 'fetchJson')
-      .mockImplementation((url) =>
-        Promise.resolve(url.match(/overpass/) ? OVERPASS_CENTER_RESPONSE : WAY),
-      );
+    const fetchJson = jest.spyOn(fetch, 'fetchJson').mockResolvedValue(WAY);
 
     const feature = await fetchFeature({ type: 'way', id: 51050330 });
-    expect(fetchJson).toHaveBeenCalledTimes(2);
+    expect(fetchJson).toHaveBeenCalledTimes(1);
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining('/way/51050330/full.json'),
+    );
     expect(feature).toEqual(WAY_FEATURE);
   });
 

--- a/src/services/osm/osmApi.ts
+++ b/src/services/osm/osmApi.ts
@@ -13,7 +13,8 @@ import {
   isPublictransportRoute,
   isRouteMaster,
 } from '../../utils';
-import { getOsmHistoryUrl, getOsmUrl } from './urls';
+import { getOsmFullUrl, getOsmHistoryUrl, getOsmUrl } from './urls';
+import { getCenterOfBbox } from '../getCenter';
 import { getOsmElement } from './quickFetchFeature';
 import { fetchParentFeatures } from './fetchParentFeatures';
 import { featureCenterCache } from './featureCenterToCache';
@@ -58,22 +59,6 @@ const getOsmPromise = async (apiId: OsmId) => {
   }
 };
 
-const getCenterPromise = async (apiId: OsmId): Promise<LonLat | false> => {
-  if (apiId.type === 'node') return false;
-
-  if (isBrowser() && featureCenterCache[getShortId(apiId)]) {
-    return featureCenterCache[getShortId(apiId)]; // just use the coordinate where user clicked
-  }
-
-  try {
-    return await fetchOverpassCenter(apiId);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn('getCenterPromise()', e); // eg. 529 too many requests
-    return false;
-  }
-};
-
 export const clearFeatureCache = (apiId) => {
   removeFetchCache(getOsmUrl(apiId)); // watch out, must be same as in getOsmPromise()
   removeFetchCache(getOsmHistoryUrl(apiId));
@@ -97,6 +82,26 @@ const getRelationElementsAndCenter = async (apiId: OsmId) => {
   return { element, center };
 };
 
+const getWayElementsAndCenter = async (apiId: OsmId) => {
+  try {
+    const { elements } = await fetchJson<OsmResponse>(getOsmFullUrl(apiId)); // we use the nodes only to get center, then discard them
+    const itemsMap = getItemsMap(elements);
+    const element = itemsMap.way[apiId.id];
+    const coords = (element.nodes ?? [])
+      .map((ref) => itemsMap.node[ref])
+      .filter(Boolean)
+      .map((node): LonLat => [node.lon, node.lat]);
+    const center = getCenterOfBbox(coords) ?? (false as const);
+    return { element, center };
+  } catch (e) {
+    const undeleted = await getLastBeforeDeleted(e, apiId);
+    if (undeleted) {
+      return { element: undeleted, center: false as const };
+    }
+    throw e;
+  }
+};
+
 const getElementsAndCenter = async (apiId: OsmId) => {
   const cachedCenter = featureCenterCache[getShortId(apiId)];
   if (isBrowser() && cachedCenter) {
@@ -112,11 +117,7 @@ const getElementsAndCenter = async (apiId: OsmId) => {
         center: false as const,
       };
     case 'way':
-      const [elementWay, center] = await Promise.all([
-        getOsmPromise(apiId),
-        getCenterPromise(apiId),
-      ]);
-      return { element: elementWay, center };
+      return getWayElementsAndCenter(apiId);
     case 'relation':
       return getRelationElementsAndCenter(apiId);
   }


### PR DESCRIPTION
Since january there are [issues](https://community.openstreetmap.org/t/overpass-api-performance-issues/140598) with slow Overpass API (also #1460). We use Overpass to compute the center point of `ways` and `relations` in the case when they accessed as a permalink. (When user clicks an item on the interactive map, the click position is used instead)

This PR changes behaviour for permalinks ways, and replaces osm+overpass request with "full osm" request only. Which may load significant amount of data for very large ways, but still is faster and more predicatable then Overpass.

Behaviour for `type=multipolygon relations` can be revisted if need be.

Fixes #1487 
