### PR TITLE
Add deep link support for edit form via /node/:id/edit URL

### DIFF
--- a/.github/workflows/e2e-edit-deeplink.yml
+++ b/.github/workflows/e2e-edit-deeplink.yml
@@ -1,0 +1,51 @@
+name: E2E – Edit deep link
+
+on:
+  push:
+    branches:
+      - claude/issue-1489-PDr2b
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+
+      - name: Install deps
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - name: Build (same env as hacky-static-export)
+        run: |
+          export VERCEL_GIT_COMMIT_SHA="$(git rev-parse HEAD)"
+          export VERCEL_GIT_COMMIT_MESSAGE="$(git log -1 --pretty=%B)"
+          export NEXT_PUBLIC_FAKE_STATIC_EXPORT=true
+          export NEXT_PUBLIC_FORCE_PROJECT=osmapp.org
+          export NEXT_PUBLIC_OG_IMAGE_FETCHER_HOST=https://osmapp-preview.vercel.app
+          yarn build
+
+      - name: Start server
+        run: yarn start &
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:3000 --timeout 30000
+
+      - name: Run Playwright tests
+        run: npx playwright test e2e/edit-deeplink.spec.ts --reporter=list
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/edit-deeplink.spec.ts
+++ b/e2e/edit-deeplink.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+// Well-known OSM node: Pražský hrad (Prague Castle)
+const NODE_ID = '1601837931';
+const FEATURE_URL = `/node/${NODE_ID}`;
+const EDIT_URL = `/node/${NODE_ID}/edit`;
+
+test.describe('Edit dialog deep link', () => {
+  test('opens dialog when navigating directly to /node/:id/edit', async ({
+    page,
+  }) => {
+    await page.goto(EDIT_URL);
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('URL reverts to /node/:id when dialog is closed', async ({ page }) => {
+    await page.goto(EDIT_URL);
+    await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 15_000 });
+
+    // Close: dialog is not modified so Escape works
+    await page.keyboard.press('Escape');
+
+    await expect(page).toHaveURL(new RegExp(`/node/${NODE_ID}$`), {
+      timeout: 5_000,
+    });
+    await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+  });
+
+  test('clicking Edit button updates URL to /node/:id/edit', async ({
+    page,
+  }) => {
+    await page.goto(FEATURE_URL);
+
+    // Wait for the edit/note button (text differs by auth status)
+    const editButton = page.getByRole('button', {
+      name: /Suggest an edit|Edit place|Add a place/i,
+    });
+    await expect(editButton).toBeVisible({ timeout: 20_000 });
+    await editButton.click();
+
+    await expect(page).toHaveURL(new RegExp(`/node/${NODE_ID}/edit$`), {
+      timeout: 5_000,
+    });
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -17,6 +17,14 @@ type EditDialogType = {
 
 const EditDialogContext = createContext<EditDialogType>(undefined);
 
+const getFeatureEditUrl = () => {
+  const path = Router.query.all as string[] | undefined;
+  if (path?.[0]?.match(/^node|way|relation$/) && path?.[1]?.match(/^\d+$/)) {
+    return { featureUrl: `/${path[0]}/${path[1]}`, editUrl: `/${path[0]}/${path[1]}/edit` };
+  }
+  return null;
+};
+
 // lives in App.tsx because the context is needed in SSR
 export const EditDialogProvider = ({ children }) => {
   const initialState = isBrowser() ? Router.query.all?.[2] === 'edit' : false;
@@ -28,16 +36,29 @@ export const EditDialogProvider = ({ children }) => {
       Router.replace('/').then(() => {
         Router.replace(redirectOnClose); // to reload the panel, we need two redirects, see https://github.com/zbycz/osmapp/pull/685
       });
+    } else if ((Router.query.all as string[])?.[2] === 'edit') {
+      const urls = getFeatureEditUrl();
+      if (urls) {
+        Router.replace(urls.featureUrl, undefined, { shallow: true });
+      }
     }
     setOpened(false);
     setRedirectOnClose(undefined);
   };
 
+  const openEdit = (value: boolean | Tag) => {
+    const urls = getFeatureEditUrl();
+    if (urls && (Router.query.all as string[])?.[2] !== 'edit') {
+      Router.push(urls.editUrl, undefined, { shallow: true });
+    }
+    setOpened(value);
+  };
+
   const value: EditDialogType = {
     opened: !!opened,
     focusTag: opened,
-    open: () => setOpened(true),
-    openWithTag: (tag: Tag) => setOpened(tag),
+    open: () => openEdit(true),
+    openWithTag: (tag: Tag) => openEdit(tag),
     close,
     redirectOnClose,
     setRedirectOnClose,

--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import Router from 'next/router';
 import { isBrowser } from '../../helpers';
 import { Setter } from '../../../types';
@@ -53,6 +53,20 @@ export const EditDialogProvider = ({ children }) => {
     }
     setOpened(value);
   };
+
+  // Handle static export: fakeStaticExportStartup navigates to the actual URL after
+  // mount, so initialState may have been computed before the router was ready.
+  useEffect(() => {
+    const syncWithUrl = () => {
+      if ((Router.query.all as string[])?.[2] === 'edit') {
+        setOpened((prev) => prev || true);
+      }
+    };
+
+    syncWithUrl(); // catch case where router wasn't ready at mount
+    Router.events.on('routeChangeComplete', syncWithUrl);
+    return () => Router.events.off('routeChangeComplete', syncWithUrl);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const value: EditDialogType = {
     opened: !!opened,


### PR DESCRIPTION
Opening the edit dialog now updates the URL to /node/:id/edit (shallow),
making it shareable. Navigating directly to that URL auto-opens the
dialog (already worked via initialState). Closing the dialog navigates
back to /node/:id.

https://claude.ai/code/session_0195PthXkHFcRXqriuvhS5HH