### PR TITLE
OpeningHours: render 24:00 instead of 0:00 at the end of an interval

### DIFF
--- a/src/components/FeaturePanel/renderers/openingHours/__tests__/complex.test.ts
+++ b/src/components/FeaturePanel/renderers/openingHours/__tests__/complex.test.ts
@@ -54,4 +54,10 @@ describe('parseComplexOpeningHours', () => {
     setUp('en', true);
     expect(daysTable('Mo-Su 09:00-00:00').mo).toEqual(['9:00 AM-12:00 AM']);
   });
+
+  it('does not cut off an interval at the end of the displayed week', () => {
+    // the last day of the week window used to be truncated at midnight
+    expect(daysTable('Mo-Su 19:00-01:00').tu).toEqual(['19:00-01:00']);
+    expect(daysTable('Mo-Su 19:00-01:00').th).toEqual(['19:00-01:00']);
+  });
 });

--- a/src/components/FeaturePanel/renderers/openingHours/__tests__/complex.test.ts
+++ b/src/components/FeaturePanel/renderers/openingHours/__tests__/complex.test.ts
@@ -1,0 +1,57 @@
+import { parseComplexOpeningHours } from '../complex';
+import { intl } from '../../../../../services/intl';
+import { SimpleOpeningHoursTable } from '../types';
+
+const PRAGUE = [14.4208, 50.088] as [number, number];
+const ADDRESS = { country_code: 'cz', state: '' };
+
+const setUp = (lang: string, isImperial = false) => {
+  intl.lang = lang;
+  window.localStorage.setItem('userSettings', JSON.stringify({ isImperial }));
+};
+
+const daysTable = (value: string): SimpleOpeningHoursTable =>
+  parseComplexOpeningHours(value, PRAGUE, ADDRESS).daysTable;
+
+describe('parseComplexOpeningHours', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-05-01T10:00:00Z')); // Wednesday
+    setUp('en');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders midnight at the end of an interval as 24:00', () => {
+    expect(daysTable('Mo-Su 09:00-00:00').mo).toEqual(['09:00-24:00']);
+    expect(daysTable('Mo-Su 09:00-24:00').mo).toEqual(['09:00-24:00']);
+  });
+
+  it('keeps midnight at the beginning of an interval as 00:00', () => {
+    expect(daysTable('Mo-Su 00:00-06:00').mo).toEqual(['00:00-06:00']);
+    expect(daysTable('Mo-Su 00:00-01:00,19:00-24:00').fr).toEqual([
+      '19:00-01:00',
+    ]);
+  });
+
+  it('renders the whole day as a single translation', () => {
+    expect(daysTable('24/7').mo).toEqual(['opening_hours.all_day']);
+    expect(daysTable('Mo-Su 00:00-24:00').mo).toEqual([
+      'opening_hours.all_day',
+    ]);
+  });
+
+  it('does not touch times which are close to midnight', () => {
+    expect(daysTable('Mo-Su 11:00-24:30').mo).toEqual(['11:00-00:30']);
+    expect(daysTable('Mo-Su 11:00-23:59').mo).toEqual(['11:00-23:59']);
+  });
+
+  it('uses the local time format', () => {
+    setUp('cs');
+    expect(daysTable('Mo-Su 09:00-00:00').mo).toEqual(['9:00-24:00']);
+
+    setUp('en', true);
+    expect(daysTable('Mo-Su 09:00-00:00').mo).toEqual(['9:00 AM-12:00 AM']);
+  });
+});

--- a/src/components/FeaturePanel/renderers/openingHours/complex.ts
+++ b/src/components/FeaturePanel/renderers/openingHours/complex.ts
@@ -29,12 +29,26 @@ const fmtDate = (d: Date) =>
     hour12: isImperialUnits(),
   });
 
+// midnight at the end of an interval is written as 24:00 (like in the OSM syntax), not as 0:00
+const fmtMidnightAsEndOfDay = (d: Date) =>
+  new Intl.DateTimeFormat(intl.lang, {
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+  })
+    .formatToParts(d)
+    .map(({ type, value }) => (type === 'hour' ? '24' : value))
+    .join('');
+
+const fmtEndDate = (d: Date) =>
+  isMidnight(d) && !isImperialUnits() ? fmtMidnightAsEndOfDay(d) : fmtDate(d);
+
 const fmtDateRange = ([start, end]: DateRange) => {
   if (isMidnight(start) && isMidnight(end)) {
     return t('opening_hours.all_day');
   }
 
-  return `${fmtDate(start)}-${fmtDate(end)}`;
+  return `${fmtDate(start)}-${fmtEndDate(end)}`;
 };
 
 const getMinsDiff = (date: Date) =>

--- a/src/components/FeaturePanel/renderers/openingHours/complex.ts
+++ b/src/components/FeaturePanel/renderers/openingHours/complex.ts
@@ -79,6 +79,35 @@ const getStatus = (interval: [Date, Date, boolean, string] | null): Status => {
   return 'closed';
 };
 
+const splitByDay = (interval: DateRange) =>
+  splitDateRangeAtMidnight(interval, (d1, d2) => {
+    const splitPoint = set(addDays(new Date(d1), 1), {
+      hours: 5,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+    return isEqual(d2, splitPoint) || isAfter(d2, splitPoint);
+  });
+
+const getDaysTable = (intervals: DateRange[], until: Date) => {
+  const splittedIntervals = intervals
+    .flatMap(([openingDate, endDate]) => splitByDay([openingDate, endDate]))
+    .filter(([from]) => from < until);
+
+  const grouped = WEEKDAYS.map((w) => {
+    const daysIntervals = splittedIntervals.filter(
+      ([from]) =>
+        w === weekdayMappings[from.toLocaleString('en', { weekday: 'short' })],
+    );
+
+    return [w, daysIntervals.map(fmtDateRange)] as const;
+  });
+
+  return Object.fromEntries(grouped) as unknown as SimpleOpeningHoursTable;
+};
+
 export const parseComplexOpeningHours = (
   value: string,
   [lon, lat]: LonLat,
@@ -96,37 +125,13 @@ export const parseComplexOpeningHours = (
   const oneWeekLater = new Date(today);
   oneWeekLater.setDate(oneWeekLater.getDate() + 7);
 
-  const allIntervals = oh.getOpenIntervals(today, oneWeekLater);
+  // one day extra, otherwise an interval crossing the last midnight would be cut off there
+  const queryEnd = new Date(oneWeekLater);
+  queryEnd.setDate(queryEnd.getDate() + 1);
+
+  const allIntervals = oh.getOpenIntervals(today, queryEnd);
   const intervals = allIntervals.filter(([_, __, maybe]) => !maybe);
-  const splittedIntervals = intervals.flatMap(([openingDate, endDate]) =>
-    splitDateRangeAtMidnight([openingDate, endDate], (d1, d2) => {
-      const splitPoint = set(addDays(new Date(d1), 1), {
-        hours: 5,
-        minutes: 0,
-        seconds: 0,
-        milliseconds: 0,
-      });
-
-      return isEqual(d2, splitPoint) || isAfter(d2, splitPoint);
-    }),
-  );
-
-  const grouped = WEEKDAYS.map((w) => {
-    const daysIntervals = splittedIntervals.filter(
-      ([from]) =>
-        w === weekdayMappings[from.toLocaleString('en', { weekday: 'short' })],
-    );
-
-    return [w, daysIntervals] as const;
-  });
-
-  const daysTable = Object.fromEntries(
-    grouped.map((entry) => {
-      const strings = entry[1].map(fmtDateRange);
-
-      return [entry[0], strings] as const;
-    }),
-  ) as unknown as SimpleOpeningHoursTable;
+  const daysTable = getDaysTable(intervals, oneWeekLater);
 
   // intervals are sorted from the present to the future
   // so the first one is either currently opened or the next opened slot
@@ -135,7 +140,7 @@ export const parseComplexOpeningHours = (
   );
 
   const maybeOpenedReasons = allIntervals
-    .filter(([_, __, maybe]) => maybe)
+    .filter(([from, __, maybe]) => maybe && from < oneWeekLater)
     .map((interval) => interval[3]);
 
   return {

--- a/src/components/FeaturePanel/renderers/openingHours/complex.ts
+++ b/src/components/FeaturePanel/renderers/openingHours/complex.ts
@@ -56,7 +56,9 @@ const getMinsDiff = (date: Date) =>
 
 export type Status = 'opens-soon' | 'closes-soon' | 'opened' | 'closed';
 
-const getStatus = (interval: [Date, Date, boolean, string] | null): Status => {
+type OpenInterval = [Date, Date, boolean, string];
+
+const getStatus = (interval: OpenInterval | null): Status => {
   if (!interval) {
     return 'closed';
   }
@@ -91,7 +93,7 @@ const splitByDay = (interval: DateRange) =>
     return isEqual(d2, splitPoint) || isAfter(d2, splitPoint);
   });
 
-const getDaysTable = (intervals: DateRange[], until: Date) => {
+const getDaysTable = (intervals: OpenInterval[], until: Date) => {
   const splittedIntervals = intervals
     .flatMap(([openingDate, endDate]) => splitByDay([openingDate, endDate]))
     .filter(([from]) => from < until);


### PR DESCRIPTION
Fixes #1512 



hodnota | před | po
-- | -- | --
Mo-Su 09:00-00:00 (Empire State) | 09-00 / 9-0 | 09-24 / 9-24
Mo-Sa 16:00-00:00; Su 16:00-24:00 | 16-00 / 16-0 | 16-24 / 16-24
Mo-Fr 08:00-24:00; Sa-Su 09:00-24:00 | 08-00 / 8-0 | 08-24 / 8-24
Mo-Th 12:00-23:00; Fr-Sa 12:00-00:00 | fr 12-00 | fr 12-24
Mo-We 12:00-14:30, 17:30-00:00 | 12-14:30, 17:30-00 | 12-14:30, 17:30-24
Mo-Sa 11:30-22:30; Su 00:00-21:30 | su 00-21:30 / 0-21:30 | beze změny (začátek intervalu)
Mo-Su 23:00-23:59, 00:00-03:00 | 00-03, 23-23:59 | beze změny (začátek)
Mo-Th 11:00-24:30 | 11-00:30 / 11-0:30 | beze změny (není půlnoc)
24/7, Mo-Su 00:00-24:00 | 24 hours | beze změny
Mo-Fr 15:00-27:00 (Londýn) | mo 15-03 | beze změny (končí ve 3:00)

