### PR TITLE
EditDialog: fix deeplink in hacky-static-export

### DIFF
--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -17,6 +17,9 @@ type EditDialogType = {
 
 const EditDialogContext = createContext<EditDialogType>(undefined);
 
+const EDIT_DEEPLINK_REGEX =
+  /^\/(?:[a-z]{2}\/)?(?:node|way|relation)\/\d+\/edit\/?$/i;
+
 const isEditDeeplink = () => {
   if (!isBrowser()) {
     return false;
@@ -26,9 +29,21 @@ const isEditDeeplink = () => {
   }
   // In the hacky static export the page is served from 404.html, so Router.query
   // is not yet populated on the first render – fall back to the real browser URL.
-  return /^\/(?:[a-z]{2}\/)?(?:node|way|relation)\/\d+\/edit\/?$/i.test(
-    window.location.pathname,
-  );
+  return EDIT_DEEPLINK_REGEX.test(window.location.pathname);
+};
+
+// when the dialog was opened via the /edit deeplink, drop the suffix on close
+const removeEditDeeplink = () => {
+  if (!isBrowser()) {
+    return;
+  }
+  const { pathname, search, hash } = window.location;
+  if (EDIT_DEEPLINK_REGEX.test(pathname)) {
+    const cleanPathname = pathname.replace(/\/edit\/?$/, '');
+    Router.replace(`${cleanPathname}${search}${hash}`, undefined, {
+      shallow: true,
+    });
+  }
 };
 
 // lives in App.tsx because the context is needed in SSR
@@ -42,6 +57,8 @@ export const EditDialogProvider = ({ children }) => {
       Router.replace('/').then(() => {
         Router.replace(redirectOnClose); // to reload the panel, we need two redirects, see https://github.com/zbycz/osmapp/pull/685
       });
+    } else {
+      removeEditDeeplink();
     }
     setOpened(false);
     setRedirectOnClose(undefined);

--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -17,9 +17,23 @@ type EditDialogType = {
 
 const EditDialogContext = createContext<EditDialogType>(undefined);
 
+const isEditDeeplink = () => {
+  if (!isBrowser()) {
+    return false;
+  }
+  if (Router.query.all?.[2] === 'edit') {
+    return true;
+  }
+  // In the hacky static export the page is served from 404.html, so Router.query
+  // is not yet populated on the first render – fall back to the real browser URL.
+  return /^\/(?:[a-z]{2}\/)?(?:node|way|relation)\/\d+\/edit\/?$/i.test(
+    window.location.pathname,
+  );
+};
+
 // lives in App.tsx because the context is needed in SSR
 export const EditDialogProvider = ({ children }) => {
-  const initialState = isBrowser() ? Router.query.all?.[2] === 'edit' : false;
+  const initialState = isEditDeeplink();
   const [opened, setOpened] = useState<boolean | Tag>(initialState);
   const [redirectOnClose, setRedirectOnClose] = useState<string | undefined>();
 

--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -21,14 +21,10 @@ const EDIT_DEEPLINK_REGEX =
   /^\/(?:[a-z]{2}\/)?(?:node|way|relation)\/\d+\/edit\/?$/i;
 
 const isEditDeeplink = () => {
-  if (!isBrowser()) {
-    return false;
-  }
   if (Router.query.all?.[2] === 'edit') {
     return true;
   }
-  // In the hacky static export the page is served from 404.html, so Router.query
-  // is not yet populated on the first render – fall back to the real browser URL.
+  // hacky static export:
   return EDIT_DEEPLINK_REGEX.test(window.location.pathname);
 };
 

--- a/src/components/FeaturePanel/helpers/EditDialogContext.tsx
+++ b/src/components/FeaturePanel/helpers/EditDialogContext.tsx
@@ -28,7 +28,6 @@ const isEditDeeplink = () => {
   return EDIT_DEEPLINK_REGEX.test(window.location.pathname);
 };
 
-// when the dialog was opened via the /edit deeplink, drop the suffix on close
 const removeEditDeeplink = () => {
   if (!isBrowser()) {
     return;


### PR DESCRIPTION
Fixes the `/node/{id}/edit` deeplink not opening the edit dialog in the hacky static export (404.html fallback), and strips the `/edit` suffix from the URL when the dialog closes.

#1489