### PR TITLE
SearchBox: fix preset search crash with id-tagging-schema v7

### DIFF
--- a/src/components/SearchBox/options/preset.tsx
+++ b/src/components/SearchBox/options/preset.tsx
@@ -41,7 +41,7 @@ const getPresetsForSearch = async () => {
         tags,
         tagsAsOneString: tagsAsStrings.join(', '),
         texts: [
-          ...getPresetTermsTranslation(presetKey).split(','),
+          ...getPresetTermsTranslation(presetKey),
           ...tagsAsStrings,
           presetKey,
         ],

--- a/src/services/tagging/translations.ts
+++ b/src/services/tagging/translations.ts
@@ -43,8 +43,12 @@ export const mockSchemaTranslations = (mockTranslations) => {
 export const getPresetTranslation = (key: string): string =>
   translations?.[intl.lang]?.presets?.presets?.[key]?.name ?? `[${key}]`;
 
-export const getPresetTermsTranslation = (key: string) =>
-  translations?.[intl.lang]?.presets?.presets?.[key]?.terms ?? '';
+export const getPresetTermsTranslation = (key: string): string[] => {
+  const terms = translations?.[intl.lang]?.presets?.presets?.[key]?.terms;
+  if (Array.isArray(terms)) return terms; // id-tagging-schema v7+
+  if (typeof terms === 'string') return terms.split(','); // v6 CSV string
+  return [];
+};
 
 export const getAllTranslations = () => translations?.[intl.lang];
 


### PR DESCRIPTION
## Problem

Preset search in the SearchBox crashes for any query longer than 2 characters:

```
TypeError: getPresetTermsTranslation(...).split is not a function
```

Since queries of 1–2 chars are short-circuited (return no options), search only appeared to "work" for 1–2 characters. Fixes #1501.

## Root cause

The schema is fetched at runtime from the jsDelivr CDN, which serves the **latest** `@openstreetmap/id-tagging-schema` (currently v7.0.1). In **v7**, preset `terms` changed from a comma-separated **string** (`"screen,flag,sign"`) to a **string array** (`["screen","flag","sign"]`), so calling `.split(',')` on it throws.

- Changelog: https://github.com/openstreetmap/id-tagging-schema/blob/main/CHANGELOG.md#700
- Migration guide: https://github.com/openstreetmap/id-tagging-schema/blob/main/MIGRATION_GUIDE.md

## Fix

Normalize `getPresetTermsTranslation` to always return `string[]`, accepting both the v7 array and the v6 CSV string (the local npm fallback is still pinned `^6.12.0`), then drop the `.split(',')` at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)